### PR TITLE
feat(US-05): knowledge service facade

### DIFF
--- a/docs/decisions/INDEX.md
+++ b/docs/decisions/INDEX.md
@@ -15,3 +15,4 @@ Stories whose PASS recorded no material architectural decisions. One row per sto
 | US-02 | no new decisions | 484cee16abbc983923c66324f60701179a9d451b |
 | US-03 | no new decisions | 484cee16abbc983923c66324f60701179a9d451b |
 | US-04 | no new decisions | 484cee16abbc983923c66324f60701179a9d451b |
+| US-05 | no new decisions | 9fecce531c1a7445a071190299fdafa15f98e5b3 |

--- a/docs/generated/TECHNICAL-SPEC.md
+++ b/docs/generated/TECHNICAL-SPEC.md
@@ -1,6 +1,6 @@
 ---
 schemaVersion: "1.0.0"
-lastUpdated: "2026-04-25T16:14:26.405Z"
+lastUpdated: "2026-04-26T05:14:39.001Z"
 stories:
   - id: "US-01"
     lastUpdated: "2026-04-25T16:06:52.426Z"
@@ -14,6 +14,9 @@ stories:
   - id: "US-04"
     lastUpdated: "2026-04-25T16:14:26.405Z"
     lastGitSha: "484cee16abbc983923c66324f60701179a9d451b"
+  - id: "US-05"
+    lastUpdated: "2026-04-26T05:14:39.001Z"
+    lastGitSha: "9fecce531c1a7445a071190299fdafa15f98e5b3"
 ---
 
 ## story: US-01
@@ -37,6 +40,7 @@ stories:
 
 
 
+
 ## story: US-02
 
 ### api-contracts
@@ -55,6 +59,7 @@ stories:
 ### test-surface
 
 - Existing ingestion test suite (`jest --testPathPattern=ingestion`) used as regression gate for `anthropicClient` changes
+
 
 
 
@@ -82,6 +87,7 @@ stories:
 - `tests/vectorIndex.test.ts`: covers index reload and deletion correctness
 
 
+
 ## story: US-04
 
 ### api-contracts
@@ -99,3 +105,30 @@ stories:
 ### test-surface
 
 (none)
+
+
+## story: US-05
+
+### api-contracts
+
+- `KnowledgeService`: new public class exported from `src/knowledge/index.ts`
+- `KnowledgeService.search(query: string): Promise<KnowledgeResult[]>`: searches indexed knowledge base
+- `KnowledgeService.index(doc: KnowledgeDocument): Promise<void>`: adds a document to the knowledge store
+- `KnowledgeService.delete(id: string): Promise<void>`: removes a document by id from the knowledge store
+
+### data-models
+
+- `KnowledgeDocument`: persisted shape with at minimum `id: string`, `content: string`, and metadata fields
+- `KnowledgeResult`: wire-format response shape returned by `search`, wrapping `KnowledgeDocument` with a relevance score
+
+### invariants
+
+- `KnowledgeService.search` MUST return results sorted by descending relevance score
+- `KnowledgeService.index` MUST be idempotent on `id` (re-indexing same id overwrites, no duplicates)
+- `KnowledgeService.delete` MUST NOT throw if the given `id` does not exist
+- `src/knowledge/index.ts` MUST re-export all public surfaces of `src/knowledge/service.ts`
+
+### test-surface
+
+- `tests/knowledge.test.ts`: new file, 123 lines covering `KnowledgeService` index / search / delete behaviour
+- Test file matched by Jest pattern `--testPathPattern=knowledge`; MUST remain passing (AC-04 ratchet)

--- a/docs/generated/TECHNICAL-SPEC.md
+++ b/docs/generated/TECHNICAL-SPEC.md
@@ -112,23 +112,29 @@ stories:
 ### api-contracts
 
 - `KnowledgeService`: new public class exported from `src/knowledge/index.ts`
-- `KnowledgeService.search(query: string): Promise<KnowledgeResult[]>`: searches indexed knowledge base
-- `KnowledgeService.index(doc: KnowledgeDocument): Promise<void>`: adds a document to the knowledge store
-- `KnowledgeService.delete(id: string): Promise<void>`: removes a document by id from the knowledge store
+- `KnowledgeService.query(question: string): Promise<QueryResult>`: orchestrates vector search + LLM answer generation against the indexed corpus
+- `KnowledgeService.indexFile(absolutePath: string): Promise<void>`: ingests a single file from disk into the in-memory vector index
+- `KnowledgeService.getStatus(): ServiceStatus`: returns synchronous service health snapshot
 
 ### data-models
 
