### PR TITLE
feat(US-09): admin slash commands (status/sync/reindex/help/feedback)

### DIFF
--- a/docs/decisions/INDEX.md
+++ b/docs/decisions/INDEX.md
@@ -19,3 +19,4 @@ Stories whose PASS recorded no material architectural decisions. One row per sto
 | US-05 | no new decisions | 9fecce531c1a7445a071190299fdafa15f98e5b3 |
 | US-06 | no new decisions | 6fa4f9301df97dd0372bf915c6c64fb157c64456 |
 | US-07 | no new decisions | 8ed171074dc7bb5703596a9e5124fb46537305bf |
+| US-09 | no new decisions | 6059593519286d6b06f6d46bff1b05485c7445ea |

--- a/docs/generated/TECHNICAL-SPEC.md
+++ b/docs/generated/TECHNICAL-SPEC.md
@@ -1,6 +1,6 @@
 ---
 schemaVersion: "1.0.0"
-lastUpdated: "2026-04-27T03:07:56.654Z"
+lastUpdated: "2026-04-27T14:17:04.337Z"
 stories:
   - id: "US-01"
     lastUpdated: "2026-04-25T16:06:52.426Z"
@@ -26,6 +26,9 @@ stories:
   - id: "US-08"
     lastUpdated: "2026-04-27T03:07:56.654Z"
     lastGitSha: "4a44c8937071b02dd6af8891e0dd9bc9251ad82c"
+  - id: "US-09"
+    lastUpdated: "2026-04-27T14:17:04.337Z"
+    lastGitSha: "6059593519286d6b06f6d46bff1b05485c7445ea"
 ---
 
 ## story: US-01
@@ -54,6 +57,7 @@ stories:
 
 
 
+
 ## story: US-02
 
 ### api-contracts
@@ -72,6 +76,7 @@ stories:
 ### test-surface
 
 - Existing ingestion test suite (`jest --testPathPattern=ingestion`) used as regression gate for `anthropicClient` changes
+
 
 
 
@@ -109,6 +114,7 @@ stories:
 
 
 
+
 ## story: US-04
 
 ### api-contracts
@@ -126,6 +132,7 @@ stories:
 ### test-surface
 
 (none)
+
 
 
 
@@ -168,6 +175,7 @@ stories:
 
 
 
+
 ## story: US-06
 
 ### api-contracts
@@ -192,6 +200,7 @@ stories:
 ### test-surface
 
 - `tests/watcher.test.ts`: new file, 374 lines; covers `FolderWatcher` start/close lifecycle, `isAlive` state transitions, debounce behaviour, filter predicate, and all four callback paths
+
 
 
 
@@ -221,6 +230,7 @@ stories:
 ### test-surface
 
 - `tests/confluence.test.ts`: added 265-line test file covering `ConfluenceSync.syncSpace` happy-path, partial-failure, and `buildConfluenceFetcher` construction
+
 
 
 ## story: US-08
@@ -264,3 +274,30 @@ stories:
 - `tests/slack-adapter.test.ts`: 210-line suite; covers config-error path, `start`/`stop` lifecycle, `app_mention` happy-path, and `AnswerProvider` integration (21 tests total across both suites)
 - `tests/slack-formatter.test.ts`: 95-line suite; covers block count, answer block content, citation blocks, divider presence, and plain-text fallback
 - `jest.config.js`: updated `testPathPattern` default or added `slack|adapter|formatter` pattern entry
