### PR TITLE
fix: US-11 follow-up: add test asserting confluence subsection round-trip in loadConfig

### DIFF
--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -54,4 +54,23 @@ describe("loadConfig", () => {
     fs.writeFileSync(file, "- just\n- a\n- list\n");
     expect(() => loadConfig(file)).toThrow(ConfigLoadError);
   });
+
+  it("round-trips confluence subsection fields without mutation", () => {
+    const file = path.join(tmpDir, "config.yaml");
+    fs.writeFileSync(
+      file,
+      [
+        "confluence:",
+        '  schedule: "0 */6 * * *"',
+        "  spaces:",
+        "    - ENG",
+        "    - HR",
+        "  pageLimit: 200",
+      ].join("\n")
+    );
+    const cfg = loadConfig(file);
+    expect(cfg.confluence?.schedule).toBe("0 */6 * * *");
+    expect(cfg.confluence?.spaces).toEqual(["ENG", "HR"]);
+    expect(cfg.confluence?.pageLimit).toBe(200);
+  });
 });


### PR DESCRIPTION
Closes #143

Auto-fix by /housekeep Stage 4.

Adds a jest test that writes a config.yaml with a `confluence:` subsection (schedule, spaces, pageLimit) and asserts all three fields survive `loadConfig` unchanged. Follows the same tmpDir fixture pattern as the existing tests.