### PR TITLE
fix: split re-exports for isolatedModules compat

### DIFF
--- a/src/knowledge/index.ts
+++ b/src/knowledge/index.ts
@@ -1,5 +1,5 @@
-export {
-  KnowledgeService,
+export { KnowledgeService } from "./service";
+export type {
   KnowledgeServiceOptions,
   QueryResult,
   ServiceStatus,


### PR DESCRIPTION
Closes #77

Auto-fix by /housekeep Stage 4.

Split re-exports so the runtime class KnowledgeService uses a value re-export and the five type-only interfaces (KnowledgeServiceOptions, QueryResult, ServiceStatus, AnswerGenerator, FileIngestor) use `export type` for isolatedModules compatibility.