### PR TITLE
fix: replace require() with ES import for pdfjs-dist

### DIFF
--- a/src/ingestion/parsers/pdf.ts
+++ b/src/ingestion/parsers/pdf.ts
@@ -1,8 +1,6 @@
 import * as fs from "fs/promises";
+import * as pdfjs from "pdfjs-dist/legacy/build/pdf.js";
 import type { Chunk } from "../ingest";
-
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const pdfjs = require("pdfjs-dist/legacy/build/pdf.js");
 
 export async function parsePdf(filePath: string, source: string): Promise<Chunk[]> {
   const buffer = await fs.readFile(filePath);


### PR DESCRIPTION
Closes #12

Auto-fix by /housekeep Stage 4.

Replaced the `require('pdfjs-dist/legacy/build/pdf.js')` with ES namespace import (`import * as pdfjs from ...`). Removes the any-typed binding so TypeScript can infer types from pdfjs-dist's declarations. Validation: `npx tsc --noEmit` passes.