### PR TITLE
chore: release 0.12.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to monday-bot will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.12.6](https://github.com/ziyilam3999/monday-bot/compare/v0.12.5...v0.12.6) (2026-06-22)
+
+### Bug Fixes
+
+* load .env on CLI startup so documented setup works (#197)
+
 ## [0.12.5](https://github.com/ziyilam3999/monday-bot/compare/v0.12.4...v0.12.5) (2026-05-11)
 
 ### Miscellaneous

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "monday-bot",
-  "version": "0.12.5",
+  "version": "0.12.6",
   "description": "Team Slack knowledge assistant \u2014 answers from internal documents with cited, fact-based summaries.",
   "private": true,
   "type": "commonjs",


### PR DESCRIPTION
release-pr: true

Cuts v0.12.6 — bumps package.json and prepends the CHANGELOG entry for the #1165 fix (load .env on CLI startup so the documented setup works), merged in #197.

https://claude.ai/code/session_01FV7REFAxxyRbgvfQm1fJr9