### PR TITLE
chore: release 0.12.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to monday-bot will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.12.4](https://github.com/ziyilam3999/monday-bot/compare/v0.12.3...v0.12.4) (2026-05-11)
+
+### Bug Fixes
+
+* **llm:** mirror F6 macOS Keychain fallback in anthropicClient (#178)
+
 ## [0.12.3](https://github.com/ziyilam3999/monday-bot/compare/v0.12.2...v0.12.3) (2026-05-11)
 
 ### Miscellaneous

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "monday-bot",
-  "version": "0.12.3",
+  "version": "0.12.4",
   "description": "Team Slack knowledge assistant \u2014 answers from internal documents with cited, fact-based summaries.",
   "private": true,
   "type": "commonjs",


### PR DESCRIPTION
release-pr: true

## [0.12.4](https://github.com/ziyilam3999/monday-bot/compare/v0.12.3...v0.12.4) (2026-05-11)

### Bug Fixes

* **llm:** mirror F6 macOS Keychain fallback in anthropicClient (#178)

---
plan-refresh: baseline