### PR TITLE
fix: PM2: add log_date_format + explicit out_file/error_file paths

### DIFF
--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -33,6 +33,9 @@ module.exports = {
       min_uptime: "10s",
       max_restarts: 10,
       restart_delay: 4000,
+      log_date_format: "YYYY-MM-DD HH:mm:ss Z",
+      out_file: "./logs/monday-bot-out.log",
+      error_file: "./logs/monday-bot-error.log",
     },
   ],
 };


### PR DESCRIPTION
Closes #154

Auto-fix by /housekeep Stage 4.

In the PM2 ecosystem.config.js, add `log_date_format: "YYYY-MM-DD HH:mm:ss Z"` to the apps[0] block. Also add explicit `out_file: "./logs/monday-bot-out.log"` and `error_file: "./logs/monday-bot-error.log"` entries. This improves incident diagnosis for unattended ARM Linux deployment.