### PR TITLE
chore: release 0.12.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to monday-bot will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.12.2](https://github.com/ziyilam3999/monday-bot/compare/v0.12.1...v0.12.2) (2026-05-10)
+
+### Bug Fixes
+
+* **US-13:** wire SlackAdapter into src/index.ts so the bot actually starts (#166) (#167)
+
 ## [0.12.1](https://github.com/ziyilam3999/monday-bot/compare/v0.12.0...v0.12.1) (2026-05-09)
 
 ### Bug Fixes

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "monday-bot",
-  "version": "0.12.1",
-  "description": "Team Slack knowledge assistant — answers from internal documents with cited, fact-based summaries.",
+  "version": "0.12.2",
+  "description": "Team Slack knowledge assistant \u2014 answers from internal documents with cited, fact-based summaries.",
   "private": true,
   "type": "commonjs",
   "main": "dist/index.js",


### PR DESCRIPTION
release-pr: true

## [0.12.2](https://github.com/ziyilam3999/monday-bot/compare/v0.12.1...v0.12.2) (2026-05-10)

### Bug Fixes

* **US-13:** wire SlackAdapter into src/index.ts so the bot actually starts (#166) (#167)

---
plan-refresh: baseline