### PR TITLE
fix: jest.config.js use createDefaultPreset()

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,7 @@
+const { createDefaultPreset } = require("ts-jest");
+
 module.exports = {
-  preset: "ts-jest",
+  ...createDefaultPreset(),
   testEnvironment: "node",
   testMatch: ["<rootDir>/tests/**/*.test.ts"],
   moduleFileExtensions: ["ts", "js"],


### PR DESCRIPTION
Closes #6

Auto-fix by /housekeep Stage 4.

Replaces the deprecated `preset: "ts-jest"` legacy form with the ts-jest 29.x-recommended `createDefaultPreset()` helper. Preserves existing `moduleFileExtensions` and `moduleNameMapper` (the Xenova transformers test stub). Smoke-tested: `require('./jest.config.js')` loads cleanly and the preset contributes a `transform` entry.