-- `KnowledgeDocument`: persisted shape with at minimum `id: string`, `content: string`, and metadata fields
-- `KnowledgeResult`: wire-format response shape returned by `search`, wrapping `KnowledgeDocument` with a relevance score
+- `QueryResult`: `{ answer: string; citations: Citation[] }` — `Citation` shape is reused from `src/llm/generate.ts` (US-04)
+- `ServiceStatus`: `{ documentCount: number; watcherAlive: boolean; uptimeSeconds: number }`
+- `KnowledgeServiceOptions`: optional DI surface — `{ index?, ingest?, generator?, topK?, now? }` — used by tests to inject stubs
 
 ### invariants
 
-- `KnowledgeService.search` MUST return results sorted by descending relevance score
-- `KnowledgeService.index` MUST be idempotent on `id` (re-indexing same id overwrites, no duplicates)
-- `KnowledgeService.delete` MUST NOT throw if the given `id` does not exist
-- `src/knowledge/index.ts` MUST re-export all public surfaces of `src/knowledge/service.ts`
+- `KnowledgeService.query` MUST short-circuit to a fixed no-documents answer with `citations: []` when the index is empty (no embedding, no generator call)
+- `KnowledgeService.query` MUST throw `TypeError` when `question` is not a string
+- `KnowledgeService.indexFile` MUST throw `TypeError` when `absolutePath` is not a non-empty string
+- `KnowledgeService.indexFile` MUST be a no-op when the ingestor returns zero chunks (no index mutation)
+- `KnowledgeService.getStatus().documentCount` counts unique source files, NOT individual chunks
+- `KnowledgeService.getStatus().uptimeSeconds` is monotonic non-negative seconds since constructor, derived from the injected `now()` clock
+- `KnowledgeService.getStatus().watcherAlive` is `false` in this slice — wired by US-06 (file watcher)
+- The facade MUST stay platform-agnostic: no Slack-specific types appear in its in/out shapes
+- `src/knowledge/index.ts` MUST re-export the public class and types
 
 ### test-surface
 
-- `tests/knowledge.test.ts`: new file, 123 lines covering `KnowledgeService` index / search / delete behaviour
-- Test file matched by Jest pattern `--testPathPattern=knowledge`; MUST remain passing (AC-04 ratchet)
+- `tests/knowledge.test.ts`: covers `query` / `indexFile` / `getStatus` behaviour across empty-index, end-to-end index→query, source-file dedupe, type guards, and clock-driven uptime
+- Matched by Jest pattern `--testPathPattern=knowledge`; MUST remain passing (AC-04 ratchet)

--- a/src/knowledge/index.ts
+++ b/src/knowledge/index.ts
@@ -1,0 +1,8 @@
+export {
+  KnowledgeService,
+  KnowledgeServiceOptions,
+  QueryResult,
+  ServiceStatus,
+  AnswerGenerator,
+  FileIngestor,
+} from "./service";

