### PR TITLE
docs(US-13): .env.example missing MONDAY_DEBUG line

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,3 +18,7 @@ SLACK_APP_TOKEN=replace-with-your-app-token
 # Optional — Anthropic API key for LLM-backed answers. Without this the bot
 # falls back to extractive snippets only.
 # ANTHROPIC_API_KEY=replace-with-your-anthropic-key
+
+# Optional — set to 1 to enable verbose debug logging (stack traces on startup
+# errors, extra diagnostic output). Safe to leave unset in production.
+# MONDAY_DEBUG=1


### PR DESCRIPTION
Closes #174

Auto-fix by /housekeep Stage 4.

Add a commented-out `# MONDAY_DEBUG=1` line with a brief description to `.env.example` so operators know this optional flag exists.