### PR TITLE
feat(US-06): file watcher with auto-index/unindex

### DIFF
--- a/docs/decisions/INDEX.md
+++ b/docs/decisions/INDEX.md
@@ -16,3 +16,4 @@ Stories whose PASS recorded no material architectural decisions. One row per sto
 | US-03 | no new decisions | 484cee16abbc983923c66324f60701179a9d451b |
 | US-04 | no new decisions | 484cee16abbc983923c66324f60701179a9d451b |
 | US-05 | no new decisions | 9fecce531c1a7445a071190299fdafa15f98e5b3 |
+| US-06 | no new decisions | 6fa4f9301df97dd0372bf915c6c64fb157c64456 |

--- a/docs/generated/TECHNICAL-SPEC.md
+++ b/docs/generated/TECHNICAL-SPEC.md
@@ -1,6 +1,6 @@
 ---
 schemaVersion: "1.0.0"
-lastUpdated: "2026-04-26T05:14:39.001Z"
+lastUpdated: "2026-04-26T10:54:08.210Z"
 stories:
   - id: "US-01"
     lastUpdated: "2026-04-25T16:06:52.426Z"
@@ -17,6 +17,9 @@ stories:
   - id: "US-05"
     lastUpdated: "2026-04-26T05:14:39.001Z"
     lastGitSha: "9fecce531c1a7445a071190299fdafa15f98e5b3"
+  - id: "US-06"
+    lastUpdated: "2026-04-26T10:54:08.210Z"
+    lastGitSha: "6fa4f9301df97dd0372bf915c6c64fb157c64456"
 ---
 
 ## story: US-01
@@ -41,6 +44,8 @@ stories:
 
 
 
+
+
 ## story: US-02
 
 ### api-contracts
@@ -59,6 +64,8 @@ stories:
 ### test-surface
 
 - Existing ingestion test suite (`jest --testPathPattern=ingestion`) used as regression gate for `anthropicClient` changes
+
+
 
 
 
@@ -88,6 +95,8 @@ stories:
 
 
 
+
+
 ## story: US-04
 
 ### api-contracts
@@ -105,6 +114,8 @@ stories:
 ### test-surface
 
 (none)
+
+
 
 
 ## story: US-05
@@ -138,3 +149,30 @@ stories:
 
 - `tests/knowledge.test.ts`: covers `query` / `indexFile` / `getStatus` behaviour across empty-index, end-to-end index→query, source-file dedupe, type guards, and clock-driven uptime
 - Matched by Jest pattern `--testPathPattern=knowledge`; MUST remain passing (AC-04 ratchet)
+
+
+
+## story: US-06
+
+### api-contracts
+
+- `FolderWatcher.start`: begins watching a directory; accepts `FolderWatcherOptions` and `FolderWatcherCallbacks`, returns void
+- `FolderWatcher.close`: stops the watcher and releases resources
+- `FolderWatcher.isAlive`: returns boolean indicating whether the watcher is currently active
+- `WatcherEvent`: exported value enumerating event kinds (add, change, unlink, error)
+
+### data-models
+
+- `FolderWatcherOptions`: shape `{ debounceMs?: number, existsSync?: fn, filter?: fn, watch?: fn }` — all fields optional
+- `FolderWatcherCallbacks`: shape `{ onAdd, onChange, onUnlink, onError }` — all fields are event-handler functions
+
+### invariants
+
+- `FolderWatcher.isAlive` MUST return `false` after `close()` is called
+- `FolderWatcher.isAlive` MUST return `true` between a successful `start()` and any `close()` call
+- `FolderWatcherCallbacks.onError` MUST be invoked instead of throwing when a watch error occurs
+- Debounce interval defined by `FolderWatcherOptions.debounceMs` MUST delay repeated callbacks for the same path
+
+### test-surface
+
+- `tests/watcher.test.ts`: new file, 374 lines; covers `FolderWatcher` start/close lifecycle, `isAlive` state transitions, debounce behaviour, filter predicate, and all four callback paths

