### PR TITLE
fix: load .env on CLI startup so documented setup works (#1165)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -167,6 +167,13 @@ export async function runMonday(opts: RunMondayOptions = {}): Promise<RunMondayH
 }
 
 if (require.main === module) {
+  // Load .env for the CLI entry path only. Native (Node >=20.12), dependency-free.
+  // A missing .env is fine — fall back to shell-exported env vars.
+  try {
+    process.loadEnvFile();
+  } catch {
+    /* no .env file — rely on shell-exported env vars */
+  }
   runMonday().catch((err) => {
     const message = err instanceof Error ? err.message : String(err);
     console.error(`Monday: unhandled error during startup: ${message}`);

--- a/tests/index.loadenv.test.ts
+++ b/tests/index.loadenv.test.ts
@@ -20,7 +20,7 @@
  *      on stderr at startup and is ignored.
  */
 
-import { execFileSync } from "node:child_process";
+import { execFileSync, execSync } from "node:child_process";
 import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -43,8 +43,10 @@ beforeAll(() => {
   // (G1) Build dist before spawning — bare `npm test` does not build, and the
   // child reads dist/index.js. CI builds first, but this keeps the test
   // self-contained locally and guarantees the dist reflects CURRENT source.
-  const npm = process.platform === "win32" ? "npm.cmd" : "npm";
-  execFileSync(npm, ["run", "build"], { cwd: REPO_ROOT, stdio: "ignore" });
+  // Use execSync (runs through a shell) so `npm` resolves on every platform —
+  // execFileSync("npm.cmd", …) trips Node's Windows batch-file-without-shell
+  // guard and throws a circular Error that jest can't serialize.
+  execSync("npm run build", { cwd: REPO_ROOT, stdio: "ignore" });
 });
 
 afterAll(() => {

--- a/tests/index.loadenv.test.ts
+++ b/tests/index.loadenv.test.ts
@@ -1,0 +1,118 @@
+/**
+ * #1165 — `.env` loading on the CLI entry path.
+ *
+ * The bot's `npm start` is `node dist/index.js`; nothing used to load `.env`,
+ * so `validateEnv()` threw "Missing required environment variables" even when
+ * `.env` was correctly filled. The fix calls `process.loadEnvFile()` (native,
+ * dependency-free, guarded by try/catch) as the first statement inside the
+ * `if (require.main === module)` CLI-entry block.
+ *
+ * These are child-process spawn tests: we run the BUILT `dist/index.js` in a
+ * temp cwd, because `process.loadEnvFile()` only fires on the CLI entry path
+ * (require.main === module), which jest's in-process import never triggers.
+ *
+ * (G1) The suite builds `dist/` in `beforeAll` so it validates CURRENT source
+ *      and is self-contained (bare `npm test` does not build).
+ * (G2) Case (a) scrubs SLACK_* by `delete`, not spread-undefined, so a leaked
+ *      literal "undefined" string can't false-green the test — the temp `.env`
+ *      is the only token source.
+ * (G3) Assertions read STDOUT only; a non-fatal pdfjs DOMMatrix warning prints
+ *      on stderr at startup and is ignored.
+ */
+
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+jest.setTimeout(120_000);
+
+const REPO_ROOT = join(__dirname, "..");
+const DIST_ENTRY = join(REPO_ROOT, "dist", "index.js");
+const READY_LOG = "Monday is listening (Socket Mode)";
+
+const tmpDirs: string[] = [];
+
+function mkTempDir(prefix: string): string {
+  const dir = mkdtempSync(join(tmpdir(), `monday-loadenv-${prefix}-`));
+  tmpDirs.push(dir);
+  return dir;
+}
+
+beforeAll(() => {
+  // (G1) Build dist before spawning — bare `npm test` does not build, and the
+  // child reads dist/index.js. CI builds first, but this keeps the test
+  // self-contained locally and guarantees the dist reflects CURRENT source.
+  const npm = process.platform === "win32" ? "npm.cmd" : "npm";
+  execFileSync(npm, ["run", "build"], { cwd: REPO_ROOT, stdio: "ignore" });
+});
+
+afterAll(() => {
+  for (const dir of tmpDirs) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("#1165 — CLI entry loads .env via process.loadEnvFile()", () => {
+  it("(a) reads tokens from a .env in cwd when they are absent from the child env", () => {
+    const dir = mkTempDir("with-env");
+    writeFileSync(
+      join(dir, ".env"),
+      [
+        "SLACK_BOT_TOKEN=xoxb-stub-1165",
+        "SLACK_APP_TOKEN=xapp-stub-1165",
+        "MONDAY_TEST_MODE=1",
+        "ANTHROPIC_API_KEY=test-stub-key",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+    writeFileSync(join(dir, "config.yaml"), "watchedFolders: []\n", "utf8");
+
+    // (G2) Build the child env by COPY + DELETE so SLACK_* are truly absent —
+    // not set to the literal string "undefined" (which validateEnv treats as
+    // present). The only source of tokens here is the temp .env.
+    const childEnv = { ...process.env };
+    delete childEnv.SLACK_BOT_TOKEN;
+    delete childEnv.SLACK_APP_TOKEN;
+    delete childEnv.MONDAY_TEST_MODE;
+
+    const result = execFileSync(process.execPath, [DIST_ENTRY], {
+      cwd: dir,
+      env: childEnv,
+      encoding: "utf8",
+      timeout: 60_000,
+    });
+
+    // execFileSync only returns (no throw) on exit code 0. MONDAY_TEST_MODE=1
+    // from the .env → fake Bolt app → ready-log → process.exit(0).
+    // (G3) Assert on stdout only — pdfjs warns on stderr.
+    expect(result).toContain(READY_LOG);
+  });
+
+  it("(b) a missing .env does not crash — guard swallows ENOENT, falls back to shell env", () => {
+    const dir = mkTempDir("no-env");
+    // config.yaml present, but NO .env file.
+    writeFileSync(join(dir, "config.yaml"), "watchedFolders: []\n", "utf8");
+
+    // Tokens passed DIRECTLY in the child env (the shell-exported fallback).
+    const childEnv = {
+      ...process.env,
+      SLACK_BOT_TOKEN: "xoxb-stub-1165",
+      SLACK_APP_TOKEN: "xapp-stub-1165",
+      MONDAY_TEST_MODE: "1",
+      ANTHROPIC_API_KEY: "test-stub-key",
+    };
+
+    const result = execFileSync(process.execPath, [DIST_ENTRY], {
+      cwd: dir,
+      env: childEnv,
+      encoding: "utf8",
+      timeout: 60_000,
+    });
+
+    // process.loadEnvFile() threw ENOENT, the guard swallowed it, and startup
+    // fell back to the shell-passed tokens → ready-log + clean exit.
+    expect(result).toContain(READY_LOG);
+  });
+});


### PR DESCRIPTION
## What

`npm start` (= `node dist/index.js`) never loaded `.env`. `dotenv` is not a dependency and nothing in the code read the file, so `validateEnv()` threw `Missing required environment variables: SLACK_BOT_TOKEN, SLACK_APP_TOKEN` even when `.env` was correctly populated — the documented setup was broken.

## Fix

Load `.env` via Node's native, dependency-free `process.loadEnvFile()` (Node >=20.12) inside the `require.main === module` CLI-entry path **only**, before `runMonday()`, guarded by try/catch so a missing `.env` falls back to shell-exported env vars. It is deliberately NOT at module top-level and NOT inside `runMonday()` — the jest suite imports the module and injects env into `runMonday`, and must never read a real `.env`.

## Verification

- `npm run build` clean (tsc); `npm test` green — **19 suites / 151 tests**, including the new `tests/index.loadenv.test.ts`.
- New test spawns the built `dist/index.js` as a child process and proves: (a) the loader IS invoked on the CLI path (tokens supplied only via a temp `.env`, SLACK_* scrubbed from the child env), and (b) a missing `.env` does not crash (guard swallows ENOENT, falls back to shell env). A mutation check (removing the loader line) turns case (a) red — the test genuinely depends on the fix.
- Live proof: bare `node dist/index.js` (no `--env-file` flag) with a real `.env` now prints `Monday is listening (Socket Mode). Slack bot token configured (xoxb-...).` instead of the Missing-env error.

## Docs

`ecosystem.config.js` and the README "Deployment" section already stated Monday reads `.env` at boot — those statements are now TRUE and left as-is. `.env.example` untouched. No doc lie remains.

refs #1165

https://claude.ai/code/session_01FV7REFAxxyRbgvfQm1fJr9