### PR TITLE
fix: strip BOM from TXT/MD parsers

### DIFF
--- a/src/ingestion/parsers/markdown.ts
+++ b/src/ingestion/parsers/markdown.ts
@@ -2,7 +2,7 @@ import * as fs from "fs/promises";
 import type { Chunk } from "../ingest";
 
 export async function parseMarkdown(filePath: string, source: string): Promise<Chunk[]> {
-  const raw = await fs.readFile(filePath, "utf8");
+  const raw = (await fs.readFile(filePath, "utf8")).replace(/^\uFEFF/, "");
   const lines = raw.split(/\r?\n/);
 
   const chunks: Chunk[] = [];

--- a/src/ingestion/parsers/txt.ts
+++ b/src/ingestion/parsers/txt.ts
@@ -2,7 +2,7 @@ import * as fs from "fs/promises";
 import type { Chunk } from "../ingest";
 
 export async function parseTxt(filePath: string, source: string): Promise<Chunk[]> {
-  const raw = await fs.readFile(filePath, "utf8");
+  const raw = (await fs.readFile(filePath, "utf8")).replace(/^\uFEFF/, "");
   const paragraphs = raw
     .split(/\n\s*\n/)
     .map((p) => p.trim())


### PR DESCRIPTION
Closes #9

Auto-fix by /housekeep Stage 4.

Strips a leading U+FEFF byte-order-mark once at read time in both `parseTxt` and `parseMarkdown` via `.replace(/^\uFEFF/, "")`. Windows UTF-8 files often start with the BOM; without stripping it, the first chunk carries an invisible prefix that pollutes downstream embedding vectors (US-03). Scoped to the two parsers only — PDF/DOCX parsers unaffected since those formats don't expose a raw-text BOM.

---
plan-refresh: no-op