### PR TITLE
fix(llm): mirror F6 macOS Keychain fallback in anthropicClient

### DIFF
--- a/src/llm/anthropicClient.ts
+++ b/src/llm/anthropicClient.ts
@@ -1,22 +1,48 @@
 import Anthropic from "@anthropic-ai/sdk";
 import { readFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
 import { join } from "node:path";
-import { homedir } from "node:os";
+import { homedir, userInfo } from "node:os";
 
 const EXPIRY_BUFFER_MS = 5 * 60 * 1000;
+
+// F6 mirror — macOS Keychain service name for Claude Code's OAuth blob.
+// Mirrors forge-harness anthropic.ts (v0.40.5). If Claude Code renames the
+// entry in a future release, this constant must follow.
+export const KEYCHAIN_SERVICE_NAME = "Claude Code-credentials";
 
 let client: Anthropic | null = null;
 let clientExpiresAt: number | null = null;
 let warnedOnceForMalformedCreds = false;
 
-function readOAuthToken(): { accessToken: string; expiresAt: number } | null {
-  const credPath = join(homedir(), ".claude", ".credentials.json");
-  let raw: string;
+// F6 mirror — macOS Keychain fallback for the OAuth blob. On macOS, Claude
+// Code stores credentials in Keychain rather than on disk after `/login`. When
+// the file read fails AND we are on darwin, shell out to /usr/bin/security to
+// fetch the blob. Returns the raw JSON-encoded blob (same shape as the file
+// would have had) or null on any failure (non-darwin, missing entry, timeout).
+function readOAuthTokenFromKeychain(): string | null {
+  if (process.platform !== "darwin") return null;
   try {
-    raw = readFileSync(credPath, "utf-8");
+    const username = userInfo().username;
+    return execFileSync(
+      "/usr/bin/security",
+      ["find-generic-password", "-s", KEYCHAIN_SERVICE_NAME, "-a", username, "-w"],
+      { encoding: "utf-8", timeout: 2000 },
+    ).trim();
   } catch {
     return null;
   }
+}
+
+function readOAuthToken(): { accessToken: string; expiresAt: number } | null {
+  const credPath = join(homedir(), ".claude", ".credentials.json");
+  let raw: string | null;
+  try {
+    raw = readFileSync(credPath, "utf-8");
+  } catch {
+    raw = readOAuthTokenFromKeychain();
+  }
+  if (raw === null || raw === "") return null;
   let creds: unknown;
   try {
     creds = JSON.parse(raw);
@@ -24,7 +50,7 @@ function readOAuthToken(): { accessToken: string; expiresAt: number } | null {
     if (!warnedOnceForMalformedCreds) {
       warnedOnceForMalformedCreds = true;
       console.warn(
-        `[anthropicClient] Malformed JSON at ${credPath} — falling back to ANTHROPIC_API_KEY: ${(err as Error).message}`,
+        `[anthropicClient] Malformed JSON credentials — falling back to ANTHROPIC_API_KEY: ${(err as Error).message}`,
       );
     }
     return null;

--- a/tests/anthropicClient.test.ts
+++ b/tests/anthropicClient.test.ts
@@ -12,6 +12,16 @@ jest.mock("node:os", () => {
   };
 });
 
+const mockExecFileSync = jest.fn();
+
+jest.mock("node:child_process", () => {
+  const actual = jest.requireActual("node:child_process") as typeof import("node:child_process");
+  return {
+    ...actual,
+    execFileSync: (...args: unknown[]) => mockExecFileSync(...args),
+  };
+});
+
 import { getClient, resetClient } from "../src/llm/anthropicClient";
 
 function writeOAuth(home: string, expiresAtMs: number) {
@@ -35,6 +45,12 @@ describe("anthropicClient.getClient", () => {
     resetClient();
     delete process.env.ANTHROPIC_API_KEY;
     currentHome = mkdtempSync(join(tmpdir(), "monday-ac06-"));
+    // F6 mirror — default: Keychain probe throws (matches non-darwin / missing entry).
+    // Tests that exercise the Keychain fallback override per-case via mockImplementationOnce.
+    mockExecFileSync.mockReset();
+    mockExecFileSync.mockImplementation(() => {
+      throw new Error("security: SecKeychainSearchCopyNext: The specified item could not be found");
+    });
   });
 
   afterAll(() => {
@@ -73,5 +89,87 @@ describe("anthropicClient.getClient", () => {
     resetClient();
     const c = getClient();
     expect(c).not.toBe(a);
+  });
+});
+
+// ── F6 mirror — macOS Keychain fallback in readOAuthToken() ────────────────
+//
+// On darwin, Claude Code stores OAuth in Keychain rather than on disk. When
+// the file read fails AND we are on darwin, anthropicClient shells out to
+// /usr/bin/security to fetch the blob (same JSON shape). Mirrors forge-harness
+// anthropic.ts v0.40.5.
+//
+// Test isolation: per-test Object.defineProperty(process, "platform", ...)
+// with afterEach restore. process.platform is read-only on Node 20+, so
+// configurable: true is required for the setter to succeed.
+
+describe("F6 — readOAuthToken() falls back to macOS Keychain on darwin", () => {
+  const ORIGINAL_PLATFORM = process.platform;
+  const originalApiKey = process.env.ANTHROPIC_API_KEY;
+
+  function setPlatform(platform: NodeJS.Platform): void {
+    Object.defineProperty(process, "platform", { value: platform, configurable: true });
+  }
+
+  beforeEach(() => {
+    resetClient();
+    delete process.env.ANTHROPIC_API_KEY;
+    // Fresh tmp home that does NOT contain ~/.claude/.credentials.json so the
+    // file read fails and the Keychain fallback path triggers.
+    currentHome = mkdtempSync(join(tmpdir(), "monday-f6-"));
+    mockExecFileSync.mockReset();
+  });
+
+  afterEach(() => {
+    Object.defineProperty(process, "platform", { value: ORIGINAL_PLATFORM, configurable: true });
+  });
+
+  afterAll(() => {
+    if (originalApiKey === undefined) delete process.env.ANTHROPIC_API_KEY;
+    else process.env.ANTHROPIC_API_KEY = originalApiKey;
+    resetClient();
+  });
+
+  function keychainBlob(accessToken: string, expiresAt: number): string {
+    return JSON.stringify({ claudeAiOauth: { accessToken, expiresAt } });
+  }
+
+  test("(i) darwin + Keychain returns valid JSON blob → getClient() builds a client", () => {
+    setPlatform("darwin");
+    mockExecFileSync.mockImplementationOnce(() =>
+      keychainBlob("oauth-from-keychain", Date.now() + 60 * 60 * 1000),
+    );
+    expect(getClient()).toBeDefined();
+    expect(mockExecFileSync).toHaveBeenCalledTimes(1);
+    const callArgs = mockExecFileSync.mock.calls[0];
+    expect(callArgs[0]).toBe("/usr/bin/security");
+    expect(callArgs[1]).toEqual(
+      expect.arrayContaining(["find-generic-password", "-s", "Claude Code-credentials", "-w"]),
+    );
+  });
+
+  test("(ii) darwin + Keychain execFileSync throws → falls through to API key", () => {
+    setPlatform("darwin");
+    mockExecFileSync.mockImplementationOnce(() => {
+      throw new Error("security: SecKeychainSearchCopyNext: not found");
+    });
+    process.env.ANTHROPIC_API_KEY = "sk-test-stub";
+    expect(getClient()).toBeDefined();
+    expect(mockExecFileSync).toHaveBeenCalledTimes(1);
+  });
+
+  test("(iii) non-darwin + missing file → Keychain shell-out is never called", () => {
+    setPlatform("linux");
+    process.env.ANTHROPIC_API_KEY = "sk-test-stub";
+    expect(getClient()).toBeDefined();
+    expect(mockExecFileSync).not.toHaveBeenCalled();
+  });
+
+  test("(iv) darwin + Keychain returns malformed JSON → null sentinel, no crash", () => {
+    setPlatform("darwin");
+    mockExecFileSync.mockImplementationOnce(() => "this-is-not-json");
+    process.env.ANTHROPIC_API_KEY = "sk-test-stub";
+    expect(getClient()).toBeDefined();
+    expect(mockExecFileSync).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## Summary

- Mirrors the F6 fix shipped in **forge-harness v0.40.5** (2026-05-03) into monday-bot's `src/llm/anthropicClient.ts`.
- On macOS, Claude Code stores OAuth credentials in **Keychain** (entry `Claude Code-credentials`) instead of writing `~/.claude/.credentials.json` after `/login`. The current monday-bot client only reads the file, so it falls through to "no creds" on a freshly-logged-in Mac.
- Fix: when `readFileSync` fails AND `process.platform === "darwin"`, shell out to `/usr/bin/security find-generic-password -s "Claude Code-credentials" -a <user> -w` with a 2000ms timeout. Empty catch → null sentinel; non-darwin platforms short-circuit before any shell-out.
- Closes the F6-mirror gap noted in `.ai-workspace/PROJECT-INDEX-reference.md` and Task #15 of the post-v0.43.1 priority card.

## Test plan

- [x] **AC-1..AC-5** — grep counts on `src/llm/anthropicClient.ts`: `KEYCHAIN_SERVICE_NAME` = 2, `execFileSync` = 2 (import + use), `readOAuthTokenFromKeychain` = 2, `process.platform` = 1, `/usr/bin/security` ≥ 1.
- [x] **AC-6** — 9/9 tests passing in `tests/anthropicClient.test.ts` (5 existing + 4 new F6 cases mirroring forge-harness's `anthropic.test.ts:501-588`):
  - (i) darwin + Keychain returns valid JSON → client built
  - (ii) darwin + Keychain `execFileSync` throws → falls through to API key
  - (iii) non-darwin → Keychain shell-out never called
  - (iv) darwin + Keychain returns malformed JSON → null sentinel, no crash
- [x] **AC-7** — `npm run build` clean (no TS errors).
- [x] **AC-8** — `npm run typecheck` clean.
- [x] **AC-9** — commit message contains `F6` / `Keychain` / `macOS.*fallback` (release-please-immune; CHANGELOG section is auto-generated on release).
- [x] **Full suite** — 147/147 tests passing, no regression.
- [ ] **AC-10** (post-ship, operator-gated) — on a Mac where Claude Code was logged in via `/login` and `~/.claude/.credentials.json` is confirmed absent, `node -e "require('./dist/llm/anthropicClient.js').getClient()"` returns without throwing.

## Review trail

Plan-chain (P1 stateless → P2 comparative → P3 cairn-grounded → P4 coherence) + per-task post-code reviewer all returned PASS or PASS-WITH-FOLLOW-UP with GREAT signal. KB patterns P34/P44/P49/P64 correctly applied; F2/F45/F49/F54 avoided or mitigated; zero F-DIRECTIVE-INTO-VOID risk.

Plan: `.ai-workspace/plans/2026-05-11-f6-mirror-keychain-fallback.md` (v2 post-fold).

---
plan-refresh: baseline