### PR TITLE
chore(polish): ship-review rollup v0.4.6 (#44 + #45 + #58 + #59)

### DIFF
--- a/src/embeddings/embed.ts
+++ b/src/embeddings/embed.ts
@@ -21,7 +21,7 @@ async function getExtractor() {
 export function _resetExtractorForTests(): void {
   if (process.env.NODE_ENV !== "test") {
     throw new Error(
-      "_resetExtractorForTests() is a test-only seam. Set NODE_ENV=test to call it.",
+      "_resetExtractorForTests() must only be called from Jest tests; production code should not import it.",
     );
   }
   pipelinePromise = null;

--- a/src/llm/anthropicClient.ts
+++ b/src/llm/anthropicClient.ts
@@ -9,24 +9,34 @@ let client: Anthropic | null = null;
 let clientExpiresAt: number | null = null;
 
 function readOAuthToken(): { accessToken: string; expiresAt: number } | null {
+  const credPath = join(homedir(), ".claude", ".credentials.json");
+  let raw: string;
   try {
-    const credPath = join(homedir(), ".claude", ".credentials.json");
-    const creds = JSON.parse(readFileSync(credPath, "utf-8"));
-    const oauth = creds.claudeAiOauth as
-      | { accessToken?: unknown; expiresAt?: unknown }
-      | undefined;
-    if (
-      typeof oauth?.accessToken !== "string" ||
-      typeof oauth?.expiresAt !== "number"
-    ) {
-      return null;
-    }
-    const remainingMs = oauth.expiresAt - Date.now();
-    if (remainingMs < EXPIRY_BUFFER_MS) return null;
-    return { accessToken: oauth.accessToken, expiresAt: oauth.expiresAt };
+    raw = readFileSync(credPath, "utf-8");
   } catch {
     return null;
   }
+  let creds: unknown;
+  try {
+    creds = JSON.parse(raw);
+  } catch (err) {
+    console.warn(
+      `[anthropicClient] Malformed JSON at ${credPath} — falling back to ANTHROPIC_API_KEY: ${(err as Error).message}`,
+    );
+    return null;
+  }
+  const oauth = (creds as { claudeAiOauth?: unknown }).claudeAiOauth as
+    | { accessToken?: unknown; expiresAt?: unknown }
+    | undefined;
+  if (
+    typeof oauth?.accessToken !== "string" ||
+    typeof oauth?.expiresAt !== "number"
+  ) {
+    return null;
+  }
+  const remainingMs = oauth.expiresAt - Date.now();
+  if (remainingMs < EXPIRY_BUFFER_MS) return null;
+  return { accessToken: oauth.accessToken, expiresAt: oauth.expiresAt };
 }
 
 export function resetClient(): void {

--- a/src/llm/generate.ts
+++ b/src/llm/generate.ts
@@ -80,6 +80,10 @@ export async function generateAnswer(
     .join("")
     .trim();
 
+  if (text.length === 0) {
+    return { answer: NO_CONTEXT_ANSWER, citations: [] };
+  }
+
   return {
     answer: text,
     citations: buildCitations(chunks),

--- a/tests/embed-cache.test.ts
+++ b/tests/embed-cache.test.ts
@@ -48,7 +48,9 @@ describe("embed cache lifecycle", () => {
     const original = process.env.NODE_ENV;
     process.env.NODE_ENV = "production";
     try {
-      expect(() => _resetExtractorForTests()).toThrow(/test-only seam/);
+      expect(() => _resetExtractorForTests()).toThrow(
+        /must only be called from Jest tests/,
+      );
     } finally {
       process.env.NODE_ENV = original;
     }

--- a/tests/embed-cache.test.ts
+++ b/tests/embed-cache.test.ts
@@ -7,11 +7,11 @@
  * stay free of module mocks.
  */
 
-let pipelineInvocations = 0;
+let mockPipelineInvocations = 0;
 
 jest.mock("@xenova/transformers", () => ({
   pipeline: jest.fn(async () => {
-    pipelineInvocations += 1;
+    mockPipelineInvocations += 1;
     // Return a stub extractor that yields a deterministic 4-d vector.
     return async (_text: string, _opts?: unknown) => ({
       data: new Float32Array([0.1, 0.2, 0.3, 0.4]),
@@ -23,25 +23,25 @@ import { embed, _resetExtractorForTests } from "../src/embeddings/embed";
 
 describe("embed cache lifecycle", () => {
   beforeEach(() => {
-    pipelineInvocations = 0;
+    mockPipelineInvocations = 0;
     _resetExtractorForTests();
-    pipelineInvocations = 0;
+    mockPipelineInvocations = 0;
   });
 
   it("first call invokes pipeline once; second call hits cache", async () => {
-    expect(pipelineInvocations).toBe(0);
+    expect(mockPipelineInvocations).toBe(0);
     await embed("warm");
-    expect(pipelineInvocations).toBe(1);
+    expect(mockPipelineInvocations).toBe(1);
     await embed("cached");
-    expect(pipelineInvocations).toBe(1);
+    expect(mockPipelineInvocations).toBe(1);
   });
 
   it("_resetExtractorForTests() forces a fresh pipeline build on next call", async () => {
     await embed("warm");
-    expect(pipelineInvocations).toBe(1);
+    expect(mockPipelineInvocations).toBe(1);
     _resetExtractorForTests();
     await embed("after-reset");
-    expect(pipelineInvocations).toBe(2);
+    expect(mockPipelineInvocations).toBe(2);
   });
 
   it("_resetExtractorForTests() throws when NODE_ENV is not test", () => {


### PR DESCRIPTION
## Summary

Bundles four small ship-review enhancements surfaced by the stateless reviewer on prior PRs (#41, #57). All forward-compat hardening and quality-of-life tweaks; no behavior changes for happy-path callers.

- **#44** (`fix(generate)`): If Claude returns only tool-use / refusal blocks, trimmed text is empty. Previously the caller got an empty Slack message with citations attached. Now falls through to `NO_CONTEXT_ANSWER` with empty citations, matching the no-chunks path.
- **#45** (`fix(anthropicClient)`): `readOAuthToken`'s catch-all conflated ENOENT, EACCES, and `SyntaxError`. Now logs malformed JSON at warn level so operators see the misconfiguration; ENOENT/EACCES still silent fall-through.
- **#58** (`test(embed-cache)`): Rename `pipelineInvocations` → `mockPipelineInvocations` for `babel-plugin-jest-hoist` forward-compat (works today; future jest/babel/ts-jest tightening may not).
- **#59** (`fix(embed)`): Rephrase `_resetExtractorForTests()` NODE_ENV gate error away from the footgun "Set NODE_ENV=test to call it" — a panicking caller might literally do that in production. New message describes the constraint without suggesting a worse fix.

## Test plan
- [x] `npm run typecheck` clean
- [x] `npm test` — 8/8 suites, 47/47 tests pass
- [x] embed-cache.test.ts thrown-message regex updated to match new error text
- [x] generate.test.ts existing assertions still pass (empty-text fallback is purely additive)

Closes #44, #45, #58, #59.

---
plan-refresh: baseline