### PR TITLE
fix: guard MONDAY_TEST_MODE auto-shutdown when appFactory explicitly supplied

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -86,6 +86,7 @@ export async function runMonday(opts: RunMondayOptions = {}): Promise<RunMondayH
     }
   }
 
+  const appFactoryExplicitlySupplied = opts.appFactory !== undefined;
   let appFactory = opts.appFactory;
   if (!appFactory && process.env.MONDAY_TEST_MODE === "1") {
     appFactory = createFakeAppFactory();
@@ -144,7 +145,9 @@ export async function runMonday(opts: RunMondayOptions = {}): Promise<RunMondayH
     // In test mode (no real Slack workspace), exit cleanly after the ready-log
     // so AC-06's shell verifier can rely on `set -o pipefail` + `timeout` without
     // the timeout-signal exit-code (124) masking the success path.
-    if (process.env.MONDAY_TEST_MODE === "1") {
+    // Guard: only fire when no explicit appFactory was injected — callers that
+    // supply a real factory intend to keep the process alive for test assertions.
+    if (process.env.MONDAY_TEST_MODE === "1" && !appFactoryExplicitlySupplied) {
       setImmediate(() => {
         shutdown().finally(() => process.exit(0));
       });


### PR DESCRIPTION
Closes #170

Auto-fix by /housekeep Stage 4.

Added `appFactoryExplicitlySupplied` flag (captured before the fake-factory assignment) and conditioned the `setImmediate(() => shutdown())` block on `!appFactoryExplicitlySupplied`. Callers that inject a real `appFactory` intend to keep the process alive for test assertions and are no longer affected by the auto-shutdown.