### PR TITLE
fix: validateEnv trim returned token values

### DIFF
--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -22,7 +22,7 @@ export function validateEnv(env: NodeJS.ProcessEnv = process.env): AppEnv {
     throw new MissingEnvVarError(missing);
   }
   return {
-    slackBotToken: env.SLACK_BOT_TOKEN!,
-    slackAppToken: env.SLACK_APP_TOKEN!,
+    slackBotToken: env.SLACK_BOT_TOKEN!.trim(),
+    slackAppToken: env.SLACK_APP_TOKEN!.trim(),
   };
 }


### PR DESCRIPTION
Closes #2

Auto-fix by /housekeep Stage 4.

Returns `env.SLACK_BOT_TOKEN!.trim()` and `env.SLACK_APP_TOKEN!.trim()` from `validateEnv` so downstream consumers always see whitespace-clean token values (guards against copy-paste foot-guns like trailing newlines from password managers).