### PR TITLE
fix(ingest): mammoth warnings + heading/section divergence (#10, #20)

### DIFF
--- a/src/ingestion/parsers/docx.ts
+++ b/src/ingestion/parsers/docx.ts
@@ -3,6 +3,11 @@ import type { Chunk } from "../ingest";
 
 export async function parseDocx(filePath: string, source: string): Promise<Chunk[]> {
   const result = await mammoth.extractRawText({ path: filePath });
+  if (process.env.MONDAY_DEBUG === "1" && result.messages && result.messages.length > 0) {
+    for (const m of result.messages) {
+      console.warn(`mammoth ${m.type ?? "warn"}: ${m.message ?? String(m)} (${source})`);
+    }
+  }
   const text = result.value.trim();
 
   if (text.length === 0) {

--- a/src/ingestion/parsers/markdown.ts
+++ b/src/ingestion/parsers/markdown.ts
@@ -7,7 +7,11 @@ export async function parseMarkdown(filePath: string, source: string): Promise<C
   const lines = raw.split(/\r?\n/);
 
   const chunks: Chunk[] = [];
+  // heading = nearest heading at any level (where the chunk lives).
+  // section = nearest H1 only (which top-level group the chunk is under).
+  // They diverge under sub-headings; equal under top-level.
   let currentHeading: string | undefined;
+  let currentSection: string | undefined;
   let buffer: string[] = [];
   let inCodeFence = false;
 
@@ -15,10 +19,8 @@ export async function parseMarkdown(filePath: string, source: string): Promise<C
     const text = buffer.join("\n").trim();
     if (text.length > 0) {
       const chunk: Chunk = { text, source };
-      if (currentHeading) {
-        chunk.heading = currentHeading;
-        chunk.section = currentHeading;
-      }
+      if (currentHeading) chunk.heading = currentHeading;
+      if (currentSection) chunk.section = currentSection;
       chunks.push(chunk);
     }
     buffer = [];
@@ -38,6 +40,7 @@ export async function parseMarkdown(filePath: string, source: string): Promise<C
       if (headingMatch) {
         flush();
         currentHeading = headingMatch[2];
+        if (headingMatch[1].length === 1) currentSection = headingMatch[2];
         continue;
       }
 
@@ -55,6 +58,8 @@ export async function parseMarkdown(filePath: string, source: string): Promise<C
       ) {
         flush();
         currentHeading = line.trim();
+        // === underline = setext H1; --- underline = setext H2.
+        if (/^=+\s*$/.test(next)) currentSection = currentHeading;
         i++;
         continue;
       }

--- a/tests/ingestion.test.ts
+++ b/tests/ingestion.test.ts
@@ -192,4 +192,40 @@ describe("ingestFile", () => {
       fs.unlinkSync(tmpFile);
     }
   });
+
+  it("Markdown heading and section diverge: section tracks H1 only, heading tracks any level", async () => {
+    const pathMod = require("path");
+    const fs = require("fs");
+    const os = require("os");
+    const tmpFile = pathMod.join(os.tmpdir(), "monday-heading-section-divergence.md");
+    const content = [
+      "# Top Title",
+      "",
+      "intro paragraph",
+      "",
+      "## Sub Topic",
+      "",
+      "sub paragraph",
+      "",
+      "### Deeper",
+      "",
+      "deeper paragraph",
+    ].join("\n");
+    fs.writeFileSync(tmpFile, content);
+    try {
+      const chunks = await ingestFile(tmpFile);
+      const intro = chunks.find((c) => c.text.includes("intro paragraph"))!;
+      const sub = chunks.find((c) => c.text.includes("sub paragraph"))!;
+      const deep = chunks.find((c) => c.text.includes("deeper paragraph"))!;
+      expect(intro.heading).toBe("Top Title");
+      expect(intro.section).toBe("Top Title");
+      expect(sub.heading).toBe("Sub Topic");
+      expect(sub.section).toBe("Top Title");
+      expect(deep.heading).toBe("Deeper");
+      expect(deep.section).toBe("Top Title");
+      expect(sub.heading).not.toBe(sub.section);
+    } finally {
+      fs.unlinkSync(tmpFile);
+    }
+  });
 });


### PR DESCRIPTION
## Summary
- **#10**: `parseDocx` logs `result.messages` when `MONDAY_DEBUG=1` so mammoth conversion warnings (ignored elements, etc.) are visible during debugging instead of silently swallowed.
- **#20**: `parseMarkdown` tracks `currentHeading` (any level) and `currentSection` (most recent H1 only) separately. Chunks under sub-headings carry both fields with potentially different values — `heading` = where the chunk lives, `section` = which top-level group it belongs to. Setext rule: `===` underline updates section (H1), `---` underline updates heading only (H2).

## Test plan
- `npm run typecheck` → exit 0.
- `npx jest` → 47/47 (was 46, net +1 divergence test).
- Divergence test asserts: under `## Sub Topic` of `# Top Title`, `chunk.heading === "Sub Topic"` while `chunk.section === "Top Title"`.

## Closed without code change
- **#14** (CORPUS_ROOT path validation) deferred — issue text marks it as future-only, "Fine for US-02 scaffolding".
- **#15** (parser-map injection for router tests) deferred — issue text says "Low priority — current surface is small". `jest.mock()` works fine for the 4-parser surface.

Closes #10
Closes #20

---
plan-refresh: no-op