### PR TITLE
fix: strip all <@USER> mentions in app_mention handler

### DIFF
--- a/src/slack/adapter.ts
+++ b/src/slack/adapter.ts
@@ -96,8 +96,8 @@ export class SlackAdapter {
       const logger = args?.logger ?? console;
       const text: string = typeof event.text === "string" ? event.text : "";
       const channel: string = typeof event.channel === "string" ? event.channel : "";
-      // Strip the leading <@U123456> mention so the question is clean.
-      const question = text.replace(/^\s*<@[^>]+>\s*/, "").trim();
+      // Strip ALL <@U123456> mentions (leading and interior) so the question is clean.
+      const question = text.replace(/<@[^>]+>/g, "").replace(/\s+/g, " ").trim();
       const threadTs: string | undefined = event.thread_ts ?? event.ts;
 
       if (!question) {


### PR DESCRIPTION
Closes #101

Auto-fix by /housekeep Stage 4.

Replaced the leading-only anchored regex `/^\s*<@[^>]+>\s*/` with a global pattern `/<@[^>]+>/g` so all `<@USER>` tokens are removed regardless of position, then collapsed runs of whitespace before `.trim()`. Fixes US-08 E1: messages like `hello <@OTHER> can you check?` now have the interior mention stripped.