### PR TITLE
chore: US-01 scaffold hygiene — trim env tokens (#2) + simplify filter (#3) + modern ts-jest (#6)

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,7 @@
+const { createDefaultPreset } = require("ts-jest");
+
 module.exports = {
-  preset: "ts-jest",
+  ...createDefaultPreset(),
   testEnvironment: "node",
   testMatch: ["<rootDir>/tests/**/*.test.ts"],
   moduleFileExtensions: ["ts", "js"],

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -17,12 +17,12 @@ export class MissingEnvVarError extends Error {
 }
 
 export function validateEnv(env: NodeJS.ProcessEnv = process.env): AppEnv {
-  const missing = REQUIRED_ENV_VARS.filter((key) => !env[key] || env[key]?.trim() === "");
+  const missing = REQUIRED_ENV_VARS.filter((key) => !env[key]?.trim());
   if (missing.length > 0) {
     throw new MissingEnvVarError(missing);
   }
   return {
-    slackBotToken: env.SLACK_BOT_TOKEN!,
-    slackAppToken: env.SLACK_APP_TOKEN!,
+    slackBotToken: env.SLACK_BOT_TOKEN!.trim(),
+    slackAppToken: env.SLACK_APP_TOKEN!.trim(),
   };
 }

--- a/tests/env.test.ts
+++ b/tests/env.test.ts
@@ -39,4 +39,19 @@ describe("validateEnv", () => {
       expect(msg.toLowerCase()).toContain("missing");
     }
   });
+
+  it("throws MissingEnvVarError when a token is whitespace-only", () => {
+    expect(() =>
+      validateEnv({ SLACK_BOT_TOKEN: BOT_TOKEN_PLACEHOLDER, SLACK_APP_TOKEN: "   \t  " })
+    ).toThrow(MissingEnvVarError);
+  });
+
+  it("trims leading/trailing whitespace from returned token values", () => {
+    const env = validateEnv({
+      SLACK_BOT_TOKEN: `  ${BOT_TOKEN_PLACEHOLDER}  `,
+      SLACK_APP_TOKEN: `\t${APP_TOKEN_PLACEHOLDER}\n`,
+    });
+    expect(env.slackBotToken).toBe(BOT_TOKEN_PLACEHOLDER);
+    expect(env.slackAppToken).toBe(APP_TOKEN_PLACEHOLDER);
+  });
 });


### PR DESCRIPTION
## Summary

Close three ship-review enhancements from PR #1 (US-01):

- **#2** — `validateEnv()` now returns trimmed token values (`env.SLACK_BOT_TOKEN!.trim()` / `env.SLACK_APP_TOKEN!.trim()`). Prevents stray whitespace in tokens from leaking into Slack client init.
- **#3** — Collapse the redundant two-part filter `!env[key] || env[key]?.trim() === ""` into the single expression `!env[key]?.trim()`. Same semantics: catches `undefined`, `null`, empty-string, and whitespace-only in one optional-chain.
- **#6** — Replace deprecated `preset: "ts-jest"` with `...createDefaultPreset()` per ts-jest 29.x guidance. Pure config modernization, identical transform behavior.

## Test plan

- [x] `npm run build` clean
- [x] `npm test` — 25/25 pass (2 new env specs, all existing specs still pass)
- [x] New specs:
  - Rejects whitespace-only tokens with MissingEnvVarError (regression guard for the simpler filter)
  - Trims leading/trailing whitespace from returned token values
- [x] Jest config migration: ts-jest `createDefaultPreset()` produces identical transform behavior — verified by 25/25 specs still passing

Closes #2
Closes #3
Closes #6

---
plan-refresh: baseline