### PR TITLE
docs: add self-documenting forensic-recovery hint to hand-authored marker

### DIFF
--- a/docs/generated/TECHNICAL-SPEC.md
+++ b/docs/generated/TECHNICAL-SPEC.md
@@ -306,7 +306,7 @@ stories:
 
 ## story: US-11
 
-<!-- hand-authored 2026-05-11 — Max-plan OAuth only; supersedes auto-gen placeholder. Future forge_generate may overwrite. -->
+<!-- hand-authored 2026-05-11 — Max-plan OAuth only; supersedes auto-gen placeholder. Future forge_generate may overwrite. Recovery: git log -p docs/generated/TECHNICAL-SPEC.md -->
 
 ### api-contracts
 
@@ -337,7 +337,7 @@ stories:
 
 ## story: US-12
 
-<!-- hand-authored 2026-05-11 — Max-plan OAuth only; supersedes auto-gen placeholder. Future forge_generate may overwrite. -->
+<!-- hand-authored 2026-05-11 — Max-plan OAuth only; supersedes auto-gen placeholder. Future forge_generate may overwrite. Recovery: git log -p docs/generated/TECHNICAL-SPEC.md -->
 
 ### api-contracts
 


### PR DESCRIPTION
Closes #176

Auto-fix by /housekeep Stage 4.

Appended `Recovery: git log -p docs/generated/TECHNICAL-SPEC.md` to both hand-authored markers on US-11 and US-12 sections in TECHNICAL-SPEC.md. Future readers who find these sections overwritten by forge_generate now have a concrete command to recover the hand-authored content from git history.