### PR TITLE
fix: US-12 E2: integration test leaks ANTHROPIC_API_KEY into process env

### DIFF
--- a/tests/integration.e2e.test.ts
+++ b/tests/integration.e2e.test.ts
@@ -23,6 +23,7 @@ import { formatAnswer } from "../src/slack/formatter";
 jest.setTimeout(60_000);
 
 const tmpDirs: string[] = [];
+const originalApiKey = process.env.ANTHROPIC_API_KEY;
 
 function mkTempDir(prefix: string): string {
   const dir = mkdtempSync(join(tmpdir(), `monday-${prefix}-`));
@@ -39,6 +40,13 @@ beforeAll(() => {
 });
 
 afterAll(() => {
+  // Restore ANTHROPIC_API_KEY to its original value to prevent env leakage
+  // between test suites.
+  if (originalApiKey === undefined) {
+    delete process.env.ANTHROPIC_API_KEY;
+  } else {
+    process.env.ANTHROPIC_API_KEY = originalApiKey;
+  }
   for (const dir of tmpDirs) {
     rmSync(dir, { recursive: true, force: true });
   }


### PR DESCRIPTION
Closes #149

Auto-fix by /housekeep Stage 4.

Saves `ANTHROPIC_API_KEY` before the suite runs (`const originalApiKey = process.env.ANTHROPIC_API_KEY`) and restores it in `afterAll` using the same pattern as `tests/generate.test.ts`. This prevents the stub key set by `beforeAll` from leaking into other test suites.