### PR TITLE
chore: backfill US-08 ADR + INDEX (forge-harness v0.39.6 W2)

### DIFF
--- a/docs/decisions/ADR-0001-adopt-slack-bolt-with-socket-mode-for-the-slack-adapter-US-08.md
+++ b/docs/decisions/ADR-0001-adopt-slack-bolt-with-socket-mode-for-the-slack-adapter-US-08.md
@@ -1,0 +1,57 @@
+---
+adr: 1
+status: "Accepted"
+story: "US-08"
+date: "2026-04-27"
+title: "Adopt @slack/bolt with Socket Mode for the Slack adapter"
+---
+
+# ADR-0001: Adopt @slack/bolt with Socket Mode for the Slack adapter
+
+## Context
+
+US-08 introduces the Slack-facing surface of monday-bot — handling @mention
+events and the /ask slash command, and posting Block Kit replies that include
+the answer text and per-citation source lines. We need a Slack SDK that
+(a) supports Socket Mode so the bot needs no public HTTP ingress (laptop / dev
+containers can connect outbound only), (b) exposes typed event and command
+handlers with sane middleware semantics, and (c) is officially supported by
+Slack so we inherit ongoing breaking-API mitigations.
+
+## Decision
+
+Add `@slack/bolt` (v4.x) as a runtime dependency and wire the adapter to use
+Socket Mode (`socketMode: true`, `appToken: <xapp-...>`). The adapter
+registers `app_mention` and `/ask` handlers in its constructor, validates
+that `botToken`, `appToken`, and `knowledgeService` are provided (throwing a
+`SlackConfigError` otherwise), and queries the injected knowledge service —
+not a hard import — so the platform-agnostic boundary in
+`src/knowledge/service.ts` is preserved (verified by AC-02: requiring the
+service module does not pull `@slack/bolt` or `@slack/web-api` into
+`require.cache`).
+
+## Consequences
+
++ Bundle gains `@slack/bolt` + transitive `@slack/web-api`, `@slack/socket-mode`,
+  `axios`, etc. (~110 packages). Acceptable for a server-side bot.
++ Socket Mode means we never expose a public URL — fits laptop-only and
+  forge-harness sandbox deployment.
++ Bolt's `App` constructor handles auth, retries, and event routing; we keep
+  the adapter thin.
+- Bolt v4 is ESM-leaning but ships CommonJS-compatible builds; we keep the
+  project on `"type": "commonjs"`. If we later move to ESM we'll need a
+  review. Not a US-08 blocker.
+- Bolt's surface is large; we deliberately type handler args as `any` inside
+  the adapter to avoid leaking the full type surface into our public API.
+- 4 high / 4 critical npm audit advisories surfaced from transitive deps
+  (sub-deps of axios / form-data); follow up with `npm audit` review in a
+  separate slice (out of scope for US-08 functional ACs).
+
+## Alternatives considered
+
+- `@slack/web-api` alone + a hand-rolled Socket Mode client: rejected — we'd
+  reimplement event routing, ack semantics, and reconnect logic that Bolt
+  already gets right.
+- HTTP Receiver (default Bolt): rejected — requires public ingress (ngrok,
+  a real domain, or a tunnel). Socket Mode keeps the deploy story simple.
+- Slack's older `node-slack-client`: deprecated; rejected.

--- a/docs/decisions/INDEX.md
+++ b/docs/decisions/INDEX.md
@@ -4,6 +4,7 @@
 
 | ADR | Story | Title | Date | Status |
 | --- | --- | --- | --- | --- |
+| ADR-0001 | US-08 | Adopt @slack/bolt with Socket Mode for the Slack adapter | 2026-04-27 | Accepted |
 
 ## No-decisions registry
 


### PR DESCRIPTION
## Summary

Recovery PR for the v0.39.0 forge-harness adr-extractor regression. Restores `docs/decisions/INDEX.md`'s missing US-08 row and writes the previously-dropped `ADR-0001` file from the staging stub.

- Generated by `~/coding_projects/forge-harness/scripts/forge-adr-backfill.mjs --project ~/coding_projects/monday-bot` against the freshly-rebuilt v0.39.6 dist (PR ziyilam3999/forge-harness#500).
- Root cause confirmed by forge-plan: v0.39.0 introduced a line-by-line scalar-only `parseStubFrontMatter` that threw `unexpected indented line` on YAML `|` (literal) and `>` (folded) block scalars. US-08's stub used `context: |`, `decision: |`, `consequences: |`, `alternatives: |` — the throw was silently caught at `evaluate.ts:442`, no INDEX.md write.
- v0.39.6 ships W1 (parser fix for `|`/`>` block scalars) and W2 (this backfill CLI). Idempotent — re-running on a current project is a byte-stable no-op.

Diff:
- `docs/decisions/INDEX.md` — `+1 line` (US-08 row in the ADR table).
- `docs/decisions/ADR-0001-adopt-slack-bolt-with-socket-mode-for-the-slack-adapter-US-08.md` — `+57 lines` (new file; preserves all four block-scalar sections from the staging stub).

W3-W6 follow-ups filed by forge-plan as separate issues for v0.40.0:
- ziyilam3999/forge-harness#505 — emit `adr-extract` audit event per evaluate run
- ziyilam3999/forge-harness#506 — split RunRecord `generatedDocs` for diagnosability
- ziyilam3999/forge-harness#507 — post-evaluate invariant
- ziyilam3999/forge-harness#508 — embed `harnessVersion + harnessGitSha` in run records

## Test plan

- [x] Backfill CLI ran successfully — 1 ADR created, 0 no-decisions rows added, 7 stories `no change` (idempotency confirmed).
- [x] `docs/decisions/INDEX.md` ADR-table row present and well-formed.
- [x] `docs/decisions/ADR-0001-*.md` content readable, all four sections preserved verbatim from the block-scalar source.
- [x] `.forge/staging/adr/US-08/` cleared by the backfill (post-condition).
- [ ] Stateless reviewer re-checks against current dist behaviour.

---
plan-refresh: baseline