### PR TITLE
fix: drop unreachable adminService fallback (#117)

### DIFF
--- a/src/slack/adapter.ts
+++ b/src/slack/adapter.ts
@@ -94,7 +94,7 @@ export class SlackAdapter {
     // Default: if the knowledgeService object also exposes admin methods (e.g.
     // KnowledgeService's getStatus()), use it for /status. Otherwise the admin
     // surface is empty and individual handlers degrade to "not configured".
-    this.adminService = opts.adminService ?? (opts.knowledgeService as unknown as AdminService) ?? {};
+    this.adminService = opts.adminService ?? (opts.knowledgeService as unknown as AdminService);
 
     const factory: AppFactory = opts.appFactory ?? ((appOpts) => new App(appOpts));
     this.app = factory({


### PR DESCRIPTION
Closes #117

Auto-fix by /housekeep Stage 4.

Removes the trailing `?? {}` fallback at adapter.ts:97. The non-null guard at lines 85-89 already throws SlackConfigError when knowledgeService is null/undefined, so the fallback was dead code. Single-line mechanical change per triage.