### PR TITLE
fix: formatUptime: drop trailing 0s when hours present (E7, US-09)

### DIFF
--- a/src/slack/commands.ts
+++ b/src/slack/commands.ts
@@ -52,7 +52,7 @@ function formatUptime(totalSeconds: number): string {
   const parts: string[] = [];
   if (h > 0) parts.push(`${h}h`);
   if (m > 0 || h > 0) parts.push(`${m}m`);
-  parts.push(`${s}s`);
+  if (s > 0 || h === 0) parts.push(`${s}s`);
   return parts.join(" ");
 }
 


### PR DESCRIPTION
Closes #121

Auto-fix by /housekeep Stage 4.

Gated the seconds push in formatUptime to omit trailing 0s when hours present. Mirrors the existing minutes gate idiom.