--- a/src/knowledge/service.ts
+++ b/src/knowledge/service.ts
@@ -1,0 +1,95 @@
+import { ingestFile, Chunk as IngestChunk } from "../ingestion/ingest";
+import { VectorIndex, SearchResult } from "../index/vectorIndex";
+import { generateAnswer, Chunk as LlmChunk, Citation } from "../llm/generate";
+
+const DEFAULT_TOP_K = 5;
+const NO_DOCUMENTS_ANSWER =
+  "I couldn't find any relevant information in the indexed documents to answer this question.";
+
+export interface QueryResult {
+  answer: string;
+  citations: Citation[];
+}
+
+export interface ServiceStatus {
+  documentCount: number;
+  watcherAlive: boolean;
+  uptimeSeconds: number;
+}
+
+export interface AnswerGenerator {
+  (question: string, chunks: LlmChunk[]): Promise<{ answer: string; citations: Citation[] }>;
+}
+
+export interface FileIngestor {
+  (absolutePath: string): Promise<IngestChunk[]>;
+}
+
+export interface KnowledgeServiceOptions {
+  index?: VectorIndex;
+  ingest?: FileIngestor;
+  generator?: AnswerGenerator;
+  topK?: number;
+  now?: () => number;
+}
+
+function toLlmChunk(result: SearchResult): LlmChunk {
+  const out: LlmChunk = {
+    id: result.id,
+    text: result.text,
+    source: result.source,
+    score: result.score,
+  };
+  if (result.heading !== undefined) out.heading = result.heading;
+  if (result.section !== undefined) out.section = result.section;
+  return out;
+}
+
+export class KnowledgeService {
+  private readonly index: VectorIndex;
+  private readonly ingest: FileIngestor;
+  private readonly generator: AnswerGenerator;
+  private readonly topK: number;
+  private readonly now: () => number;
+  private readonly startedAt: number;
+  private readonly indexedSources = new Set<string>();
+
+  constructor(opts: KnowledgeServiceOptions = {}) {
+    this.index = opts.index ?? new VectorIndex();
+    this.ingest = opts.ingest ?? ingestFile;
+    this.generator = opts.generator ?? generateAnswer;
+    this.topK = opts.topK ?? DEFAULT_TOP_K;
+    this.now = opts.now ?? Date.now;
+    this.startedAt = this.now();
+  }
+
+  async query(question: string): Promise<QueryResult> {
+    if (typeof question !== "string") {
+      throw new TypeError("KnowledgeService.query: question must be a string");
+    }
+    if (this.index.size() === 0) {
+      return { answer: NO_DOCUMENTS_ANSWER, citations: [] };
+    }
+    const hits = await this.index.search(question, this.topK);
+    const chunks = hits.map(toLlmChunk);
+    return this.generator(question, chunks);
+  }
+
+  async indexFile(absolutePath: string): Promise<void> {
+    if (typeof absolutePath !== "string" || absolutePath.length === 0) {
+      throw new TypeError("KnowledgeService.indexFile: absolutePath must be a non-empty string");
+    }
+    const chunks = await this.ingest(absolutePath);
+    if (chunks.length === 0) return;
+    await this.index.add(chunks);
+    for (const c of chunks) this.indexedSources.add(c.source);
+  }
+
+  getStatus(): ServiceStatus {
+    return {
+      documentCount: this.indexedSources.size,
+      watcherAlive: false,
+      uptimeSeconds: Math.max(0, Math.floor((this.now() - this.startedAt) / 1000)),
+    };
+  }
+}

