### PR TITLE
fix: shutdown() is not strictly idempotent — calling twice may double-stop

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -113,7 +113,10 @@ export async function runMonday(opts: RunMondayOptions = {}): Promise<RunMondayH
     `Monday is listening (Socket Mode). Slack bot token configured (${env.slackBotToken.slice(0, 5)}...).`,
   );
 
+  let stopped = false;
   const shutdown = async (): Promise<void> => {
+    if (stopped) return;
+    stopped = true;
     try {
       await adapter.stop();
     } catch (err) {


### PR DESCRIPTION
Closes #168

Auto-fix by /housekeep Stage 4.

Add a `stopped` boolean guard in the `shutdown()` closure so that calling it multiple times is a no-op. The second and subsequent calls return early before invoking `adapter.stop()` or `knowledge.stopWatching()` again.