### PR TITLE
fix(embed): NODE_ENV gate + cache-miss spy test (#35, #36)

### DIFF
--- a/src/embeddings/embed.ts
+++ b/src/embeddings/embed.ts
@@ -19,6 +19,11 @@ async function getExtractor() {
 }
 
 export function _resetExtractorForTests(): void {
+  if (process.env.NODE_ENV !== "test") {
+    throw new Error(
+      "_resetExtractorForTests() is a test-only seam. Set NODE_ENV=test to call it.",
+    );
+  }
   pipelinePromise = null;
 }
 

--- a/tests/embed-cache.test.ts
+++ b/tests/embed-cache.test.ts
@@ -1,0 +1,56 @@
+/**
+ * Cache-miss spy test for `_resetExtractorForTests`. Mocks @xenova/transformers
+ * to count pipeline-builder invocations; asserts cache hit on second call,
+ * cache miss after reset. See PR #34 / issue #36 for the no-op-passes-too gap.
+ *
+ * Lives in a separate file so the real-model tests in tests/embed.test.ts
+ * stay free of module mocks.
+ */
+
+let pipelineInvocations = 0;
+
+jest.mock("@xenova/transformers", () => ({
+  pipeline: jest.fn(async () => {
+    pipelineInvocations += 1;
+    // Return a stub extractor that yields a deterministic 4-d vector.
+    return async (_text: string, _opts?: unknown) => ({
+      data: new Float32Array([0.1, 0.2, 0.3, 0.4]),
+    });
+  }),
+}));
+
+import { embed, _resetExtractorForTests } from "../src/embeddings/embed";
+
+describe("embed cache lifecycle", () => {
+  beforeEach(() => {
+    pipelineInvocations = 0;
+    _resetExtractorForTests();
+    pipelineInvocations = 0;
+  });
+
+  it("first call invokes pipeline once; second call hits cache", async () => {
+    expect(pipelineInvocations).toBe(0);
+    await embed("warm");
+    expect(pipelineInvocations).toBe(1);
+    await embed("cached");
+    expect(pipelineInvocations).toBe(1);
+  });
+
+  it("_resetExtractorForTests() forces a fresh pipeline build on next call", async () => {
+    await embed("warm");
+    expect(pipelineInvocations).toBe(1);
+    _resetExtractorForTests();
+    await embed("after-reset");
+    expect(pipelineInvocations).toBe(2);
+  });
+
+  it("_resetExtractorForTests() throws when NODE_ENV is not test", () => {
+    const original = process.env.NODE_ENV;
+    process.env.NODE_ENV = "production";
+    try {
+      expect(() => _resetExtractorForTests()).toThrow(/test-only seam/);
+    } finally {
+      process.env.NODE_ENV = original;
+    }
+  });
+});


### PR DESCRIPTION
## Summary
Two LLM-answers track polish items from PR #34 review:

- **#35**: `_resetExtractorForTests()` now throws when `NODE_ENV !== "test"`. Production callers calling it by mistake get a clear error instead of silently wiping the cache. Jest sets `NODE_ENV=test` automatically, so existing real-model tests are unaffected.
- **#36**: new `tests/embed-cache.test.ts` mocks `@xenova/transformers` and counts pipeline-builder invocations. Asserts cache lifecycle is real (no-op reset would fail). Plus a third test asserts the NODE_ENV gate throws — locks in #35 from the test side.

Issue #37 (per-chunk duplicate-id warn) was closed separately as deferred — its own text says "fine at PRD scale, revisit at US-04/US-06 corpus scale-up" and no production trigger exists today.

## Test plan
- `npm run typecheck` → exit 0.
- `npx jest tests/embed-cache.test.ts` → 3/3 pass.
- `npx jest` → 46/46 pass (was 43, net +3).

Closes #35
Closes #36

---
plan-refresh: no-op