### PR TITLE
fix(bootstrap): friendly error fallback + tsconfig.test.json (#4, #7)

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   "scripts": {
     "build": "tsc",
     "start": "node dist/index.js",
-    "test": "jest"
+    "test": "jest",
+    "typecheck": "tsc --noEmit && tsc --noEmit -p tsconfig.test.json"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,12 @@ function main(): void {
       console.error(`\nMonday cannot start: ${err.message}\n`);
       process.exit(1);
     }
-    throw err;
+    const message = err instanceof Error ? err.message : String(err);
+    console.error(`\nMonday cannot start: ${message}\n`);
+    if (process.env.MONDAY_DEBUG === "1" && err instanceof Error && err.stack) {
+      console.error(err.stack);
+    }
+    process.exit(1);
   }
 }
 

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": ["src/**/*", "tests/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary
Two leftover bootstrap-track polish items from PR #1 review:

- **#4**: `main()` now catches all errors (not just `MissingEnvVarError`), prints a one-line friendly message, exits 1. Set `MONDAY_DEBUG=1` to also print the stack — preserves debugging escape hatch.
- **#7**: add `tsconfig.test.json` that includes both `src/` and `tests/`, plus a `npm run typecheck` script that runs both passes. Test files are now type-checked.

## Test plan
- `npx tsc --noEmit` → exit 0 (no regression to existing AC-01).
- `npx tsc --noEmit -p tsconfig.test.json` → exit 0.
- `npm run typecheck` → exit 0 (runs both).
- Negative probe (`const bad: number = "x";` in a test file) → exit 2 with TS2322 — confirms tests are now type-checked.
- Friendly error: `SLACK_BOT_TOKEN= node dist/index.js` → "Monday cannot start: …" + exit 1, no raw stack.
- `npx jest` → 43/43 still pass.

Closes #4
Closes #7

---
plan-refresh: no-op