### PR TITLE
docs(readme): refresh Status table — all 13 stories done

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,23 +4,23 @@ A Slack bot that answers team questions from internal documents (shared folders,
 
 ## Status
 
-Active development. Bootstrap pipeline in progress.
+PH-02 complete (v0.12.0, 2026-05-09). All 13 stories shipped. End-to-end usability gated on operator-side setup (Slack creds + corpus + PM2) — see Deployment section below.
 
 | Story | Title | Status |
 |-------|-------|--------|
 | US-01 | TS scaffolding + secrets validation + build | done |
-| US-02 | Document ingestion (TXT/MD/PDF/DOCX → chunks) | ready |
-| US-03 | Embeddings + vector index + persistence | pending |
-| US-04 | LLM answer generation (cited, facts-only) | pending |
-| US-05 | Knowledge service (platform-agnostic facade) | pending |
-| US-06 | File watcher (auto-index ≤5s) | pending |
-| US-07 | Confluence sync (REST + cron) | pending |
-| US-08 | Slack core (Socket Mode, @mention, /ask) | pending |
-| US-09 | Admin commands (status/sync/reindex/help/feedback) | pending |
-| US-10 | Graceful errors (no stack traces in Slack) | pending |
-| US-11 | Config file (watched paths, schedule) | ready |
-| US-12 | E2E integration (full round-trip) | pending |
-| US-13 | Deployment packaging (PM2/systemd/Docker) | pending |
+| US-02 | Document ingestion (TXT/MD/PDF/DOCX → chunks) | done |
+| US-03 | Embeddings + vector index + persistence | done |
+| US-04 | LLM answer generation (cited, facts-only) | done |
+| US-05 | Knowledge service (platform-agnostic facade) | done |
+| US-06 | File watcher (auto-index ≤5s) | done |
+| US-07 | Confluence sync (REST + cron) | done |
+| US-08 | Slack core (Socket Mode, @mention, /ask) | done |
+| US-09 | Admin commands (status/sync/reindex/help/feedback) | done |
+| US-10 | Graceful errors (no stack traces in Slack) | done |
+| US-11 | Config file (watched paths, schedule) | done |
+| US-12 | E2E integration (full round-trip) | done |
+| US-13 | Deployment packaging (PM2/systemd/Docker) | done |
 
 See [`docs/PLAN_MONDAY_BOT.md`](docs/PLAN_MONDAY_BOT.md) for the v2.0.0 product requirements (intent-only, executor-owns-how).
 


### PR DESCRIPTION
## Summary

- Updates README Status table: US-02..US-13 from \`pending\`/\`ready\` → \`done\`. PH-02 closed at v0.12.0 (2026-05-09).
- Replaces the \"Active development. Bootstrap pipeline in progress.\" blurb with a PH-02-complete summary that points readers at the Deployment section.

Resolves the long-standing drift where the README claimed work-in-progress for stories that had already shipped via PRs #142 (US-11), #147 (US-12), #153 (US-13), and v0.12.0 (#159).

## Test plan

- [x] forge_coordinate('PH-02') reports 13/13 done (verified pre-PR)
- [x] No source changes — pure docs

---
plan-refresh: baseline