### PR TITLE
chore: release 0.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to monday-bot will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.1](https://github.com/ziyilam3999/monday-bot/compare/v0.8.0...v0.8.1) (2026-04-27)
+
+### Bug Fixes
+
+* strip all `<@USER>` mentions in app_mention handler (#108)
+
+### Miscellaneous
+
+* backfill US-08 ADR + INDEX after forge-harness v0.39.6 W2 recovery (#109)
+
 ## [0.8.0](https://github.com/ziyilam3999/monday-bot/compare/v0.7.0...v0.8.0) (2026-04-27)
 
 ### Features

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "monday-bot",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Team Slack knowledge assistant — answers from internal documents with cited, fact-based summaries.",
   "private": true,
   "type": "commonjs",


### PR DESCRIPTION
## Summary

Release v0.8.1 covering #108 and #109.

- **Bug fix:** strip all `<@USER>` mentions in `app_mention` handler (#108).
- **Chore:** backfill US-08 ADR + INDEX after forge-harness v0.39.6 W2 recovery (#109).

Both prior-merged. This PR carries only the version bump + CHANGELOG entry.

## Test plan

- [x] `package.json` version bumped 0.8.0 → 0.8.1.
- [x] `CHANGELOG.md` prepends a 0.8.1 section linking compare URL v0.8.0...v0.8.1.

---
plan-refresh: baseline