### PR TITLE
fix(pdfjs): narrow doc type + regression test for PasswordException (#53, #54)

### DIFF
--- a/src/ingestion/parsers/pdf.ts
+++ b/src/ingestion/parsers/pdf.ts
@@ -7,7 +7,7 @@ export async function parsePdf(filePath: string, source: string): Promise<Chunk[
   const data = new Uint8Array(buffer);
 
   const loadingTask = pdfjs.getDocument({ data, useWorkerFetch: false, isEvalSupported: false });
-  let doc;
+  let doc!: Awaited<typeof loadingTask.promise>;
   try {
     doc = await loadingTask.promise;
   } catch (err: unknown) {

--- a/tests/pdf-password.test.ts
+++ b/tests/pdf-password.test.ts
@@ -1,0 +1,29 @@
+/**
+ * Regression test for pdfjs PasswordException → friendly error wrapping.
+ *
+ * Pins the discriminator on `err.name === "PasswordException"` so a future pdfjs
+ * upgrade that renames the class is caught instead of silently falling through
+ * to the generic rethrow path. See PR #52 / issue #54.
+ */
+
+jest.mock("fs/promises", () => ({
+  readFile: jest.fn(() => Promise.resolve(Buffer.from("dummy-pdf-bytes"))),
+}));
+
+jest.mock("pdfjs-dist/legacy/build/pdf.js", () => ({
+  getDocument: jest.fn(() => ({
+    promise: Promise.reject(
+      Object.assign(new Error("File is encrypted"), { name: "PasswordException" }),
+    ),
+  })),
+}));
+
+import { parsePdf } from "../src/ingestion/parsers/pdf";
+
+describe("parsePdf — PasswordException wrapping", () => {
+  it("rethrows pdfjs PasswordException as <filePath> is password-protected", async () => {
+    await expect(parsePdf("/tmp/secret.pdf", "secret.pdf")).rejects.toThrow(
+      "/tmp/secret.pdf is password-protected",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
Two follow-ups from the /ship Stage 5 review on PR #52:

- **#53**: replace `let doc;` (implicit `any`) with `let doc!: Awaited<typeof loadingTask.promise>;` — pins the type via inference from the pdfjs API surface, no extra import. Definite-assignment assertion (`!`) is correct here because the catch always rethrows.
- **#54**: add `tests/pdf-password.test.ts`. Mocks pdfjs's `getDocument` to reject with an error whose `name === "PasswordException"`, then asserts `parsePdf` rethrows the friendly `<filePath> is password-protected` message. Locks the discriminator against silent renames in pdfjs upgrades.

## Test plan
- `npx tsc --noEmit` — clean.
- `npx jest tests/pdf-password.test.ts` — 1 passed.
- `npx jest` — full suite **43/43 pass** (was 42/42 before this PR — net +1).
- `grep -nE '^[[:space:]]*let doc;' src/ingestion/parsers/pdf.ts` returns no match.

Closes #53
Closes #54

---
plan-refresh: no-op