### PR TITLE
fix: mock node:os for deterministic API-key fallback test

### DIFF
--- a/tests/generate.test.ts
+++ b/tests/generate.test.ts
@@ -1,9 +1,24 @@
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+let currentHome = tmpdir();
+
+jest.mock("node:os", () => {
+  const actual = jest.requireActual("node:os") as typeof import("node:os");
+  return {
+    ...actual,
+    homedir: () => currentHome,
+  };
+});
+
 import { generateAnswer, Chunk } from "../src/llm/generate";
 
 describe("generateAnswer", () => {
   const originalEnv = process.env.ANTHROPIC_API_KEY;
 
   beforeAll(() => {
+    currentHome = mkdtempSync(join(tmpdir(), "monday-gen-"));
     process.env.ANTHROPIC_API_KEY = "test-stub-key";
   });
 


### PR DESCRIPTION
Closes #43

Auto-fix by /housekeep Stage 4.

Mirrors the jest.mock('node:os', ...) pattern from anthropicClient.test.ts so homedir() returns an empty tmpdir. The API-key fallback path is now exercised deterministically regardless of whether the developer machine has real Claude Code credentials on disk.