### PR TITLE
fix: US-08 E4: log app_mention fallback postMessage failure

### DIFF
--- a/src/slack/adapter.ts
+++ b/src/slack/adapter.ts
@@ -150,8 +150,8 @@ export class SlackAdapter {
             thread_ts: threadTs,
             text: DEFAULT_FALLBACK_TEXT,
           });
-        } catch {
-          // best-effort fallback
+        } catch (err2) {
+          logger.error?.("SlackAdapter app_mention fallback post failed:", err2);
         }
       }
     });


### PR DESCRIPTION
Closes #104

Auto-fix by /housekeep Stage 4.

Replaced empty inner-catch on the app_mention fallback with logger.error so the secondary postMessage failure is no longer swallowed.