### PR TITLE
fix: README: link 'Deployment section below' as markdown anchor

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A Slack bot that answers team questions from internal documents (shared folders,
 
 ## Status
 
-13/13 stories shipped — see [CHANGELOG](CHANGELOG.md) / [docs/PLAN_MONDAY_BOT.md](docs/PLAN_MONDAY_BOT.md) for story-level history.
+13/13 stories shipped — see [CHANGELOG](CHANGELOG.md) / [docs/PLAN_MONDAY_BOT.md](docs/PLAN_MONDAY_BOT.md) for story-level history. For production setup see the [Deployment section below](#deployment).
 
 ## What Monday does
 


### PR DESCRIPTION
Closes #162

Auto-fix by /housekeep Stage 4.

The Status blurb had no clickable link to the Deployment section. Added `[Deployment section below](#deployment)` anchor to the Status line so readers can navigate directly to the deployment instructions from the top of the README. The `## Deployment` heading produces the `#deployment` anchor on GitHub.