### PR TITLE
chore: release 0.12.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to monday-bot will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.12.1](https://github.com/ziyilam3999/monday-bot/compare/v0.12.0...v0.12.1) (2026-05-09)
+
+### Bug Fixes
+
+* annotate RESUME.md projected-handoff timestamps (#141)
+
+### Miscellaneous
+
+* **docs:** refresh README Status table — all 13 stories done (#161)
+
 ## [0.12.0](https://github.com/ziyilam3999/monday-bot/compare/v0.11.0...v0.12.0) (2026-05-08)
 
 ### Features

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "monday-bot",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "Team Slack knowledge assistant — answers from internal documents with cited, fact-based summaries.",
   "private": true,
   "type": "commonjs",


### PR DESCRIPTION
release-pr: true

## [0.12.1](https://github.com/ziyilam3999/monday-bot/compare/v0.12.0...v0.12.1) (2026-05-09)

### Bug Fixes

* annotate RESUME.md projected-handoff timestamps (#141)

### Miscellaneous

* **docs:** refresh README Status table — all 13 stories done (#161)