### PR TITLE
fix: rename KnowledgeService.index to vectorIndex

### DIFF
--- a/src/knowledge/service.ts
+++ b/src/knowledge/service.ts
@@ -46,7 +46,7 @@ function toLlmChunk(result: SearchResult): LlmChunk {
 }
 
 export class KnowledgeService {
-  private readonly index: VectorIndex;
+  private readonly vectorIndex: VectorIndex;
   private readonly ingest: FileIngestor;
   private readonly generator: AnswerGenerator;
   private readonly topK: number;
@@ -55,7 +55,7 @@ export class KnowledgeService {
   private readonly indexedSources = new Set<string>();
 
   constructor(opts: KnowledgeServiceOptions = {}) {
-    this.index = opts.index ?? new VectorIndex();
+    this.vectorIndex = opts.index ?? new VectorIndex();
     this.ingest = opts.ingest ?? ingestFile;
     this.generator = opts.generator ?? generateAnswer;
     this.topK = opts.topK ?? DEFAULT_TOP_K;
@@ -67,10 +67,10 @@ export class KnowledgeService {
     if (typeof question !== "string") {
       throw new TypeError("KnowledgeService.query: question must be a string");
     }
-    if (this.index.size() === 0) {
+    if (this.vectorIndex.size() === 0) {
       return { answer: NO_DOCUMENTS_ANSWER, citations: [] };
     }
-    const hits = await this.index.search(question, this.topK);
+    const hits = await this.vectorIndex.search(question, this.topK);
     const chunks = hits.map(toLlmChunk);
     return this.generator(question, chunks);
   }
@@ -81,7 +81,7 @@ export class KnowledgeService {
     }
     const chunks = await this.ingest(absolutePath);
     if (chunks.length === 0) return;
-    await this.index.add(chunks);
+    await this.vectorIndex.add(chunks);
     for (const c of chunks) this.indexedSources.add(c.source);
   }
 


### PR DESCRIPTION
Closes #75

Auto-fix by /housekeep Stage 4.

Renamed private field `index` to `vectorIndex` (declaration, constructor assignment, and all this.index references) in KnowledgeService to avoid shadowing src/index/ directory name.