### PR TITLE
fix(US-13): wire SlackAdapter into src/index.ts (#166)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,25 +1,160 @@
-import { MissingEnvVarError, validateEnv } from "./config/env";
+import { App } from "@slack/bolt";
+import { MissingEnvVarError, validateEnv, AppEnv } from "./config/env";
+import { loadConfig } from "./config/config";
+import { KnowledgeService } from "./knowledge/service";
+import { SlackAdapter, AppFactory } from "./slack/adapter";
 
-function main(): void {
-  try {
-    const env = validateEnv();
-    console.log(
-      `Monday is starting. Slack bot token configured (${env.slackBotToken.slice(0, 5)}...).`
-    );
-  } catch (err) {
-    if (err instanceof MissingEnvVarError) {
-      console.error(`\nMonday cannot start: ${err.message}\n`);
-      process.exit(1);
-    }
+export interface RunMondayOptions {
+  /** Override Bolt App factory (jest tests + AC-06 shell-spawn path). */
+  appFactory?: AppFactory;
+  /** Override config.yaml path. Defaults to <cwd>/config.yaml. */
+  configPath?: string;
+  /**
+   * If true (production default), startup errors call `process.exit(1)`.
+   * If false (jest tests), startup errors are thrown so callers can assert.
+   */
+  exitOnError?: boolean;
+}
+
+export interface RunMondayHandle {
+  adapter: SlackAdapter;
+  knowledge: KnowledgeService;
+  /** Idempotent shutdown — stops the Slack adapter and folder watchers. */
+  shutdown: () => Promise<void>;
+}
+
+/**
+ * Inline no-op fake Bolt App. Used only when MONDAY_TEST_MODE=1 is set and no
+ * explicit `appFactory` was supplied — i.e. the AC-06 shell-spawn verifier
+ * (`node dist/index.js` with stub Slack tokens). Production has MONDAY_TEST_MODE
+ * unset and so always falls through to the real `@slack/bolt` App.
+ */
+function createFakeAppFactory(): AppFactory {
+  return ((_opts: unknown) => {
+    const handlers = new Map<string, unknown>();
+    return {
+      event: (name: string, handler: unknown) => handlers.set(`event:${name}`, handler),
+      command: (name: string, handler: unknown) => handlers.set(`command:${name}`, handler),
+      start: async () => undefined,
+      stop: async () => undefined,
+    } as unknown as App;
+  }) as AppFactory;
+}
+
+export async function runMonday(opts: RunMondayOptions = {}): Promise<RunMondayHandle> {
+  const exitOnError = opts.exitOnError ?? true;
+
+  const handleStartupError = (err: unknown): never => {
     const message = err instanceof Error ? err.message : String(err);
     console.error(`\nMonday cannot start: ${message}\n`);
-    if (process.env.MONDAY_DEBUG === "1" && err instanceof Error && err.stack) {
+    if (
+      process.env.MONDAY_DEBUG === "1" &&
+      err instanceof Error &&
+      err.stack &&
+      !(err instanceof MissingEnvVarError)
+    ) {
       console.error(err.stack);
     }
-    process.exit(1);
+    if (exitOnError) {
+      process.exit(1);
+    }
+    throw err instanceof Error ? err : new Error(message);
+  };
+
+  let env: AppEnv;
+  try {
+    env = validateEnv();
+  } catch (err) {
+    return handleStartupError(err);
   }
+
+  let watchedFolders: string[];
+  try {
+    const config = loadConfig(opts.configPath);
+    watchedFolders = config.watchedFolders ?? [];
+  } catch (err) {
+    return handleStartupError(err);
+  }
+
+  const knowledge = new KnowledgeService();
+  for (const folder of watchedFolders) {
+    try {
+      knowledge.watchFolder(folder);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      console.error(`Monday: failed to watch folder ${folder}: ${message} (continuing)`);
+    }
+  }
+
+  let appFactory = opts.appFactory;
+  if (!appFactory && process.env.MONDAY_TEST_MODE === "1") {
+    appFactory = createFakeAppFactory();
+  }
+
+  let adapter: SlackAdapter;
+  try {
+    adapter = new SlackAdapter({
+      botToken: env.slackBotToken,
+      appToken: env.slackAppToken,
+      knowledgeService: knowledge,
+      appFactory,
+    });
+  } catch (err) {
+    return handleStartupError(err);
+  }
+
+  try {
+    await adapter.start();
+  } catch (err) {
+    return handleStartupError(err);
+  }
+
+  console.log(
+    `Monday is listening (Socket Mode). Slack bot token configured (${env.slackBotToken.slice(0, 5)}...).`,
+  );
+
+  const shutdown = async (): Promise<void> => {
+    try {
+      await adapter.stop();
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      console.error(`Monday: error stopping Slack adapter: ${message}`);
+    }
+    knowledge.stopWatching();
+  };
+
+  if (exitOnError) {
+    const onSignal = (signal: string): void => {
+      console.log(`Monday: received ${signal}, shutting down…`);
+      shutdown()
+        .catch((err) => {
+          const message = err instanceof Error ? err.message : String(err);
+          console.error(`Monday: shutdown error: ${message}`);
+        })
+        .finally(() => {
+          process.exit(0);
+        });
+    };
+    process.once("SIGINT", () => onSignal("SIGINT"));
+    process.once("SIGTERM", () => onSignal("SIGTERM"));
+
+    // In test mode (no real Slack workspace), exit cleanly after the ready-log
+    // so AC-06's shell verifier can rely on `set -o pipefail` + `timeout` without
+    // the timeout-signal exit-code (124) masking the success path.
+    if (process.env.MONDAY_TEST_MODE === "1") {
+      setImmediate(() => {
+        shutdown().finally(() => process.exit(0));
+      });
+    }
+  }
+
+  return { adapter, knowledge, shutdown };
 }
 
 if (require.main === module) {
-  main();
+  runMonday().catch((err) => {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error(`Monday: unhandled error during startup: ${message}`);
+    process.exit(1);
+  });
 }

--- a/tests/index.startup.test.ts
+++ b/tests/index.startup.test.ts
@@ -1,0 +1,172 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+import { runMonday } from "../src/index";
+import { MissingEnvVarError } from "../src/config/env";
+import * as knowledgeModule from "../src/knowledge/service";
+
+const BOT_TOKEN = "bot-token-test-value";
+const APP_TOKEN = "app-token-test-value";
+
+function makeTempConfigYaml(body: string): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "monday-startup-"));
+  const file = path.join(dir, "config.yaml");
+  fs.writeFileSync(file, body, "utf8");
+  return file;
+}
+
+describe("runMonday — startup wiring (AC-4, regression for AC-04)", () => {
+  let savedEnv: Record<string, string | undefined>;
+
+  beforeEach(() => {
+    savedEnv = {
+      SLACK_BOT_TOKEN: process.env.SLACK_BOT_TOKEN,
+      SLACK_APP_TOKEN: process.env.SLACK_APP_TOKEN,
+      MONDAY_TEST_MODE: process.env.MONDAY_TEST_MODE,
+      MONDAY_DEBUG: process.env.MONDAY_DEBUG,
+    };
+  });
+
+  afterEach(() => {
+    for (const k of Object.keys(savedEnv)) {
+      const v = savedEnv[k];
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+  });
+
+  it("instantiates SlackAdapter and resolves adapter.start() with valid env (jest auto-stubbed Bolt)", async () => {
+    process.env.SLACK_BOT_TOKEN = BOT_TOKEN;
+    process.env.SLACK_APP_TOKEN = APP_TOKEN;
+    const cfg = makeTempConfigYaml("watchedFolders: []\n");
+
+    const handle = await runMonday({ configPath: cfg, exitOnError: false });
+
+    expect(handle.adapter).toBeDefined();
+    expect(handle.knowledge).toBeDefined();
+    expect(typeof handle.shutdown).toBe("function");
+
+    const fakeApp = handle.adapter._getApp() as unknown as {
+      _started: boolean;
+      _eventHandlers: Map<string, unknown>;
+    };
+    expect(fakeApp._started).toBe(true);
+    expect(fakeApp._eventHandlers.has("app_mention")).toBe(true);
+
+    await handle.shutdown();
+  });
+
+  it("shutdown() stops the Slack adapter and folder watchers (SIGTERM equivalent)", async () => {
+    process.env.SLACK_BOT_TOKEN = BOT_TOKEN;
+    process.env.SLACK_APP_TOKEN = APP_TOKEN;
+    const cfg = makeTempConfigYaml("watchedFolders: []\n");
+
+    const handle = await runMonday({ configPath: cfg, exitOnError: false });
+
+    const fakeApp = handle.adapter._getApp() as unknown as { _stopped: boolean };
+    expect(fakeApp._stopped).toBe(false);
+
+    const stopWatchingSpy = jest.spyOn(handle.knowledge, "stopWatching");
+    await handle.shutdown();
+
+    expect(fakeApp._stopped).toBe(true);
+    expect(stopWatchingSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("missing SLACK_BOT_TOKEN throws MissingEnvVarError when exitOnError is false (AC-04 regression coverage)", async () => {
+    delete process.env.SLACK_BOT_TOKEN;
+    process.env.SLACK_APP_TOKEN = APP_TOKEN;
+    const cfg = makeTempConfigYaml("watchedFolders: []\n");
+
+    const errSpy = jest.spyOn(console, "error").mockImplementation(() => undefined);
+    await expect(runMonday({ configPath: cfg, exitOnError: false })).rejects.toBeInstanceOf(
+      MissingEnvVarError,
+    );
+    const printed = errSpy.mock.calls.map((c) => c.join(" ")).join("\n");
+    expect(printed).toContain("Monday cannot start");
+    expect(printed).toContain("SLACK_BOT_TOKEN");
+    errSpy.mockRestore();
+  });
+});
+
+describe("runMonday — folder watcher attachment (AC-5)", () => {
+  let savedEnv: Record<string, string | undefined>;
+
+  beforeEach(() => {
+    savedEnv = {
+      SLACK_BOT_TOKEN: process.env.SLACK_BOT_TOKEN,
+      SLACK_APP_TOKEN: process.env.SLACK_APP_TOKEN,
+    };
+    process.env.SLACK_BOT_TOKEN = BOT_TOKEN;
+    process.env.SLACK_APP_TOKEN = APP_TOKEN;
+  });
+
+  afterEach(() => {
+    for (const k of Object.keys(savedEnv)) {
+      const v = savedEnv[k];
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+  });
+
+  it("calls knowledge.watchFolder once per entry in config.watchedFolders", async () => {
+    const folderA = fs.mkdtempSync(path.join(os.tmpdir(), "monday-folder-a-"));
+    const folderB = fs.mkdtempSync(path.join(os.tmpdir(), "monday-folder-b-"));
+    const cfg = makeTempConfigYaml(
+      `watchedFolders:\n  - ${folderA}\n  - ${folderB}\n`,
+    );
+
+    const watchSpy = jest.spyOn(knowledgeModule.KnowledgeService.prototype, "watchFolder");
+
+    const handle = await runMonday({ configPath: cfg, exitOnError: false });
+
+    const watchedDirs = watchSpy.mock.calls.map((c) => c[0]);
+    expect(watchedDirs).toContain(folderA);
+    expect(watchedDirs).toContain(folderB);
+    expect(watchSpy).toHaveBeenCalledTimes(2);
+
+    await handle.shutdown();
+    watchSpy.mockRestore();
+  });
+
+  it("nullish-coalesces watchedFolders to [] when undefined (no watchFolder calls)", async () => {
+    const cfg = makeTempConfigYaml("indexPath: ./tmp/index\n");
+
+    const watchSpy = jest.spyOn(knowledgeModule.KnowledgeService.prototype, "watchFolder");
+
+    const handle = await runMonday({ configPath: cfg, exitOnError: false });
+
+    expect(watchSpy).not.toHaveBeenCalled();
+
+    await handle.shutdown();
+    watchSpy.mockRestore();
+  });
+
+  it("logs and continues when watchFolder throws (one bad folder doesn't kill the bot)", async () => {
+    const goodFolder = fs.mkdtempSync(path.join(os.tmpdir(), "monday-good-"));
+    const cfg = makeTempConfigYaml(
+      `watchedFolders:\n  - /nonexistent/path/that/will/throw\n  - ${goodFolder}\n`,
+    );
+
+    const errSpy = jest.spyOn(console, "error").mockImplementation(() => undefined);
+    const watchSpy = jest
+      .spyOn(knowledgeModule.KnowledgeService.prototype, "watchFolder")
+      .mockImplementationOnce(() => {
+        throw new Error("simulated watch failure");
+      });
+
+    const handle = await runMonday({ configPath: cfg, exitOnError: false });
+
+    // Adapter still came up despite first watcher throwing.
+    const fakeApp = handle.adapter._getApp() as unknown as { _started: boolean };
+    expect(fakeApp._started).toBe(true);
+
+    const printed = errSpy.mock.calls.map((c) => c.join(" ")).join("\n");
+    expect(printed).toContain("failed to watch folder");
+
+    await handle.shutdown();
+    watchSpy.mockRestore();
+    errSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary

- Closes #166 — `src/index.ts` previously validated env vars and exited within milliseconds; the deployed bot was a paper aeroplane behind 5 green ACs.
- Adds `runMonday(opts: { appFactory?, configPath?, exitOnError? })`: loads config → builds KnowledgeService → attaches folder watchers from `config.yaml` → constructs SlackAdapter → `await adapter.start()` → registers SIGINT/SIGTERM graceful shutdown.
- New US-13 acceptance criterion **AC-06** (entrypoint-readiness) plus 6 jest integration tests covering AC-4 (jest path) and AC-5 (folder watcher attachment).

## Why this matters

US-13's existing 5 ACs (build / config-presence / start-script / missing-env / docs) all check "stuff in the right place" — none spawn the binary and grep a ready-signal. PM2 with `min_uptime: "10s"` + `max_restarts: 10` ends up in `errored` after ~40s.

The new AC-06 is shell-level and outside-the-diff: spawn `node dist/index.js` with stub creds + `MONDAY_TEST_MODE=1`, grep for `Monday is listening`, expect `PASS_AC06` token + exit 0.

## Plan

`.ai-workspace/plans/2026-05-10-us-13-followup-wire-index-ts-listener-startup.md` — chain-reviewed by `/per-task-review-loop plan-chain` (P1 stateless → P2 comparative → P3 cairn-grounded → P4 coherent), 4× GREAT signal, 14 mechanical edits folded.

## Test plan

- [x] `npm run build` — exit 0
- [x] `npm test` — 143/143 pass across 18 suites (no regression)
- [x] AC-3 — `SLACK_BOT_TOKEN='' SLACK_APP_TOKEN='' node dist/index.js` exits 1 with "Monday cannot start" + var names (regression coverage for AC-04)
- [x] AC-4 — `npm test -- index.startup` → 6/6 pass (jest auto-stubs Bolt via `tests/__stubs__/slack-bolt.js`)
- [x] AC-4b — `set -o pipefail; SLACK_BOT_TOKEN=xoxb-test SLACK_APP_TOKEN=xapp-test MONDAY_TEST_MODE=1 timeout 8 node dist/index.js 2>&1 | grep -E "Monday is listening" && echo PASS_AC06` → exit 0, prints `PASS_AC06`
- [x] AC-5 — folder watcher spy hits called once per `config.watchedFolders` entry (3 sub-cases including nullish-coalesce + continue-on-error)
- [x] AC-6 — JSON `acceptanceCriteria.length` = 6
- [x] AC-7 — AC-06 description matches `/listen|adapter|start|connect/i`
- [ ] AC-8 — operator-orchestrated post-merge: fresh Claude Code session → `mcp__forge__forge_evaluate({storyId:'US-13'})` reports 6/6 PASS

## Anti-pattern citations

- `planner-executor-workflow-spec.md:33` — "AC must be checkable from outside the diff"
- KB anti-patterns F2 (Behavioral Prose Without Consequences), F26 (UAT as Code Inspection), F27 (US-13 specifically named — this is the third recurring incident)
- tier-b card `bash-pipeline-ac-vacuous-pass` — required `set -o pipefail` to prevent grep's exit code masking node's

---
plan-refresh: baseline