### PR TITLE
fix: US-12 E3: MONDAY_TEST_MODE=1 has zero direct test coverage

### DIFF
--- a/tests/generate.test.ts
+++ b/tests/generate.test.ts
@@ -82,4 +82,33 @@ describe("generateAnswer", () => {
     expect(result.citations).toEqual([]);
     expect(result.answer.toLowerCase()).toMatch(/find/);
   });
+
+  describe("MONDAY_TEST_MODE=1 offline path", () => {
+    afterEach(() => {
+      delete process.env.MONDAY_TEST_MODE;
+    });
+
+    test("returns deterministic offline body without calling the LLM", async () => {
+      process.env.MONDAY_TEST_MODE = "1";
+      const chunks: Chunk[] = [
+        {
+          id: "c1",
+          text: "Annual leave is 14 days per year.",
+          source: "hr-policy.txt",
+          heading: "Leave",
+        },
+      ];
+      const result = await generateAnswer("How many days of leave?", chunks);
+      // Offline body concatenates chunk text and appends [1].
+      expect(result.answer).toContain("Annual leave is 14 days per year.");
+      expect(result.answer).toContain("[1]");
+      // Citations are still populated from the chunks.
+      expect(result.citations).toHaveLength(1);
+      expect(result.citations[0]).toEqual({
+        number: 1,
+        source: "hr-policy.txt",
+        heading: "Leave",
+      });
+    });
+  });
 });


### PR DESCRIPTION
Closes #150

Auto-fix by /housekeep Stage 4.

Adds a nested `describe` block in `tests/generate.test.ts` that sets `process.env.MONDAY_TEST_MODE = '1'` before calling `generateAnswer` and asserts the deterministic offline body is returned (chunk text + `[1]` citation marker) without hitting the Anthropic SDK. `afterEach` deletes the env var to prevent leakage. No changes to `src/llm/generate.ts` were needed — the feature was already implemented.