+
+
+## story: US-09
+
+### api-contracts
+
+- `commandHandlers`: exported `Record<string, CommandHandler>` covering keys `status`, `syncconfluence`, `reindex`, `help`, `feedback`
+- `statusCommand`: calls `AdminService.getStatus`, returns formatted string with `documentCount`, `uptimeSeconds`, `watcherAlive`
+- `syncConfluenceCommand`: calls `AdminService.syncConfluence`, returns confirmation string
+- `reindexCommand`: calls `AdminService.reindex`, returns confirmation string
+- `helpCommand`: returns static help string (length 382)
+- `feedbackCommand`: calls `AdminService.recordFeedback`, returns acknowledgement string
+
+### data-models
+
+(none)
+
+### invariants
+
+- `commandHandlers` MUST contain exactly the keys: `status`, `syncconfluence`, `reindex`, `help`, `feedback`
+- Every value in `commandHandlers` MUST satisfy the `CommandHandler` type
+- `statusCommand` output MUST include all three fields from `AdminServiceStatus`: `documentCount`, `uptimeSeconds`, `watcherAlive`
+- `feedbackCommand` MUST return a non-empty acknowledgement string on success
+
+### test-surface
+
+- `tests/commands.test.ts`: added; covers registry shape — asserts all five command keys present in `commandHandlers`

--- a/src/slack/adapter.ts
+++ b/src/slack/adapter.ts
@@ -1,5 +1,13 @@
 import { App, LogLevel } from "@slack/bolt";
 import { formatAnswer } from "./formatter";
+import {
+  AdminService,
+  statusCommand,
+  syncConfluenceCommand,
+  reindexCommand,
+  helpCommand,
+  feedbackCommand,
+} from "./commands";
 
 /**
  * Minimal contract the adapter requires from the knowledge layer. We don't import
@@ -20,6 +28,12 @@ export interface SlackAdapterOptions {
   appToken: string;
   /** Knowledge service used to answer questions. Required. */
   knowledgeService: AnswerProvider | null | undefined;
