### PR TITLE
fix: wrap pdfjs PasswordException with friendly error

### DIFF
--- a/src/ingestion/parsers/pdf.ts
+++ b/src/ingestion/parsers/pdf.ts
@@ -7,7 +7,15 @@ export async function parsePdf(filePath: string, source: string): Promise<Chunk[
   const data = new Uint8Array(buffer);
 
   const loadingTask = pdfjs.getDocument({ data, useWorkerFetch: false, isEvalSupported: false });
-  const doc = await loadingTask.promise;
+  let doc;
+  try {
+    doc = await loadingTask.promise;
+  } catch (err: unknown) {
+    if (err instanceof Error && err.name === "PasswordException") {
+      throw new Error(`${filePath} is password-protected`);
+    }
+    throw err;
+  }
 
   try {
     const chunks: Chunk[] = [];


### PR DESCRIPTION
Closes #19

Auto-fix by /housekeep Stage 4.

Wrapped `await loadingTask.promise` in a try/catch that detects pdfjs PasswordException (via `err.name === 'PasswordException'`) and rethrows as `Error('{filePath} is password-protected')`. All other errors are re-thrown unchanged.

Validation: `npx tsc --noEmit` clean.

---
plan-refresh: no-op