### PR TITLE
fix: generate.ts log structured signal for empty model response

### DIFF
--- a/src/llm/generate.ts
+++ b/src/llm/generate.ts
@@ -81,6 +81,10 @@ export async function generateAnswer(
     .trim();
 
   if (text.length === 0) {
+    const blockTypes = response.content.map((block) => block.type);
+    console.warn(
+      `[generateAnswer] model returned non-text-only response: block_types=${JSON.stringify(blockTypes)} stop_reason=${response.stop_reason ?? "unknown"}`,
+    );
     return { answer: NO_CONTEXT_ANSWER, citations: [] };
   }
 


### PR DESCRIPTION
Closes #64

Auto-fix by /housekeep Stage 4.

Added a `console.warn` before the empty-text `NO_CONTEXT_ANSWER` return in `generateAnswer()`. The log records the response's block types (e.g. tool_use, refusal) and `stop_reason`, so operators can distinguish a non-text-only model response from the no-chunks path and diagnose prompt regressions or refusal trends.

Validation: `npx tsc --noEmit` PASSED.