### PR TITLE
fix: reword US-10 AC-02 invariant to slack-handler-path layer

### DIFF
--- a/docs/generated/TECHNICAL-SPEC.md
+++ b/docs/generated/TECHNICAL-SPEC.md
@@ -337,7 +337,7 @@ stories:
 ### invariants
 
 - `handleQuery` MUST return a human-readable error string in `text` when `QueryService.query` throws (AC-01)
-- `handleQuery` MUST surface an explicit not-found message when the service returns no results (AC-02)
+- The slack handler path MUST surface an explicit not-found message when the service returns no results (AC-02)
 - `handleQuery` MUST NOT propagate raw exceptions to callers; all errors MUST be caught and converted to `QueryHandlerResult`
 
 ### test-surface


### PR DESCRIPTION
Closes #128

Auto-fix by /housekeep Stage 4.

Reworded the US-10 invariant in `docs/generated/TECHNICAL-SPEC.md` from "`handleQuery` MUST surface an explicit not-found message..." to "The slack handler path MUST surface an explicit not-found message...". The original mis-attributed AC-02 enforcement to `handleQuery`, which only forwards results through `formatAnswer`; the not-found copy is actually produced upstream by `NO_CONTEXT_ANSWER` (src/llm/generate.ts) and `NO_DOCUMENTS_ANSWER` (src/knowledge/service.ts). The new layer-agnostic phrasing accurately describes the slack handler path without lying about which module enforces it.