### PR TITLE
fix: drop pdf-parse reference in PDF fixture body

### DIFF
--- a/scripts/generate-test-fixtures.js
+++ b/scripts/generate-test-fixtures.js
@@ -18,7 +18,7 @@ async function generatePdf() {
     doc
       .fontSize(11)
       .text(
-        "This PDF is used as an ingestion fixture. It contains enough text to verify that pdf-parse can extract content and that ingestFile returns a chunk with non-empty text."
+        "This PDF is used as an ingestion fixture. It contains enough text to verify that the PDF parser can extract content and that ingestFile returns a chunk with non-empty text."
       );
     doc.end();
     stream.on("finish", () => resolve(pdfPath));


### PR DESCRIPTION
Closes #18

Auto-fix by /housekeep Stage 4.

Replaced 'pdf-parse' with generic 'the PDF parser' in the PDF body fixture text to drop the library-name coupling. Parser implementation remains free to use pdfjs-dist or any other library without fixture drift.