--- a/tests/knowledge.test.ts
+++ b/tests/knowledge.test.ts
@@ -1,0 +1,123 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+import { KnowledgeService } from "../src/knowledge/service";
+import { Chunk as LlmChunk, Citation } from "../src/llm/generate";
+
+jest.setTimeout(60_000);
+
+function mkTempFile(name: string, body: string): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "monday-svc-test-"));
+  const file = path.join(dir, name);
+  fs.writeFileSync(file, body, "utf-8");
+  return file;
+}
+
+describe("KnowledgeService", () => {
+  describe("query without indexed documents", () => {
+    it("returns the no-documents answer with empty citations", async () => {
+      const svc = new KnowledgeService();
+      const result = await svc.query("what is the firewall policy?");
+      expect(typeof result.answer).toBe("string");
+      expect(result.answer.toLowerCase()).toMatch(/find|index/);
+      expect(Array.isArray(result.citations)).toBe(true);
+      expect(result.citations).toEqual([]);
+    });
+
+    it("does not call the generator when index is empty", async () => {
+      const generator = jest.fn();
+      const svc = new KnowledgeService({ generator });
+      await svc.query("anything");
+      expect(generator).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("indexFile + query end-to-end", () => {
+    it("indexes a real file then routes search hits into the generator", async () => {
+      const file = mkTempFile(
+        "firewall.txt",
+        "The firewall policy blocks port 80 entirely. Port 443 is logged.",
+      );
+
+      const generator = jest.fn(async (_q: string, chunks: LlmChunk[]) => {
+        const citations: Citation[] = chunks.map((c, i) => {
+          const entry: Citation = { number: i + 1, source: c.source };
+          if (c.heading) entry.heading = c.heading;
+          return entry;
+        });
+        return {
+          answer: `Port 80 is blocked entirely [1].`,
+          citations,
+        };
+      });
+
+      const svc = new KnowledgeService({ generator });
+      await svc.indexFile(file);
+      const result = await svc.query("what ports does the firewall block?");
+
+      expect(result.answer).toContain("80");
+      expect(result.citations.length).toBeGreaterThan(0);
+      expect(result.citations[0]).toMatchObject({ number: 1 });
+      expect(generator).toHaveBeenCalledTimes(1);
+
+      const passedChunks = generator.mock.calls[0][1];
+      expect(Array.isArray(passedChunks)).toBe(true);
+      expect(passedChunks.length).toBeGreaterThan(0);
+      expect(typeof passedChunks[0].text).toBe("string");
+      expect(typeof passedChunks[0].source).toBe("string");
+    });
+
+    it("indexFile is a no-op when ingest returns no chunks", async () => {
+      const ingest = jest.fn(async () => []);
+      const svc = new KnowledgeService({ ingest });
+      await svc.indexFile("/some/empty/file.txt");
+      expect(svc.getStatus().documentCount).toBe(0);
+    });
+
+    it("rejects empty paths", async () => {
+      const svc = new KnowledgeService();
+      await expect(svc.indexFile("")).rejects.toThrow(TypeError);
+    });
+  });
+
+  describe("getStatus", () => {
+    it("returns the documented shape with correct types", () => {
+      const svc = new KnowledgeService();
+      const status = svc.getStatus();
+      expect(typeof status.documentCount).toBe("number");
+      expect(typeof status.watcherAlive).toBe("boolean");
+      expect(typeof status.uptimeSeconds).toBe("number");
+      expect(status.documentCount).toBe(0);
+      expect(status.watcherAlive).toBe(false);
+      expect(status.uptimeSeconds).toBeGreaterThanOrEqual(0);
+    });
+
+    it("counts unique source files, not individual chunks", async () => {
+      const ingest = jest.fn(async (p: string) => [
+        { text: "chunk a", source: p },
+        { text: "chunk b", source: p },
+      ]);
+      const svc = new KnowledgeService({ ingest });
+      await svc.indexFile("/fake/path/one.txt");
+      await svc.indexFile("/fake/path/two.txt");
+      expect(svc.getStatus().documentCount).toBe(2);
+    });
+
+    it("reports uptimeSeconds based on injected clock", () => {
+      let t = 1_000_000;
+      const svc = new KnowledgeService({ now: () => t });
+      t += 7_500;
+      expect(svc.getStatus().uptimeSeconds).toBe(7);
+    });
+  });
+
+  describe("query type guards", () => {
+    it("throws on non-string question", async () => {
+      const svc = new KnowledgeService();
+      await expect(
+        svc.query(undefined as unknown as string),
+      ).rejects.toThrow(TypeError);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

US-05 — knowledge retrieval service that orchestrates ingestion + vector search + LLM generation behind a platform-agnostic `KnowledgeService` facade. Slack-free in/out so a future non-Slack adapter is a thin shim, not a rewrite.

- `src/knowledge/service.ts` — `KnowledgeService` class with `query(string)`, `indexFile(path)`, `getStatus()`. Composes existing modules (`ingestion/ingest`, `embeddings/embed`, `index/vectorIndex`, `llm/generate`) via optional DI for tests.
- `src/knowledge/index.ts` — re-exports for callers.
- `tests/knowledge.test.ts` — 9 unit tests covering empty-index path, end-to-end index→query, status shape, source-file dedupe, type guards.
- `docs/generated/TECHNICAL-SPEC.md` — schema-validated US-05 spec block (auto-generated by forge_evaluate v0.36.0 spec-writer).
- `docs/decisions/INDEX.md` — "no new decisions" row for US-05 (no qualifying ADR triggers).

forge_evaluate verdict: PASS (4/4 ACs, all `trusted` reliability). Full test suite 56/56 green. No new external deps.

## Test plan

- [x] AC-01 service interface shape (`query` returns `{answer, citations}`, no Slack types)
- [x] AC-02 indexFile + query routes a real file's content into the answer
- [x] AC-03 getStatus returns `{documentCount, watcherAlive, uptimeSeconds}` typed correctly
- [x] AC-04 \`npm test --testPathPattern=knowledge\` (9/9 pass)
- [x] Full suite still green (\`npm test\`, 56/56)
- [x] \`npm run build\` clean
- [x] \`npm run typecheck\` clean (src + test tsconfig)

---
plan-refresh: baseline
index-check: none