### PR TITLE
fix: anthropicClient error message should mention macOS Keychain as credential fallback

### DIFF
--- a/src/llm/anthropicClient.ts
+++ b/src/llm/anthropicClient.ts
@@ -100,6 +100,6 @@ export function getClient(): Anthropic {
   }
 
   throw new Error(
-    "No Anthropic credentials found: OAuth token missing/expired at ~/.claude/.credentials.json AND ANTHROPIC_API_KEY not set in environment.",
+    "No Anthropic credentials found: OAuth token missing/expired at ~/.claude/.credentials.json or macOS Keychain (entry 'Claude Code-credentials') AND ANTHROPIC_API_KEY not set in environment.",
   );
 }


### PR DESCRIPTION
Closes #179

Auto-fix by /housekeep Stage 4.

Update the thrown Error message in `src/llm/anthropicClient.ts` to mention the macOS Keychain entry `'Claude Code-credentials'` as an additional credential lookup path alongside `~/.claude/.credentials.json`.