### PR TITLE
fix: tighten KnowledgeService cast to preserve options signature

### DIFF
--- a/src/slack/queryHandler.ts
+++ b/src/slack/queryHandler.ts
@@ -63,7 +63,7 @@ const FRIENDLY_ERROR_TEXT =
 function defaultService(): QueryService {
   // eslint-disable-next-line @typescript-eslint/no-var-requires
   const { KnowledgeService } = require("../knowledge/service") as {
-    KnowledgeService: new () => QueryService;
+    KnowledgeService: new (opts?: unknown) => QueryService;
   };
   return new KnowledgeService();
 }


### PR DESCRIPTION
Closes #127

Auto-fix by /housekeep Stage 4.

Tightened the lazy-require cast for `KnowledgeService` in `src/slack/queryHandler.ts` from `new () => QueryService` to `new (opts?: unknown) => QueryService`. The original cast erased the real `KnowledgeServiceOptions` parameter (declared in `src/knowledge/service.ts:96`); the new shape accurately reflects that the constructor accepts an optional options object. Single-line surgical change — preserves the existing lazy-require pattern.