### PR TITLE
fix: main() guard with require.main === module

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -15,4 +15,6 @@ function main(): void {
   }
 }
 
-main();
+if (require.main === module) {
+  main();
+}


### PR DESCRIPTION
Closes #5

Auto-fix by /housekeep Stage 4.

Wraps the `main()` invocation in `if (require.main === module)` so the file can be imported for tests or tooling without triggering startup side effects. Standard Node entrypoint pattern.