+  /**
+   * Optional admin surface used by /status, /sync-confluence, /reindex,
+   * /feedback. May be the same object as `knowledgeService` if it implements
+   * both contracts. Missing methods degrade to "not configured" responses.
+   */
+  adminService?: AdminService;
   /**
    * Optional override for the Bolt `App` constructor. Used by tests to inject a
    * fake without monkey-patching the SDK at runtime.
@@ -51,6 +65,7 @@ export class SlackAdapter {
   private readonly botToken: string;
   private readonly appToken: string;
   private readonly knowledgeService: AnswerProvider;
+  private readonly adminService: AdminService;
   private readonly app: App;
 
   constructor(opts: SlackAdapterOptions) {
@@ -76,6 +91,10 @@ export class SlackAdapter {
     this.botToken = opts.botToken.trim();
     this.appToken = opts.appToken.trim();
     this.knowledgeService = opts.knowledgeService;
+    // Default: if the knowledgeService object also exposes admin methods (e.g.
+    // KnowledgeService's getStatus()), use it for /status. Otherwise the admin
+    // surface is empty and individual handlers degrade to "not configured".
+    this.adminService = opts.adminService ?? (opts.knowledgeService as unknown as AdminService) ?? {};
 
     const factory: AppFactory = opts.appFactory ?? ((appOpts) => new App(appOpts));
     this.app = factory({
@@ -165,6 +184,52 @@ export class SlackAdapter {
         });
       } catch (err) {
         logger.error?.("SlackAdapter /ask handler failed:", err);
+        await respond?.({
+          response_type: "ephemeral",
+          text: DEFAULT_FALLBACK_TEXT,
+        });
+      }
+    });
+
+    this.registerAdminCommand("/status", (_args, _text) => statusCommand(this.adminService));
+    this.registerAdminCommand("/sync-confluence", (_args, text) =>
+      syncConfluenceCommand(this.adminService, text),
+    );
+    this.registerAdminCommand("/reindex", (_args, _text) => reindexCommand(this.adminService));
+    this.registerAdminCommand("/help", (_args, _text) => helpCommand(this.adminService));
+    this.registerAdminCommand("/feedback", (_args, text) =>
+      feedbackCommand(this.adminService, text),
+    );
+  }
+
+  /**
+   * Generic glue for admin commands: ack immediately, run the handler, post the
+   * result ephemerally. Errors are logged and surfaced as a fallback message
+   * rather than crashing the Bolt event loop.
+   */
+  private registerAdminCommand(
+    name: string,
+    runner: (args: unknown, text: string) => string | Promise<string>,
+  ): void {
+    this.app.command(name, async (args: any) => {
+      const ack = args?.ack;
+      const respond = args?.respond;
+      const command = args?.command ?? {};
+      const logger = args?.logger ?? console;
+      try {
+        await ack?.();
+      } catch (err) {
+        logger.error?.(`SlackAdapter ${name} ack failed:`, err);
+      }
+      const text = typeof command.text === "string" ? command.text.trim() : "";
+      try {
+        const reply = await runner(args, text);
+        await respond?.({
+          response_type: "ephemeral",
+          text: reply,
+        });
+      } catch (err) {
+        logger.error?.(`SlackAdapter ${name} handler failed:`, err);
         await respond?.({
           response_type: "ephemeral",
           text: DEFAULT_FALLBACK_TEXT,

--- a/src/slack/commands.ts
+++ b/src/slack/commands.ts
@@ -1,0 +1,158 @@
+/**
+ * Admin slash command handlers for the Slack adapter (US-09).
+ *
+ * Each handler is a plain function so it can be unit-tested without the Bolt
+ * runtime. The adapter wires them onto specific slash commands (`/status`,
+ * `/sync-confluence`, `/reindex`, `/help`, `/feedback`).
+ *
+ * Handlers are intentionally tolerant of partial service shapes — the AC tests
+ * pass `{}` or a minimal mock object — and never throw on missing methods.
+ */
+
+export interface AdminServiceStatus {
+  documentCount: number;
+  watcherAlive: boolean;
+  uptimeSeconds: number;
+}
+
+/**
+ * Lowest-common-denominator service contract used by the admin handlers. Every
+ * field is optional so handlers can be exercised with `{}` (per AC-03/AC-04)
+ * and so test mocks can provide only what they need.
+ */
+export interface AdminService {
+  getStatus?(): AdminServiceStatus;
+  /** Trigger a Confluence sync. The result string (if any) is surfaced verbatim. */
+  syncConfluence?(spaceKey?: string): Promise<string | void> | string | void;
+  /** Re-index all watched files / Confluence pages. */
+  reindex?(): Promise<string | void> | string | void;
+  /** Optional sink for collected feedback. Defaults to console.log. */
+  recordFeedback?(message: string): Promise<void> | void;
+}
+
+export type CommandHandler = (
+  service: AdminService,
+  arg?: string,
+) => string | Promise<string>;
+
+const AVAILABLE_COMMANDS: ReadonlyArray<{ name: string; description: string }> = [
+  { name: "/ask <question>", description: "Ask the bot a question against the indexed docs." },
+  { name: "/status", description: "Show document count, watcher status, and uptime." },
+  { name: "/sync-confluence [space]", description: "Trigger a fresh sync of the Confluence space." },
+  { name: "/reindex", description: "Re-index all watched files and Confluence pages." },
+  { name: "/help", description: "Show this help message." },
+  { name: "/feedback <message>", description: "Send feedback to the bot maintainers." },
+];
+
+function formatUptime(totalSeconds: number): string {
+  const seconds = Math.max(0, Math.floor(totalSeconds));
+  const h = Math.floor(seconds / 3600);
+  const m = Math.floor((seconds % 3600) / 60);
+  const s = seconds % 60;
+  const parts: string[] = [];
+  if (h > 0) parts.push(`${h}h`);
+  if (m > 0 || h > 0) parts.push(`${m}m`);
+  parts.push(`${s}s`);
+  return parts.join(" ");
+}
+
+/**
+ * `/status` — synchronous, returns a one-line summary string. Reads from
+ * `service.getStatus()`. If the service is missing or doesn't expose
+ * `getStatus`, returns a degraded but still well-formed string so the AC's
+ * regexes still pass for callers that pass a richer mock.
+ */
+export const statusCommand: CommandHandler = (service) => {
+  const status =
+    service && typeof service.getStatus === "function"
+      ? service.getStatus()
+      : { documentCount: 0, watcherAlive: false, uptimeSeconds: 0 };
+  const docCount = Number.isFinite(status.documentCount) ? status.documentCount : 0;
+  const watcherToken = status.watcherAlive ? "alive" : "stopped";
+  const uptime = formatUptime(status.uptimeSeconds ?? 0);
+  return `Status: ${docCount} documents indexed | watcher: ${watcherToken} | uptime: ${uptime}`;
+};
+
+/**
+ * `/sync-confluence [spaceKey]` — kicks off a Confluence sync. The handler is
+ * async because `service.syncConfluence` typically performs network I/O.
+ */
+export const syncConfluenceCommand: CommandHandler = async (service, arg) => {
+  if (!service || typeof service.syncConfluence !== "function") {
+    return "Confluence sync is not configured on this bot.";
+  }
+  try {
+    const result = await service.syncConfluence(arg && arg.length > 0 ? arg : undefined);
+    if (typeof result === "string" && result.length > 0) return result;
+    return "Confluence sync triggered.";
+  } catch (err) {
+    return `Confluence sync failed: ${(err as Error).message ?? "unknown error"}`;
+  }
+};
+
+/**
+ * `/reindex` — rebuild the in-memory index from the watched folder + Confluence
+ * pages. Async because rebuilds typically involve disk + network.
+ */
+export const reindexCommand: CommandHandler = async (service) => {
+  if (!service || typeof service.reindex !== "function") {
+    return "Reindex is not configured on this bot.";
+  }
+  try {
+    const result = await service.reindex();
+    if (typeof result === "string" && result.length > 0) return result;
+    return "Reindex triggered.";
+  } catch (err) {
+    return `Reindex failed: ${(err as Error).message ?? "unknown error"}`;
+  }
+};
+
+/**
+ * `/help` — static help text listing every command. Synchronous so callers can
+ * post the response without awaiting.
+ */
+export const helpCommand: CommandHandler = () => {
+  const lines = AVAILABLE_COMMANDS.map((c) => `• ${c.name} — ${c.description}`);
+  return ["Available commands:", ...lines].join("\n");
+};
+
+/**
+ * `/feedback <message>` — capture user feedback. By default we log to stdout so
+ * operators can grep the bot logs; production wiring can supply
+ * `service.recordFeedback` to forward to a ticket system.
+ */
+export const feedbackCommand: CommandHandler = (service, message) => {
+  const text = typeof message === "string" ? message.trim() : "";
+  if (text.length === 0) {
+    return "Usage: /feedback <message> — please include a description of what was wrong.";
+  }
+  if (service && typeof service.recordFeedback === "function") {
+    try {
+      const maybe = service.recordFeedback(text);
+      // We don't await here because the handler's own contract is sync-or-async
+      // string return; callers that need durable acknowledgement should await
+      // recordFeedback themselves before calling this handler.
+      void maybe;
+    } catch {
+      // best-effort — never let a logging failure swallow the user's feedback.
+    }
+  } else {
+    // eslint-disable-next-line no-console
+    console.log(`[feedback] ${text}`);
+  }
+  return "Thanks — your feedback has been recorded.";
+};
+
+/**
+ * Registry exposed for the AC: keys must contain the substrings `status`,
+ * `sync`, `reindex`, `help`, `feedback` (case-insensitive — AC lowercases).
+ * Adapter wiring imports these by named export; the registry is the
+ * machine-readable surface.
+ */
+export const commandHandlers: Record<string, CommandHandler> = {
+  status: statusCommand,
+  syncConfluence: syncConfluenceCommand,
+  reindex: reindexCommand,
+  help: helpCommand,
+  feedback: feedbackCommand,
+};

--- a/src/slack/index.ts
+++ b/src/slack/index.ts
@@ -11,3 +11,12 @@ export type {
   SlackSectionBlock,
   SlackTextObject,
 } from "./formatter";
+export {
+  commandHandlers,
+  statusCommand,
+  syncConfluenceCommand,
+  reindexCommand,
+  helpCommand,
+  feedbackCommand,
+} from "./commands";
+export type { AdminService, AdminServiceStatus, CommandHandler } from "./commands";

--- a/tests/commands.test.ts
+++ b/tests/commands.test.ts
@@ -1,0 +1,181 @@
+import {
+  commandHandlers,
+  statusCommand,
+  syncConfluenceCommand,
+  reindexCommand,
+  helpCommand,
+  feedbackCommand,
+  AdminService,
+} from "../src/slack/commands";
+
+function makeStatusService(overrides: Partial<AdminService> = {}): AdminService {
+  return {
+    getStatus: () => ({
+      documentCount: 42,
+      watcherAlive: true,
+      uptimeSeconds: 3661, // 1h 1m 1s
+    }),
+    ...overrides,
+  };
+}
+
+describe("slack/commands — registry shape", () => {
+  it("exports a record covering status, sync, reindex, help, feedback", () => {
+    const keys = Object.keys(commandHandlers).map((k) => k.toLowerCase());
+    for (const required of ["status", "sync", "reindex", "help", "feedback"]) {
+      expect(keys.some((k) => k.includes(required))).toBe(true);
+    }
+  });
+
+  it("every handler is a function", () => {
+    for (const handler of Object.values(commandHandlers)) {
+      expect(typeof handler).toBe("function");
+    }
+  });
+});
+
+describe("slack/commands — status", () => {
+  it("returns a string containing doc count, watcher status, and uptime", () => {
+    const result = statusCommand(makeStatusService());
+    expect(typeof result).toBe("string");
+    const text = result as string;
+    expect(text).toContain("42");
+    expect(text).toMatch(/alive|true|active|yes/i);
+    expect(text).toMatch(/uptime|[0-9]+\s*(s|sec|m|min|h|hr)/i);
+  });
+
+  it("uses 'stopped' wording when the watcher is not alive", () => {
+    const result = statusCommand(
+      makeStatusService({
+        getStatus: () => ({ documentCount: 0, watcherAlive: false, uptimeSeconds: 5 }),
+      }),
+    );
+    expect(typeof result).toBe("string");
+    expect((result as string).toLowerCase()).toContain("stopped");
+  });
+
+  it("degrades gracefully when service has no getStatus", () => {
+    const result = statusCommand({} as AdminService);
+    expect(typeof result).toBe("string");
+    expect((result as string)).toContain("0");
+  });
+});
+
+describe("slack/commands — sync-confluence", () => {
+  it("calls service.syncConfluence and returns its message", async () => {
+    const calls: Array<string | undefined> = [];
+    const service: AdminService = {
+      syncConfluence: async (key) => {
+        calls.push(key);
+        return "Synced 12 pages";
+      },
+    };
+    const result = await syncConfluenceCommand(service, "ENG");
+    expect(calls).toEqual(["ENG"]);
+    expect(result).toBe("Synced 12 pages");
+  });
+
+  it("returns a default success message when service returns void", async () => {
+    const service: AdminService = { syncConfluence: async () => undefined };
+    const result = await syncConfluenceCommand(service);
+    expect(typeof result).toBe("string");
+    expect((result as string).length).toBeGreaterThan(0);
+  });
+
+  it("returns a 'not configured' string when service has no syncConfluence", async () => {
+    const result = await syncConfluenceCommand({} as AdminService);
+    expect((result as string).toLowerCase()).toContain("not configured");
+  });
+
+  it("catches sync failures and returns a friendly error string", async () => {
+    const service: AdminService = {
+      syncConfluence: async () => {
+        throw new Error("network down");
+      },
+    };
+    const result = await syncConfluenceCommand(service);
+    expect((result as string).toLowerCase()).toContain("failed");
+    expect((result as string)).toContain("network down");
+  });
+});
+
+describe("slack/commands — reindex", () => {
+  it("calls service.reindex and surfaces its message", async () => {
+    let called = false;
+    const service: AdminService = {
+      reindex: async () => {
+        called = true;
+        return "rebuilt 99 chunks";
+      },
+    };
+    const result = await reindexCommand(service);
+    expect(called).toBe(true);
+    expect(result).toBe("rebuilt 99 chunks");
+  });
+
+  it("returns a 'not configured' string when reindex is missing", async () => {
+    const result = await reindexCommand({} as AdminService);
+    expect((result as string).toLowerCase()).toContain("not configured");
+  });
+
+  it("catches reindex failures", async () => {
+    const service: AdminService = {
+      reindex: async () => {
+        throw new Error("disk full");
+      },
+    };
+    const result = await reindexCommand(service);
+    expect((result as string).toLowerCase()).toContain("failed");
+    expect(result as string).toContain("disk full");
+  });
+});
+
+describe("slack/commands — help", () => {
+  it("returns a non-empty string listing the admin commands", () => {
+    const result = helpCommand({} as AdminService);
+    expect(typeof result).toBe("string");
+    const text = result as string;
+    expect(text.length).toBeGreaterThan(20);
+    for (const cmd of ["status", "sync", "reindex", "help", "feedback", "ask"]) {
+      expect(text.toLowerCase()).toContain(cmd);
+    }
+  });
+});
+
+describe("slack/commands — feedback", () => {
+  it("returns a confirmation string and forwards to recordFeedback", () => {
+    const recorded: string[] = [];
+    const service: AdminService = { recordFeedback: (msg) => void recorded.push(msg) };
+    const result = feedbackCommand(service, "VPN answer was wrong");
+    expect(typeof result).toBe("string");
+    expect((result as string).length).toBeGreaterThan(2);
+    expect(recorded).toEqual(["VPN answer was wrong"]);
+  });
+
+  it("falls back to console.log when service has no recordFeedback", () => {
+    const original = console.log;
+    const captured: string[] = [];
+    console.log = (...args: unknown[]) => captured.push(args.map(String).join(" "));
+    try {
+      const result = feedbackCommand({} as AdminService, "Slack adapter fell over");
+      expect((result as string).length).toBeGreaterThan(2);
+      expect(captured.some((line) => line.includes("Slack adapter fell over"))).toBe(true);
+    } finally {
+      console.log = original;
+    }
+  });
+
+  it("returns a usage hint when message is empty", () => {
+    const result = feedbackCommand({} as AdminService, "");
+    expect((result as string).toLowerCase()).toContain("usage");
+  });
+
+  it("never throws when recordFeedback throws", () => {
+    const service: AdminService = {
+      recordFeedback: () => {
+        throw new Error("logging broke");
+      },
+    };
+    expect(() => feedbackCommand(service, "still want to say this")).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `src/slack/commands.ts` with handlers for `/status`, `/sync-confluence`, `/reindex`, `/help`, `/feedback`.
- Registers all 5 commands in `src/slack/adapter.ts` (Bolt) using the same pattern as `/ask`.
- Re-exports `commandHandlers` from `src/slack/index.ts` so the AC can `require('./dist/slack/commands')`.
- 17 new unit tests in `tests/commands.test.ts` covering happy paths, error paths, and missing-service degradation.

## Verdict
- forge_evaluate (US-09): PASS on all 5 ACs (AC-01 .. AC-05).
- Full suite: 120/120 (was 103/103 — 17 new tests).
- typecheck: clean.

## Test plan
- [x] `npm run typecheck`
- [x] `npm run build`
- [x] `npm test`
- [x] `npm test -- --testPathPattern=commands`
- [x] forge_evaluate story-mode US-09 — verdict PASS

## Notes
- `KnowledgeService.getStatus()` already existed from US-05/US-06 work — no service-layer changes were needed.
- Sync / reindex / feedback degrade to friendly "not configured" strings if the host doesn't supply richer admin hooks. Production wiring can pass an enriched `adminService` later without breaking the public surface.
- No ADR triggers fired (no new deps, no schema bumps, no new cross-module boundaries — `commands.ts` lives inside the existing `src/slack/` module). The `chore(US-09)` follow-on commit records this as a "no new decisions" row in `docs/decisions/INDEX.md`.

---
plan-refresh: baseline