### PR TITLE
chore: release 0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to monday-bot will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.0](https://github.com/ziyilam3999/monday-bot/compare/v0.8.1...v0.9.0) (2026-04-27)
+
+### Features
+
+* **US-09:** admin slash commands (`/status`, `/sync-confluence`, `/reindex`, `/help`, `/feedback`) (#114)
+
 ## [0.8.1](https://github.com/ziyilam3999/monday-bot/compare/v0.8.0...v0.8.1) (2026-04-27)
 
 ### Bug Fixes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "monday-bot",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "description": "Team Slack knowledge assistant — answers from internal documents with cited, fact-based summaries.",
   "private": true,
   "type": "commonjs",


### PR DESCRIPTION
## Summary
Release 0.9.0 — bundles US-09 (admin slash commands).

## Changes
- `package.json`: 0.8.1 → 0.9.0 (minor bump per `feat(US-09)` commit since v0.8.1)
- `CHANGELOG.md`: prepend 0.9.0 entry referencing PR #114

## Test plan
- [x] CI build matrix (ubuntu + windows)
- [x] Release-only diff — no source code changes

---
plan-refresh: baseline