### PR TITLE
fix: add ANTHROPIC_MODEL env override

### DIFF
--- a/src/llm/generate.ts
+++ b/src/llm/generate.ts
@@ -1,6 +1,6 @@
 import { getClient } from "./anthropicClient";
 
-const MODEL = "claude-haiku-4-5-20251001";
+const MODEL = process.env.ANTHROPIC_MODEL ?? "claude-haiku-4-5-20251001";
 const MAX_TOKENS = 1024;
 
 const SYSTEM_PROMPT =


### PR DESCRIPTION
Closes #47

Auto-fix by /housekeep Stage 4.

Reads ANTHROPIC_MODEL from env with the existing Haiku snapshot id as fallback. Enables ops-side model rotation without a code change + redeploy.