### PR TITLE
chore: US-03 polish — dup-id warn (#23) + ranking round-trip assertion (#24) + reset hook (#26)

### DIFF
--- a/src/embeddings/embed.ts
+++ b/src/embeddings/embed.ts
@@ -18,6 +18,10 @@ async function getExtractor() {
   return pipelinePromise;
 }
 
+export function _resetExtractorForTests(): void {
+  pipelinePromise = null;
+}
+
 export async function embed(text: string): Promise<number[]> {
   if (typeof text !== "string") {
     throw new TypeError("embed() requires a string input");

--- a/src/index/vectorIndex.ts
+++ b/src/index/vectorIndex.ts
@@ -56,7 +56,10 @@ export class VectorIndex {
         throw new TypeError("VectorIndex.add: each chunk must have text and source");
       }
       const id = c.id ?? autoId(c);
-      if (this.chunks.some((existing) => existing.id === id)) continue;
+      if (this.chunks.some((existing) => existing.id === id)) {
+        console.warn(`VectorIndex.add: skipping duplicate id "${id}" (source: ${c.source})`);
+        continue;
+      }
       const vec = await embed(c.text);
       this.chunks.push({ ...c, id });
       this.vectors.push(vec);

--- a/tests/embed.test.ts
+++ b/tests/embed.test.ts
@@ -1,4 +1,4 @@
-import { embed } from "../src/embeddings/embed";
+import { embed, _resetExtractorForTests } from "../src/embeddings/embed";
 
 jest.setTimeout(120_000);
 
@@ -43,5 +43,14 @@ describe("embed", () => {
     const vec = await embed("");
     expect(Array.isArray(vec)).toBe(true);
     expect(vec.length).toBeGreaterThan(0);
+  });
+
+  it("_resetExtractorForTests() clears the cached pipeline without breaking subsequent calls", async () => {
+    const before = await embed("hello world");
+    expect(before.length).toBeGreaterThan(0);
+    _resetExtractorForTests();
+    const after = await embed("hello world");
+    expect(after.length).toBe(before.length);
+    expect(after).toEqual(before);
   });
 });

--- a/tests/vectorIndex.test.ts
+++ b/tests/vectorIndex.test.ts
@@ -126,4 +126,49 @@ describe("VectorIndex", () => {
       fs.rmSync(dir, { recursive: true, force: true });
     }
   });
+
+  it("warns and skips when add() sees a duplicate chunk id", async () => {
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const idx = new VectorIndex();
+      await idx.add([
+        { id: "dup", text: "first", source: "a.txt" },
+        { id: "dup", text: "second but same id", source: "b.txt" },
+      ]);
+      const results = await idx.search("first", 5);
+      expect(results.length).toBe(1);
+      expect(results[0].text).toBe("first");
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringMatching(/duplicate id "dup"/));
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it("preserves multi-chunk ranking order across save/load round-trip", async () => {
+    const dir = path.join(os.tmpdir(), `monday-idx-ranking-${Date.now()}`);
+    try {
+      const original = new VectorIndex();
+      await original.add([
+        { id: "vpn", text: "VPN setup requires Cisco AnyConnect on your laptop.", source: "vpn.txt" },
+        { id: "hr", text: "Annual leave is fourteen days per year for permanent staff.", source: "hr.txt" },
+        { id: "refund", text: "Refund requests must be submitted within thirty days.", source: "refund.txt" },
+      ]);
+      const beforeResults = await original.search("how to connect to VPN", 3);
+      const beforeOrder = beforeResults.map((r) => r.id);
+
+      await original.save(dir);
+      const reloaded = new VectorIndex();
+      await reloaded.load(dir);
+      const afterResults = await reloaded.search("how to connect to VPN", 3);
+      const afterOrder = afterResults.map((r) => r.id);
+
+      expect(afterOrder).toEqual(beforeOrder);
+      expect(afterOrder.length).toBe(3);
+      const beforeScores = beforeResults.map((r) => r.score);
+      const afterScores = afterResults.map((r) => r.score);
+      expect(afterScores).toEqual(beforeScores);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
 });


### PR DESCRIPTION
## Summary

Close three ship-review enhancements from PR #21 (US-03):

- **#23** — `VectorIndex.add()` now emits a `console.warn` when skipping a duplicate chunk id. Previously callers accidentally re-adding the same chunk (or two distinct chunks colliding on the 16-hex sha1 prefix) had no signal that indexing was a no-op.
- **#24** — New jest spec asserts that `search()` ranking order AND per-result scores are preserved across `VectorIndex.save()` + fresh `VectorIndex.load()` round-trip. Catches future regressions where JSON serialization could drift vector values (float precision loss, array truncation, etc.).
- **#26** — Expose `_resetExtractorForTests()` from `src/embeddings/embed` that clears the module-level `pipelinePromise` cache. Enables future tests (notably US-11 model-swap scenarios) to re-initialize the pipeline without tearing down the whole test process. Named with a leading underscore to signal test-only intent.

## Test plan

- [x] `npm run build` clean
- [x] `npm test` — 33/33 pass (3 new specs, all existing specs still pass)
- [x] New specs:
  - VectorIndex: duplicate-id add emits console.warn + skips
  - VectorIndex: save/load round-trip preserves ranking order + scores
  - embed: `_resetExtractorForTests()` doesn't break subsequent `embed()`

Closes #23
Closes #24
Closes #26

---
plan-refresh: baseline