### PR TITLE
chore: US-03 polish — load length-mismatch assertion (#22) + stub header comment (#25)

### DIFF
--- a/src/index/vectorIndex.ts
+++ b/src/index/vectorIndex.ts
@@ -101,8 +101,15 @@ export class VectorIndex {
         `VectorIndex.load: index model "${parsed.model}" does not match loaded model "${EMBEDDING_MODEL}"`,
       );
     }
-    this.chunks = parsed.chunks ?? [];
-    this.vectors = parsed.vectors ?? [];
+    const chunks = parsed.chunks ?? [];
+    const vectors = parsed.vectors ?? [];
+    if (chunks.length !== vectors.length) {
+      throw new Error(
+        `VectorIndex.load: corrupt index — chunks.length (${chunks.length}) !== vectors.length (${vectors.length})`,
+      );
+    }
+    this.chunks = chunks;
+    this.vectors = vectors;
   }
 
   size(): number {

--- a/tests/__stubs__/xenova-transformers.js
+++ b/tests/__stubs__/xenova-transformers.js
@@ -1,3 +1,8 @@
+// Test-only fake of @xenova/transformers — hash-based deterministic embedder.
+// Wired in via jest.config.js moduleNameMapper. The real ONNX model runs in
+// production and is exercised end-to-end by the US-03 AC inline node commands,
+// not by jest specs.
+
 const DIM = 384;
 
 function tokenize(text) {

--- a/tests/vectorIndex.test.ts
+++ b/tests/vectorIndex.test.ts
@@ -104,4 +104,26 @@ describe("VectorIndex", () => {
       fs.rmSync(dir, { recursive: true, force: true });
     }
   });
+
+  it("rejects loading a corrupt index with chunks.length !== vectors.length", async () => {
+    const dir = path.join(os.tmpdir(), `monday-idx-corrupt-${Date.now()}`);
+    try {
+      fs.mkdirSync(dir, { recursive: true });
+      fs.writeFileSync(
+        path.join(dir, "index.json"),
+        JSON.stringify({
+          chunks: [
+            { id: "a", text: "one", source: "a.txt" },
+            { id: "b", text: "two", source: "b.txt" },
+          ],
+          vectors: [new Array(384).fill(0.1)],
+        }),
+        "utf-8",
+      );
+      const idx = new VectorIndex();
+      await expect(idx.load(dir)).rejects.toThrow(/corrupt index/);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
 });


### PR DESCRIPTION
## Summary

Close two ship-review enhancements from PR #21 (US-03):

- **#22** — `VectorIndex.load()` now throws if `parsed.chunks.length !== parsed.vectors.length`. Previously a corrupt / hand-edited `index.json` with mismatched arrays would silently produce `NaN` cosine scores (undefined at `vectors[i]`) rather than fail fast. The new assertion is consistent with the existing model-id fail-fast on line 99.
- **#25** — 4-line header comment on `tests/__stubs__/xenova-transformers.js` clarifying it is a test-only fake; the real ONNX model runs in production and is exercised by the US-03 AC inline node commands, not by jest specs.

## Test plan

- [x] `npm run build` clean
- [x] `npm test` — 23/23 pass (1 new spec for the length-mismatch assertion)
- [x] No behavior change in the success path — only adds a fail-fast on corrupt input

Closes #22
Closes #25

---
plan-refresh: baseline