### PR TITLE
fix: pin pdfjs-dist to exact 3.11.174

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,6 @@
   "dependencies": {
     "@xenova/transformers": "^2.17.2",
     "mammoth": "^1.12.0",
-    "pdfjs-dist": "^3.11.174"
+    "pdfjs-dist": "3.11.174"
   }
 }


### PR DESCRIPTION
Closes #13

Auto-fix by /housekeep Stage 4.

Changed pdfjs-dist version spec from `^3.11.174` to exact `3.11.174` to prevent lockfile regen drift to 3.12.x (breaks API compat per ship-review E5 from PR #8).