--- a/src/index/vectorIndex.ts
+++ b/src/index/vectorIndex.ts
@@ -84,6 +84,21 @@ export class VectorIndex {
     this.vectors.splice(idx, 1);
   }
 
+  async removeBySource(sourcePath: string): Promise<number> {
+    if (typeof sourcePath !== "string" || sourcePath.length === 0) {
+      throw new TypeError("VectorIndex.removeBySource: sourcePath must be a non-empty string");
+    }
+    let removed = 0;
+    for (let i = this.chunks.length - 1; i >= 0; i--) {
+      if (this.chunks[i].source === sourcePath) {
+        this.chunks.splice(i, 1);
+        this.vectors.splice(i, 1);
+        removed++;
+      }
+    }
+    return removed;
+  }
+
   async save(dir: string): Promise<void> {
     fs.mkdirSync(dir, { recursive: true });
     const payload: IndexFile = {

--- a/src/knowledge/service.ts
+++ b/src/knowledge/service.ts
@@ -1,6 +1,10 @@
 import { ingestFile, Chunk as IngestChunk } from "../ingestion/ingest";
 import { VectorIndex, SearchResult } from "../index/vectorIndex";
 import { generateAnswer, Chunk as LlmChunk, Citation } from "../llm/generate";
+import {
+  FolderWatcher,
+  FolderWatcherOptions,
+} from "../watcher/folderWatcher";
 
 const DEFAULT_TOP_K = 5;
 const NO_DOCUMENTS_ANSWER =
@@ -25,12 +29,29 @@ export interface FileIngestor {
   (absolutePath: string): Promise<IngestChunk[]>;
 }
 
+export interface WatcherFactory {
+  (
+    dir: string,
+    callbacks: {
+      onAdd: (p: string) => Promise<void>;
+      onChange: (p: string) => Promise<void>;
+      onUnlink: (p: string) => Promise<void>;
+      onError?: (e: Error) => void;
+    },
+    opts?: FolderWatcherOptions,
+  ): { start(): void; close(): void; isAlive(): boolean };
+}
+
 export interface KnowledgeServiceOptions {
   index?: VectorIndex;
   ingest?: FileIngestor;
   generator?: AnswerGenerator;
   topK?: number;
   now?: () => number;
+  /** Inject a watcher factory for tests. Defaults to `FolderWatcher`. */
+  watcherFactory?: WatcherFactory;
+  /** Forwarded to the watcher (e.g. debounceMs). Defaults `{}`. */
+  watcherOptions?: FolderWatcherOptions;
 }
 
 function toLlmChunk(result: SearchResult): LlmChunk {
@@ -45,6 +66,9 @@ function toLlmChunk(result: SearchResult): LlmChunk {
   return out;
 }
 
+const defaultWatcherFactory: WatcherFactory = (dir, callbacks, opts) =>
+  new FolderWatcher(dir, callbacks, opts);
+
 export class KnowledgeService {
   private readonly index: VectorIndex;
   private readonly ingest: FileIngestor;
@@ -53,6 +77,9 @@ export class KnowledgeService {
   private readonly now: () => number;
   private readonly startedAt: number;
   private readonly indexedSources = new Set<string>();
+  private readonly watcherFactory: WatcherFactory;
+  private readonly watcherOptions: FolderWatcherOptions;
+  private readonly watchers: Array<{ start(): void; close(): void; isAlive(): boolean }> = [];
 
   constructor(opts: KnowledgeServiceOptions = {}) {
     this.index = opts.index ?? new VectorIndex();
@@ -61,6 +88,8 @@ export class KnowledgeService {
     this.topK = opts.topK ?? DEFAULT_TOP_K;
     this.now = opts.now ?? Date.now;
     this.startedAt = this.now();
+    this.watcherFactory = opts.watcherFactory ?? defaultWatcherFactory;
+    this.watcherOptions = opts.watcherOptions ?? {};
   }
 
   async query(question: string): Promise<QueryResult> {
@@ -85,10 +114,83 @@ export class KnowledgeService {
     for (const c of chunks) this.indexedSources.add(c.source);
   }
 
+  /**
+   * Remove a file's chunks from the in-memory index. The path is resolved against
+   * whatever the ingest pipeline used as `chunk.source` (absolute path via
+   * `path.resolve`). No-op if the source isn't currently indexed.
+   */
+  async unindexFile(absolutePath: string): Promise<void> {
+    if (typeof absolutePath !== "string" || absolutePath.length === 0) {
+      throw new TypeError("KnowledgeService.unindexFile: absolutePath must be a non-empty string");
+    }
+    // chunk.source is set by the ingestion layer to path.resolve(filePath).
+    // Resolve here too so callers passing a non-resolved path still hit.
+    const path = require("node:path") as typeof import("node:path");
+    const resolved = path.resolve(absolutePath);
+    await this.index.removeBySource(resolved);
+    this.indexedSources.delete(resolved);
+  }
+
+  /**
+   * Start watching `dir` for new/changed/deleted files and keep the in-memory
+   * index in sync. Returns immediately; events are processed asynchronously.
+   * Safe to call multiple times with different directories.
+   */
+  watchFolder(dir: string): void {
+    if (typeof dir !== "string" || dir.length === 0) {
+      throw new TypeError("KnowledgeService.watchFolder: dir must be a non-empty string");
+    }
+    const watcher = this.watcherFactory(
+      dir,
+      {
+        onAdd: async (p) => {
+          try {
+            await this.indexFile(p);
+          } catch (err) {
+            // eslint-disable-next-line no-console
+            console.error(`KnowledgeService watcher onAdd failed for ${p}:`, err);
+          }
+        },
+        onChange: async (p) => {
+          try {
+            await this.unindexFile(p);
+            await this.indexFile(p);
+          } catch (err) {
+            // eslint-disable-next-line no-console
+            console.error(`KnowledgeService watcher onChange failed for ${p}:`, err);
+          }
+        },
+        onUnlink: async (p) => {
+          try {
+            await this.unindexFile(p);
+          } catch (err) {
+            // eslint-disable-next-line no-console
+            console.error(`KnowledgeService watcher onUnlink failed for ${p}:`, err);
+          }
+        },
+      },
+      this.watcherOptions,
+    );
+    watcher.start();
+    this.watchers.push(watcher);
+  }
+
+  /** Stop all watchers. Useful in tests and on shutdown. */
+  stopWatching(): void {
+    for (const w of this.watchers) {
+      try {
+        w.close();
+      } catch {
+        // best-effort
+      }
+    }
+    this.watchers.length = 0;
+  }
+
   getStatus(): ServiceStatus {
     return {
       documentCount: this.indexedSources.size,
-      watcherAlive: false,
+      watcherAlive: this.watchers.some((w) => w.isAlive()),
       uptimeSeconds: Math.max(0, Math.floor((this.now() - this.startedAt) / 1000)),
     };
   }

--- a/src/watcher/folderWatcher.ts
+++ b/src/watcher/folderWatcher.ts
@@ -1,0 +1,181 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+/**
+ * Folder watcher for the knowledge service. Wraps Node's `fs.watch` with a
+ * debounced add/change/unlink callback API so the caller doesn't see the
+ * burst of identical events that platforms emit on a single logical change.
+ *
+ * Cross-platform notes:
+ *   - On Linux + Windows + macOS, `fs.watch` reports `'rename'` on add/unlink
+ *     and `'change'` on modify. We disambiguate by stat'ing the path inside the
+ *     debounce trailing-edge handler: file exists -> add-or-change, missing -> unlink.
+ *   - We track the last "exists" state per path so a stat after debounce can decide
+ *     between "added/changed" and "deleted" without races against a quick
+ *     create-modify-delete sequence (the trailing edge wins, which is correct
+ *     for our use case — the index only cares about the final on-disk state).
+ *   - `{ recursive: true }` is supported on Linux/macOS/Windows in Node 20+.
+ */
+
+export type WatcherEvent = "add" | "change" | "unlink";
+
+export interface FolderWatcherOptions {
+  /** Debounce window in ms. Defaults to 200 ms. */
+  debounceMs?: number;
+  /** Optional file filter. Return false to ignore the path (e.g. dotfiles, swap files). */
+  filter?: (absolutePath: string) => boolean;
+  /** Injected for tests. Defaults to `fs.watch`. */
+  watch?: typeof fs.watch;
+  /** Injected for tests. Defaults to `fs.existsSync`. */
+  existsSync?: (p: string) => boolean;
+}
+
+export interface FolderWatcherCallbacks {
+  onAdd?: (absolutePath: string) => void | Promise<void>;
+  onChange?: (absolutePath: string) => void | Promise<void>;
+  onUnlink?: (absolutePath: string) => void | Promise<void>;
+  /** Called when fs.watch itself errors. Optional; logged to stderr if absent. */
+  onError?: (err: Error) => void;
+}
+
+const DEFAULT_DEBOUNCE_MS = 200;
+
+function defaultFilter(absolutePath: string): boolean {
+  const base = path.basename(absolutePath);
+  // Skip dotfiles, editor swap files, and obvious tempfiles.
+  if (base.startsWith(".")) return false;
+  if (base.endsWith("~")) return false;
+  if (base.endsWith(".swp") || base.endsWith(".swx")) return false;
+  return true;
+}
+
+export class FolderWatcher {
+  private readonly dir: string;
+  private readonly debounceMs: number;
+  private readonly filter: (absolutePath: string) => boolean;
+  private readonly watchFn: typeof fs.watch;
+  private readonly existsSyncFn: (p: string) => boolean;
+  private readonly callbacks: FolderWatcherCallbacks;
+
+  private watcher: fs.FSWatcher | null = null;
+  private readonly timers = new Map<string, NodeJS.Timeout>();
+  private readonly known = new Set<string>();
+  private closed = false;
+
+  constructor(
+    dir: string,
+    callbacks: FolderWatcherCallbacks,
+    opts: FolderWatcherOptions = {},
+  ) {
+    if (typeof dir !== "string" || dir.length === 0) {
+      throw new TypeError("FolderWatcher: dir must be a non-empty string");
+    }
+    this.dir = path.resolve(dir);
+    this.callbacks = callbacks;
+    this.debounceMs = opts.debounceMs ?? DEFAULT_DEBOUNCE_MS;
+    this.filter = opts.filter ?? defaultFilter;
+    this.watchFn = opts.watch ?? fs.watch;
+    this.existsSyncFn = opts.existsSync ?? fs.existsSync;
+  }
+
+  /**
+   * Start watching the folder. Safe to call once per instance.
+   * Throws if the underlying `fs.watch` call throws synchronously.
+   */
+  start(): void {
+    if (this.watcher) return;
+    if (this.closed) {
+      throw new Error("FolderWatcher: cannot restart a closed watcher");
+    }
+
+    // Seed `known` with the current contents so the first events after start
+    // can tell "already there" from "newly added".
+    try {
+      const entries = fs.readdirSync(this.dir, { withFileTypes: true });
+      for (const e of entries) {
+        if (e.isFile()) {
+          this.known.add(path.join(this.dir, e.name));
+        }
+      }
+    } catch {
+      // dir might not exist yet; the watch call below will throw with a clearer message
+    }
+
+    this.watcher = this.watchFn(this.dir, { recursive: true }, (_event, filename) => {
+      if (!filename) return;
+      const absolutePath = path.isAbsolute(filename as string)
+        ? (filename as string)
+        : path.join(this.dir, filename as string);
+      if (!this.filter(absolutePath)) return;
+      this.scheduleDebounced(absolutePath);
+    });
+
+    this.watcher.on("error", (err) => {
+      if (this.callbacks.onError) {
+        this.callbacks.onError(err);
+      } else {
+        // eslint-disable-next-line no-console
+        console.error("FolderWatcher error:", err);
+      }
+    });
+  }
+
+  /** Returns true if the watcher is currently active. */
+  isAlive(): boolean {
+    return this.watcher !== null && !this.closed;
+  }
+
+  /** Stop watching and release all timers. Idempotent. */
+  close(): void {
+    if (this.closed) return;
+    this.closed = true;
+    for (const t of this.timers.values()) clearTimeout(t);
+    this.timers.clear();
+    if (this.watcher) {
+      try {
+        this.watcher.close();
+      } catch {
+        // ignore — close is best-effort
+      }
+      this.watcher = null;
+    }
+  }
+
+  private scheduleDebounced(absolutePath: string): void {
+    const existing = this.timers.get(absolutePath);
+    if (existing) clearTimeout(existing);
+    const t = setTimeout(() => {
+      this.timers.delete(absolutePath);
+      void this.dispatchTrailingEdge(absolutePath);
+    }, this.debounceMs);
+    // Don't keep the event loop alive solely for a debounce timer.
+    if (typeof t.unref === "function") t.unref();
+    this.timers.set(absolutePath, t);
+  }
+
+  private async dispatchTrailingEdge(absolutePath: string): Promise<void> {
+    if (this.closed) return;
+    const exists = this.existsSyncFn(absolutePath);
+    const wasKnown = this.known.has(absolutePath);
+
+    try {
+      if (exists && !wasKnown) {
+        this.known.add(absolutePath);
+        if (this.callbacks.onAdd) await this.callbacks.onAdd(absolutePath);
+      } else if (exists && wasKnown) {
+        if (this.callbacks.onChange) await this.callbacks.onChange(absolutePath);
+      } else if (!exists && wasKnown) {
+        this.known.delete(absolutePath);
+        if (this.callbacks.onUnlink) await this.callbacks.onUnlink(absolutePath);
+      }
+      // !exists && !wasKnown -> spurious event; ignore.
+    } catch (err) {
+      if (this.callbacks.onError) {
+        this.callbacks.onError(err instanceof Error ? err : new Error(String(err)));
+      } else {
+        // eslint-disable-next-line no-console
+        console.error("FolderWatcher dispatch error:", err);
+      }
+    }
+  }
+}

--- a/tests/watcher.test.ts
+++ b/tests/watcher.test.ts
@@ -1,0 +1,374 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+import { FolderWatcher } from "../src/watcher/folderWatcher";
+
+jest.setTimeout(15_000);
+
+function mkTempDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "monday-watcher-test-"));
+}
+
+function rmDirSync(dir: string): void {
+  try {
+    fs.rmSync(dir, { recursive: true, force: true });
+  } catch {
+    // ignore
+  }
+}
+
+/**
+ * Builds a fake `fs.watch` replacement we can drive deterministically from tests.
+ * The returned `emit(filename, event)` triggers the listener installed by the
+ * watcher so we don't depend on real OS events landing in time.
+ */
+function makeFakeFsWatch(): {
+  fakeWatch: typeof fs.watch;
+  emit: (filename: string, event?: "rename" | "change") => void;
+  closed: () => boolean;
+} {
+  let listener:
+    | ((event: "rename" | "change", filename: string | Buffer | null) => void)
+    | null = null;
+  let isClosed = false;
+
+  const fakeWatch = ((
+    _dir: fs.PathLike,
+    _opts: unknown,
+    cb?: (event: "rename" | "change", filename: string | Buffer | null) => void,
+  ) => {
+    listener = cb ?? null;
+    const handlers = new Map<string, Array<(...args: unknown[]) => void>>();
+    const handle = {
+      close() {
+        isClosed = true;
+        listener = null;
+      },
+      on(event: string, fn: (...args: unknown[]) => void) {
+        const arr = handlers.get(event) ?? [];
+        arr.push(fn);
+        handlers.set(event, arr);
+        return handle;
+      },
+    };
+    return handle as unknown as fs.FSWatcher;
+  }) as unknown as typeof fs.watch;
+
+  const emit = (filename: string, event: "rename" | "change" = "rename") => {
+    if (listener) listener(event, filename);
+  };
+  const closed = () => isClosed;
+  return { fakeWatch, emit, closed };
+}
+
+describe("FolderWatcher", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkTempDir();
+  });
+
+  afterEach(() => {
+    rmDirSync(dir);
+  });
+
+  it("calls onAdd when a new file appears (debounced trailing edge)", async () => {
+    const onAdd = jest.fn();
+    const onChange = jest.fn();
+    const onUnlink = jest.fn();
+
+    const { fakeWatch, emit } = makeFakeFsWatch();
+    const existsSync = jest.fn().mockReturnValue(true); // file is "on disk"
+
+    const w = new FolderWatcher(
+      dir,
+      { onAdd, onChange, onUnlink },
+      { debounceMs: 20, watch: fakeWatch, existsSync },
+    );
+    w.start();
+
+    emit("new-doc.txt");
+    await new Promise((r) => setTimeout(r, 60));
+
+    expect(onAdd).toHaveBeenCalledTimes(1);
+    expect(onAdd.mock.calls[0][0]).toContain("new-doc.txt");
+    expect(onChange).not.toHaveBeenCalled();
+    expect(onUnlink).not.toHaveBeenCalled();
+    w.close();
+  });
+
+  it("debounces rapid burst events into a single dispatch", async () => {
+    const onAdd = jest.fn();
+    const { fakeWatch, emit } = makeFakeFsWatch();
+    const existsSync = () => true;
+
+    const w = new FolderWatcher(
+      dir,
+      { onAdd },
+      { debounceMs: 30, watch: fakeWatch, existsSync },
+    );
+    w.start();
+
+    emit("burst.txt");
+    emit("burst.txt");
+    emit("burst.txt", "change");
+    emit("burst.txt");
+    await new Promise((r) => setTimeout(r, 80));
+
+    expect(onAdd).toHaveBeenCalledTimes(1);
+    w.close();
+  });
+
+  it("calls onChange for a file that already existed at start time", async () => {
+    // Seed the directory before starting the watcher so the file is "known".
+    const seeded = path.join(dir, "seeded.txt");
+    fs.writeFileSync(seeded, "old content", "utf-8");
+
+    const onAdd = jest.fn();
+    const onChange = jest.fn();
+    const { fakeWatch, emit } = makeFakeFsWatch();
+    const existsSync = () => true;
+
+    const w = new FolderWatcher(
+      dir,
+      { onAdd, onChange },
+      { debounceMs: 20, watch: fakeWatch, existsSync },
+    );
+    w.start();
+
+    emit("seeded.txt", "change");
+    await new Promise((r) => setTimeout(r, 60));
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange.mock.calls[0][0]).toContain("seeded.txt");
+    expect(onAdd).not.toHaveBeenCalled();
+    w.close();
+  });
+
+  it("calls onUnlink when a previously-known file disappears", async () => {
+    // Seed so the watcher knows the file existed.
+    const seeded = path.join(dir, "doomed.txt");
+    fs.writeFileSync(seeded, "bye", "utf-8");
+
+    const onAdd = jest.fn();
+    const onUnlink = jest.fn();
+    const { fakeWatch, emit } = makeFakeFsWatch();
+    // Simulate the file being gone by the time the trailing edge fires.
+    const existsSync = () => false;
+
+    const w = new FolderWatcher(
+      dir,
+      { onAdd, onUnlink },
+      { debounceMs: 20, watch: fakeWatch, existsSync },
+    );
+    w.start();
+
+    emit("doomed.txt");
+    await new Promise((r) => setTimeout(r, 60));
+
+    expect(onUnlink).toHaveBeenCalledTimes(1);
+    expect(onUnlink.mock.calls[0][0]).toContain("doomed.txt");
+    expect(onAdd).not.toHaveBeenCalled();
+    w.close();
+  });
+
+  it("ignores spurious events for paths that never existed and don't exist", async () => {
+    const onAdd = jest.fn();
+    const onUnlink = jest.fn();
+    const { fakeWatch, emit } = makeFakeFsWatch();
+    const existsSync = () => false;
+
+    const w = new FolderWatcher(
+      dir,
+      { onAdd, onUnlink },
+      { debounceMs: 20, watch: fakeWatch, existsSync },
+    );
+    w.start();
+
+    emit("ghost.txt");
+    await new Promise((r) => setTimeout(r, 60));
+
+    expect(onAdd).not.toHaveBeenCalled();
+    expect(onUnlink).not.toHaveBeenCalled();
+    w.close();
+  });
+
+  it("filters dotfiles and editor swap files by default", async () => {
+    const onAdd = jest.fn();
+    const { fakeWatch, emit } = makeFakeFsWatch();
+    const existsSync = () => true;
+
+    const w = new FolderWatcher(
+      dir,
+      { onAdd },
+      { debounceMs: 20, watch: fakeWatch, existsSync },
+    );
+    w.start();
+
+    emit(".hidden");
+    emit("doc.swp");
+    emit("backup~");
+    await new Promise((r) => setTimeout(r, 60));
+
+    expect(onAdd).not.toHaveBeenCalled();
+    w.close();
+  });
+
+  it("isAlive() reflects start/close state", () => {
+    const { fakeWatch } = makeFakeFsWatch();
+    const w = new FolderWatcher(dir, {}, { watch: fakeWatch });
+    expect(w.isAlive()).toBe(false);
+    w.start();
+    expect(w.isAlive()).toBe(true);
+    w.close();
+    expect(w.isAlive()).toBe(false);
+  });
+
+  it("close() is idempotent and refuses restart", () => {
+    const { fakeWatch } = makeFakeFsWatch();
+    const w = new FolderWatcher(dir, {}, { watch: fakeWatch });
+    w.start();
+    w.close();
+    w.close(); // should not throw
+    expect(() => w.start()).toThrow(/closed/i);
+  });
+
+  it("rejects empty dir argument", () => {
+    expect(() => new FolderWatcher("", {})).toThrow(TypeError);
+  });
+
+  it("forwards onError when the underlying watcher emits an error event", () => {
+    let errorHandler: ((e: Error) => void) | null = null;
+    const fakeWatch = ((
+      _d: fs.PathLike,
+      _opts: unknown,
+      _cb?: (...a: unknown[]) => void,
+    ) => {
+      const handle = {
+        close() {},
+        on(event: string, fn: (e: Error) => void) {
+          if (event === "error") errorHandler = fn;
+          return handle;
+        },
+      };
+      return handle as unknown as fs.FSWatcher;
+    }) as unknown as typeof fs.watch;
+
+    const onError = jest.fn();
+    const w = new FolderWatcher(dir, { onError }, { watch: fakeWatch });
+    w.start();
+    expect(errorHandler).not.toBeNull();
+    errorHandler!(new Error("boom"));
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError.mock.calls[0][0].message).toBe("boom");
+    w.close();
+  });
+});
+
+describe("FolderWatcher integration with KnowledgeService", () => {
+  it("KnowledgeService.watchFolder reports watcherAlive and indexes added files", async () => {
+    const { KnowledgeService } = await import("../src/knowledge/service");
+
+    const ingestCalls: string[] = [];
+    const ingest = jest.fn(async (p: string) => {
+      ingestCalls.push(p);
+      return [{ text: `chunk for ${p}`, source: p }];
+    });
+
+    let triggerAdd: ((p: string) => Promise<void>) | null = null;
+    const fakeWatcher = {
+      start: jest.fn(),
+      close: jest.fn(),
+      isAlive: jest.fn().mockReturnValue(true),
+    };
+    const watcherFactory = jest.fn((_dir, callbacks) => {
+      triggerAdd = callbacks.onAdd;
+      return fakeWatcher;
+    });
+
+    const svc = new KnowledgeService({ ingest, watcherFactory });
+    expect(svc.getStatus().watcherAlive).toBe(false);
+
+    svc.watchFolder("/tmp/whatever");
+
+    expect(fakeWatcher.start).toHaveBeenCalledTimes(1);
+    expect(svc.getStatus().watcherAlive).toBe(true);
+
+    await triggerAdd!("/tmp/whatever/new.txt");
+    expect(ingest).toHaveBeenCalledWith("/tmp/whatever/new.txt");
+    expect(svc.getStatus().documentCount).toBe(1);
+
+    svc.stopWatching();
+    fakeWatcher.isAlive.mockReturnValue(false);
+    expect(svc.getStatus().watcherAlive).toBe(false);
+  });
+
+  it("onUnlink removes the file's chunks from the index", async () => {
+    const { KnowledgeService } = await import("../src/knowledge/service");
+    const { VectorIndex } = await import("../src/index/vectorIndex");
+
+    const filePath = path.resolve("/tmp/some/policy.txt");
+    const ingest = jest.fn(async (p: string) => [{ text: "policy body", source: p }]);
+
+    const index = new VectorIndex();
+    let triggerUnlink: ((p: string) => Promise<void>) | null = null;
+    const fakeWatcher = {
+      start: jest.fn(),
+      close: jest.fn(),
+      isAlive: jest.fn().mockReturnValue(true),
+    };
+    const watcherFactory = jest.fn((_dir, callbacks) => {
+      triggerUnlink = callbacks.onUnlink;
+      return fakeWatcher;
+    });
+
+    const svc = new KnowledgeService({ index, ingest, watcherFactory });
+    await svc.indexFile(filePath);
+    expect(index.size()).toBe(1);
+    expect(svc.getStatus().documentCount).toBe(1);
+
+    svc.watchFolder("/tmp/some");
+    await triggerUnlink!(filePath);
+
+    expect(index.size()).toBe(0);
+    expect(svc.getStatus().documentCount).toBe(0);
+  });
+
+  it("onChange re-indexes a file (drops old chunks, adds new ones)", async () => {
+    const { KnowledgeService } = await import("../src/knowledge/service");
+    const { VectorIndex } = await import("../src/index/vectorIndex");
+
+    const filePath = path.resolve("/tmp/some/changing.txt");
+    let version = 1;
+    const ingest = jest.fn(async (p: string) => [
+      { text: `v${version} body`, source: p },
+    ]);
+
+    const index = new VectorIndex();
+    let triggerChange: ((p: string) => Promise<void>) | null = null;
+    const fakeWatcher = {
+      start: jest.fn(),
+      close: jest.fn(),
+      isAlive: jest.fn().mockReturnValue(true),
+    };
+    const watcherFactory = jest.fn((_dir, callbacks) => {
+      triggerChange = callbacks.onChange;
+      return fakeWatcher;
+    });
+
+    const svc = new KnowledgeService({ index, ingest, watcherFactory });
+    await svc.indexFile(filePath);
+    expect(index.size()).toBe(1);
+
+    svc.watchFolder("/tmp/some");
+    version = 2;
+    await triggerChange!(filePath);
+
+    // Still only one chunk for this source, but it's the new content.
+    expect(index.size()).toBe(1);
+    expect(svc.getStatus().documentCount).toBe(1);
+    // Two ingest calls total: initial + onChange re-index.
+    expect(ingest).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `FolderWatcher` (Node `fs.watch` wrapper with debouncing) under `src/watcher/folderWatcher.ts` + 13 unit tests (`tests/watcher.test.ts`).
- Wires the watcher into `KnowledgeService.watchFolder()` / `unindexFile()` / `stopWatching()`; extends `getStatus()` to report `watcherAlive`.
- Adds `VectorIndex.removeBySource()` so unlinked files are dropped from the live index.
- Files added/changed in a watched folder become retrievable (or are removed from results) within ~5 seconds without restarting the service.
- Plus: regenerated `docs/generated/TECHNICAL-SPEC.md` and `docs/decisions/INDEX.md` from the v0.37.0 forge-harness spec-writer (PR #451 grounding fired clean — `warnings: []`, real symbols only).

## Test plan

- [x] AC-01 — adding a new file to a watched folder makes it retrievable within 5s (real Anthropic API call): PASS.
- [x] AC-02 — deleting a file removes it from search results within 5s (real Anthropic API call): PASS.
- [x] AC-03 — `getStatus().watcherAlive === true` after `watchFolder()`: PASS.
- [x] AC-04 — `npm test -- --testPathPattern=watcher` (13/13): PASS.
- [x] Full suite regression: 10 suites / 69 tests pass (was 9 / 56).
- [x] `npm run build` + `npm run typecheck` clean.
- [x] `forge_evaluate(US-06)` verdict: PASS (4/4).

---
plan-refresh: baseline