### PR TITLE
fix: anthropicClient one-shot warn for malformed credentials

### DIFF
--- a/src/llm/anthropicClient.ts
+++ b/src/llm/anthropicClient.ts
@@ -7,6 +7,7 @@ const EXPIRY_BUFFER_MS = 5 * 60 * 1000;
 
 let client: Anthropic | null = null;
 let clientExpiresAt: number | null = null;
+let warnedOnceForMalformedCreds = false;
 
 function readOAuthToken(): { accessToken: string; expiresAt: number } | null {
   const credPath = join(homedir(), ".claude", ".credentials.json");
@@ -20,9 +21,12 @@ function readOAuthToken(): { accessToken: string; expiresAt: number } | null {
   try {
     creds = JSON.parse(raw);
   } catch (err) {
-    console.warn(
-      `[anthropicClient] Malformed JSON at ${credPath} — falling back to ANTHROPIC_API_KEY: ${(err as Error).message}`,
-    );
+    if (!warnedOnceForMalformedCreds) {
+      warnedOnceForMalformedCreds = true;
+      console.warn(
+        `[anthropicClient] Malformed JSON at ${credPath} — falling back to ANTHROPIC_API_KEY: ${(err as Error).message}`,
+      );
+    }
     return null;
   }
   const oauth = (creds as { claudeAiOauth?: unknown }).claudeAiOauth as


### PR DESCRIPTION
Closes #62

Auto-fix by /housekeep Stage 4.

Added module-level flag `warnedOnceForMalformedCreds = false` and gated the malformed-credentials `console.warn` inside `readOAuthToken()` so it fires at most once per process. Prevents re-emission from `resetClient()` callers or token-expiry refresh paths when `~/.claude/.credentials.json` is persistently broken.

Validation: `npx tsc --noEmit` PASSED.