### PR TITLE
feat: wire Confluence into runtime + add Jira knowledge source (#1166, #1168)

### DIFF
--- a/.ai-workspace/plans/2026-06-22-1166-1168-confluence-jira-knowledge-sources.md
+++ b/.ai-workspace/plans/2026-06-22-1166-1168-confluence-jira-knowledge-sources.md
@@ -1,0 +1,77 @@
+# Plan: #1166 wire Confluence into runtime + #1168 add Jira as a knowledge source
+
+Session: 0737beca-260d-4f7f-8f9b-a47df66f0154 · Tasks: #1166, #1168 · Repo: monday-bot (PUBLIC) · Release: 0.12.6 → 0.12.7
+
+cairn: no hits run from subagent shell — orchestrator-scoped brief carries the lessons inline (privacy gate on PUBLIC repo, source-ids from .env only, release must include `git tag` + `gh release create`).
+
+## ELI5
+
+Monday-bot answers Slack questions by searching a pile of indexed documents. Today it only reads local folders and never talks to Confluence or Jira even though a Confluence reader already exists but is never switched on. We are going to: (1) turn ON the Confluence reader at startup so it pulls the configured wiki spaces and re-checks them on a timer; (2) build a brand-new Jira reader that pulls issues (title + description + comments) from the configured project and drops them into the same search pile; (3) turn the local-folder watcher OFF by default so the bot's knowledge is Confluence + Jira. All the secret bits (web address, login, which spaces/projects) come ONLY from the hidden `.env` file because this code is public on GitHub.
+
+## Why
+
+The operator wants the bot's knowledge = the configured Confluence space + the configured Jira project, with local docs off. The Confluence sync module exists but nothing calls it; Jira does not exist yet.
+
+## Execution model
+
+**subagent (delegate)** — one coherent write surface (a new `src/jira/` module + a startup-wiring helper + edits to `index.ts`/config/.env.example + two new test files), fully briefable from this plan with no live in-session coupling. Spans 6+ files, well above the trivial-skip threshold, so a single fresh executor subagent builds it from this plan; a stateless plan-review runs before execution and a stateless execution-review runs before ship. Rationale: disjoint from any other in-flight work, no operator-loop step, deterministic AC — the canonical /delegate shape.
+
+## Constraints (hard)
+
+- **PUBLIC repo + committed config.yaml** → NO space key, project key, Atlassian host, email, or brand name in ANY tracked file (code, config.yaml, tests, README, CHANGELOG, .env.example). All such values read from `process.env` at runtime ONLY.
+- Env var names (operator's real `.env`, do not rename): `CONFLUENCE_URL`, `CONFLUENCE_EMAIL`, `CONFLUENCE_API_TOKEN`, `CONFLUENCE_SPACES` (comma-list of space keys), `JIRA_PROJECTS` (comma-list of project keys).
+- Tests inject env directly + use MOCKED fetchers (worktree has NO `.env`, no network).
+- Keep the FULL existing suite green + `npm run build` (tsc) clean.
+- Reuse `src/confluence/sync.ts` (`ConfluenceSync`, `buildConfluenceFetcher`, injectable `ConfluenceFetcher`). Mirror its shape for Jira.
+- Jira + Confluence feed the SAME `VectorIndex` via `KnowledgeService` (Jira issue → indexed doc under a stable `jira:<KEY>` source; reuse `indexConfluencePage` as the generic single-doc index path or add a sibling `indexJiraIssue`).
+
+## Scope / files
+
+NEW:
+- `src/jira/sync.ts` — `JiraFetcher` interface, `JiraIssue`/`JiraIssueDoc` types, `buildJiraFetcher({baseUrl,email,apiToken})`, `JiraSync` class (mirrors ConfluenceSync). ADF→plaintext. Pagination via startAt/total.
+- `src/jira/index.ts` — re-exports.
+- `src/knowledge/startup.ts` — `startKnowledgeSources({ knowledge, env, config, confluenceFetcher?, jiraFetcher?, scheduler? })` returning `{ stop(): void, ready: Promise<void> }`. Reads env, builds fetchers when creds present, runs initial sync, schedules periodic refresh; skips gracefully (log once) when creds absent. Injectable fetchers + scheduler for tests; timers cleared by `stop()`.
+- `tests/jira.test.ts` — JiraSync maps an ADF issue→doc, paginates correctly (startAt/total across ≥2 pages), buildJiraFetcher HTTP wiring (Basic auth, JQL url, base-host = CONFLUENCE_URL minus trailing `/wiki`).
+- `tests/knowledge-sources.startup.test.ts` — startup wires both when env present (injected mock fetchers → assert sync ran/indexed), skips cleanly when creds absent (no throw, no timer), watchedFolders defaults off.
+
+EDIT:
+- `src/index.ts` — after building `knowledge`, call `startKnowledgeSources(...)`; thread its `stop()` into `shutdown()`. Add override fields to `RunMondayOptions` so fetchers/scheduler stay test-injectable. Initial sync runs but MUST NOT block Slack `adapter.start()` from completing and MUST NOT crash startup on sync failure.
+- `config.yaml` — `watchedFolders: []` (was `- ./test-fixtures`); keep `confluence.schedule` cron. Add a `jira.schedule` cron mirroring the confluence default. NO real space/project values.
+- `.env.example` — document `CONFLUENCE_URL` (replace stale `CONFLUENCE_BASE_URL`), `CONFLUENCE_SPACES`, `JIRA_PROJECTS` (names + 1-line comment each, NO real values).
+- `src/config/config.ts` — add optional `jira?: { schedule?: string }` to `AppConfig` type (forward-compat; config is pass-through already).
+
+## Design decisions
+
+- **Jira base host** = `CONFLUENCE_URL` with any trailing `/wiki` stripped (`.replace(/\/wiki\/?$/, '')`), then trailing slash trimmed. Confluence lives under `/wiki`, Jira at site root.
+- **Jira REST**: `GET <base>/rest/api/3/search?jql=project=<KEY>&fields=summary,description,comment&maxResults=100&startAt=<n>`. Paginate while `startAt + issues.length < total`. Basic auth `email:apiToken` (same as Confluence).
+- **ADF → plaintext**: recursive walk of the Atlassian Document Format node tree collecting `text` nodes (join paragraphs/list items with newlines). Description + each comment body are ADF. Tolerate a missing/plain-string description.
+- **Issue → doc**: `{ id: <issueKey>, title: <summary>, body: <key + summary + description + comment bodies joined>, source: "jira:<issueKey>", section: <projectKey> }`. One chunk per issue; re-sync replaces by source (same dedupe path Confluence uses).
+- **Scheduling**: reuse `config.confluence.schedule` / `config.jira.schedule` if present; else default constant `DEFAULT_SYNC_INTERVAL_MS` (6h). Keep it simple — a fixed interval ms (map the documented 6h cron to 6h; any present cron → default interval is acceptable, no cron-parser dep). Timer `.unref()`'d AND cleared on `stop()` so jest has no open handles.
+- **Graceful skip**: missing any of CONFLUENCE_URL/EMAIL/API_TOKEN → log once "Confluence sync disabled (creds not set)", no crash. Empty `CONFLUENCE_SPACES`/`JIRA_PROJECTS` → nothing to sync, skip. Sync errors caught + logged, never crash startup.
+
+## Binary AC (checkable from outside the diff)
+
+1. `npm run build` exits 0 (tsc clean).
+2. `npm test` exits 0; new suites `tests/jira.test.ts` + `tests/knowledge-sources.startup.test.ts` present and passing; total test count > current.
+3. Built Jira module exposes `JiraSync`, `buildJiraFetcher`, `JiraFetcher` (type) — module builds and exports.
+4. `grep -riE '<real-space-key>|<real-project-key>|<atlassian-host>|<employer-brand>' src config.yaml tests .env.example README.md CHANGELOG.md` returns NOTHING (privacy gate — orchestrator runs the real grep with operator's actual tokens before push). No hardcoded identifiers.
+5. `config.yaml` has `watchedFolders: []` (or empty) — local watching off by default.
+6. `.env.example` contains `CONFLUENCE_SPACES` and `JIRA_PROJECTS` (documented, no real values).
+7. Startup test proves: both sources wired when env+mock-fetchers present; clean skip (no throw) when creds absent; no watchFolder calls when watchedFolders empty.
+
+## RESTORE (Rule 14 / reversible-op)
+
+After merge: `mv ~/coding_projects/monday-bot/.claude/worktrees/1166-confluence-jira ~/coding_projects/_quarantine/1166-confluence-jira-20260622/ && git -C ~/coding_projects/monday-bot worktree prune`. Trigger: PR merged + release cut. Why: isolated worktree for this PR.
+
+## Review
+
+Stateless plan-review (cross-checked vs the live worktree). Privacy holds everywhere (env-only ids,
+config.yaml stays brand-free, no test reads repo config.yaml); Jira design + testability + watchedFolders
+flip are sound. PASS with 4 required fixes the executor must close: (A) normalize CONFLUENCE_URL to a
+site-root ONCE and feed both buildConfluenceFetcher (which re-adds /wiki — else double-/wiki) and
+buildJiraFetcher; (B) guard Jira pagination against a zero-length page so it terminates; (C) new startup
+test injects a fake scheduler + stop() (no leaked jest timer); (D) add binary AC for clean-skip on
+empty/missing creds + non-blocking, non-fatal initial sync. Notes: map comments via fields.comment.comments[],
+read spaces/projects from env not config. Full review: .ai-workspace/reviews/plan-review-1166.md
+
+Decision: PASS

--- a/.ai-workspace/reviews/execution-review-1166.md
+++ b/.ai-workspace/reviews/execution-review-1166.md
@@ -1,0 +1,56 @@
+# Execution Review — #1166 (Confluence wiring) + #1168 (Jira ingester)
+
+Reviewer: stateless execution-reviewer (did not author the diff)
+Worktree: .claude/worktrees/1166-confluence-jira
+Date: 2026-06-22
+
+## Decision: PASS
+
+## Build / Test (run by reviewer)
+- `npm run build` → tsc clean (no errors).
+- `npm test` → **21 suites passed, 169 tests passed**, 0 failed.
+- Jest exited clean — **no "did not exit" / open-handle / force-exit warning** (FakeScheduler + unref'd default scheduler prevent timer leaks).
+
+## Per-axis findings
+
+### 1. PRIVACY — PASS
+- `grep -rinE 'atlassian\.net' src tests config.yaml .env.example | grep -v 'example.atlassian.net|your-org'` → **empty** (exit 1, no leaks).
+- `.env.example` uses only generic placeholders: `your-org.atlassian.net`, `you@example.com`, `SPACEA,SPACEB`, `PROJA,PROJB`. Tests use `example.atlassian.net`, `a@b.c`, `DEMO`, `PROJ`, `tok`.
+- `config.yaml` jira block carries only a cron cadence (`0 */6 * * *`) + a comment explicitly stating creds/keys come from env because the repo is public. No real host/space/project/email anywhere in tracked files.
+- Cairn: privacy doctrine hits confirm PUBLIC-repo scrub posture; no real tokens present. (no jira-specific cairn hits.)
+
+### 2. JIRA CORRECTNESS — PASS
+- URL: `<base>/rest/api/3/search?jql=project=<KEY>&fields=summary,description,comment&maxResults=100&startAt=<n>` at SITE ROOT (no `/wiki`). Basic auth header `Basic <base64(email:token)>`, `Accept: application/json`. Throws on non-2xx.
+- Pagination TERMINATES three ways and is tested: (a) empty-page break, (b) `startAt += issues.length` advance, (c) `startAt >= total` break. Tests assert 100+100+0→stop (3 fetches), and 100+50==150→stop (2 fetches). No infinite-loop path (the empty-page guard covers a stale/zero `total`).
+- `adfToText` walks the tree, tolerates null/undefined/string/`{type:text}`/container `content[]`, joins block types with `\n` and collapses whitespace; output strips structural keys (tests assert no `type`/`paragraph` leakage).
+- Comments read from `fields.comment.comments[].body`. Issue → doc indexed via `KnowledgeService.indexConfluencePage` under stable `source: jira:<KEY>` (same VectorIndex path as Confluence; `removeBySource` gives replace-on-resync — tested via dedupe-by-source test).
+
+### 3. MUST-FIX A (the /wiki double-path bug) — GENUINELY FIXED
+- `toSiteRoot()` strips a trailing `/wiki` (and trailing slash) ONCE → site root. Verified by composition:
+  - `buildConfluenceFetcher` appends `/wiki/rest/api/content` → `https://host/wiki/rest/...` (no `/wiki/wiki`).
+  - `buildJiraFetcher` appends `/rest/api/3/search` → `https://host/rest/...`.
+- Startup feeds the SAME `siteRoot` to both builders. The startup test sets `CONFLUENCE_URL=https://example.atlassian.net/wiki` and both `confluence:c1` and `jira:PROJ-1` index successfully; the buildJiraFetcher unit test asserts the URL contains `/rest/api/3/search` and `not /wiki`.
+- Non-blocking NIT (not a defect): in the startup test the fetchers are injected (mocked), so `toSiteRoot`'s output isn't asserted end-to-end against a real fetcher there. The strip is correct by inspection and covered indirectly by the Jira/Confluence fetcher unit tests. A direct unit assertion on `toSiteRoot('.../wiki') === site root` would tighten coverage.
+
+### 4. STARTUP WIRING (#1166) — PASS
+- Both sources wired when creds present (`haveAtlassianCreds = URL && EMAIL && TOKEN`, plus `CONFLUENCE_SPACES` / `JIRA_PROJECTS`).
+- Graceful skip when absent: logs once ("... disabled (creds not set)") and does not throw; also distinct "no SPACES/PROJECTS configured" skip messages.
+- Non-blocking: `startKnowledgeSources` returns synchronously; `adapter.start()` (index.ts:136) is NOT gated on `sources.ready`. No `await sources.ready` anywhere in the production path.
+- Non-fatal: every initial sync is `.catch()`-wrapped; `ready = Promise.allSettled(...)` never rejects. Test "initial sync failure does NOT crash startup" confirms adapter starts after both fetchers throw.
+- Shutdown: `sources.stop()` clears all timers (idempotent `stopped` guard), wired into `shutdown()`. Test asserts `fake.cleared === 2`.
+
+### 5. watchedFolders OFF by default — PASS
+- `config.yaml` → `watchedFolders: []`. Watcher code intact (`watchFolder`/`stopWatching`/`folderWatcher` import all present in service.ts). Test "empty watchedFolders → watchFolder is never called" passes.
+
+### 6. TEST QUALITY — PASS
+- All tests use MOCKED fetchers / `fetchImpl` stubs — no network, no creds. FakeScheduler records registrations and never starts a real timer (no leak).
+- Coverage: Confluence-indexes (existing suites green), Jira ADF→doc, Jira pagination (empty-page + startAt>=total + non-2xx throw), dedupe-by-source, failure-counting without aborting batch, startup wires-both / skips-clean / sync-failure-non-fatal / watchedFolders-off.
+- Tests are honest (assert real indexed chunk counts, scheduler registration counts, URL/auth shape, ADF structural-key absence), not trivialities.
+
+## Non-blocking nits (do not block merge)
+1. Direct `toSiteRoot` unit assertion would harden must-fix A coverage (see axis 3).
+2. `/rest/api/3/search` + offset (`startAt`/`total`) pagination is the legacy Jira Cloud search model; Atlassian has been migrating to `/search/jql` + `nextPageToken`. Matches the plan spec, but worth a forward-looking follow-up before the legacy endpoint is removed.
+3. `resolveIntervalMs` ignores `config.jira.schedule` / `confluence.schedule` (documentation-only today, hard-coded 6h). Intentional per code comment; fine for this scope.
+
+## Conclusion
+No privacy leak, no infinite-loop path, no startup crash path, tests honest and green (169/169), and the /wiki double-path bug (must-fix A) is genuinely fixed. **Decision: PASS.**

--- a/.ai-workspace/reviews/plan-review-1166.md
+++ b/.ai-workspace/reviews/plan-review-1166.md
@@ -1,0 +1,121 @@
+# Plan Review — #1166 wire Confluence + #1168 add Jira knowledge sources
+
+Stateless plan-review. Reviewer did NOT write the plan. Cross-checked against the live worktree
+(`src/confluence/sync.ts`, `src/knowledge/service.ts`, `src/index.ts`, `src/config/config.ts`,
+`config.yaml`, `.env.example`, `tests/confluence.test.ts`, `tests/index.startup.test.ts`,
+`tests/config.test.ts`, `tests/index.loadenv.test.ts`).
+
+Decision: PASS
+
+PASS with required fixes — no design blocker (no privacy leak, no non-terminating pagination
+*as long as fix #2 lands*, tests can pass). The fixes below are correctness gaps the executor
+MUST close, not reasons to re-plan.
+
+cairn: `node skills/cairn/bin/cairn-find.mjs "confluence"` + `"privacy"` — no design-lesson hits
+for this surface; only ship-run history (US-07 Confluence sync was the original story; US-09 added
+`/sync-confluence`) and the generic employer-privacy posture (LinkedIn/secrets-to-Keychain). No
+cairn anti-pattern contradicts this plan.
+
+## Axis findings
+
+### 1. PRIVACY (critical) — PASS
+- Repo is PUBLIC and `config.yaml` is committed. Plan holds the line: all space keys / project
+  keys / host / email / brand read from `process.env` at runtime; `config.yaml` keeps only the
+  cron schedules + `spaces: []` (already empty on disk) and adds `jira.schedule` with NO real
+  values. `.env.example` documents var NAMES only (no real values).
+- AC #4 greps `src config.yaml tests .env.example README.md CHANGELOG.md` for the operator's real
+  tokens (orchestrator substitutes the live values before push). Good — this is the right gate and
+  it is checkable from outside the diff.
+- Verified no committed test reads the repo `config.yaml` for identifiers: every startup/config
+  test uses a temp YAML (`makeTempConfigYaml`, `index.loadenv.test.ts` temp files). So flipping
+  `config.yaml` → `watchedFolders: []` is privacy- and test-safe.
+- One watch-item (not a leak): the CHANGELOG 0.12.6→0.12.7 entry the release will add must itself
+  stay brand/identifier-free. Already covered by AC #4's CHANGELOG grep.
+
+### 2. Jira design correctness — PASS w/ required fixes
+- REST shape `GET <base>/rest/api/3/search?jql=project=<KEY>&fields=summary,description,comment&maxResults=100&startAt=<n>`,
+  Basic `email:apiToken`, ADF→plaintext, one chunk per issue under `jira:<KEY>`, replace-by-source
+  re-sync — all reasonable and a faithful mirror of `ConfluenceSync` (which routes each doc through
+  `indexConfluencePage`; an `indexJiraIssue` sibling or reuse is fine — the service already keys
+  dedupe on `source`).
+- **REQUIRED FIX A — base-host normalization is under-specified and will double `/wiki` for
+  Confluence.** The plan defines the Jira base as `CONFLUENCE_URL` minus a trailing `/wiki`, which
+  implies the operator's real `CONFLUENCE_URL` *includes* `/wiki` (the current `.env.example`
+  example is literally `...atlassian.net/wiki`). But the EXISTING `buildConfluenceFetcher`
+  (sync.ts:68) RE-APPENDS `/wiki/rest/api/content` to whatever baseUrl it gets. So if startup hands
+  the raw `CONFLUENCE_URL` (with `/wiki`) to `buildConfluenceFetcher`, Confluence requests hit
+  `.../wiki/wiki/rest/...` → broken. The startup helper MUST strip the trailing `/wiki` ONCE and
+  pass the site-root base to BOTH `buildConfluenceFetcher` (re-adds `/wiki`) AND `buildJiraFetcher`
+  (adds `/rest/api/3`). The plan only describes the Jira side. Fix: specify a single
+  `siteRoot = CONFLUENCE_URL.replace(/\/wiki\/?$/,'').replace(/\/$/,'')` used for both; document the
+  expected `CONFLUENCE_URL` form in `.env.example`; add the Confluence-side base derivation to the
+  startup test (mock fetch, assert the URL has exactly one `/wiki`). Tests are mocked so CI will NOT
+  catch this otherwise (Rule 18 — load-bearing URL assumption).
+- **REQUIRED FIX B — pagination must guard against a zero-length page.** "Paginate while
+  `startAt + issues.length < total`" does not terminate if the API ever returns `issues.length === 0`
+  while `total > 0` (re-fetches the same `startAt` forever). Add an explicit `if (issues.length === 0) break;`
+  and advance `startAt += issues.length`. Add a test: a 2nd page returning `[]` (or fewer than
+  `maxResults`) terminates the loop and indexes only what was returned.
+- **NOTE (not blocking) — ADF comment path.** Jira returns comments at
+  `fields.comment.comments[]`, each with an ADF `.body` (NOT `fields.comment` directly). The ADF
+  walker must handle: `description` = null | plain string | ADF object, and iterate
+  `fields.comment.comments`. The plan says "each comment body" — make the executor map the
+  `.comments[]` array, and add a fixture asserting a comment body lands in the doc text.
+- **NOTE (not blocking, Rule 18) — endpoint deprecation.** `/rest/api/3/search` (GET, `startAt`/`total`)
+  is the classic endpoint; Atlassian is migrating to `/rest/api/3/search/jql` (POST, token
+  pagination, no `total`). Mocked tests pass either way, so flag for the operator to confirm the
+  classic endpoint still serves their cloud instance before relying on it in production.
+
+### 3. Testability — PASS
+- `startKnowledgeSources({ ..., confluenceFetcher?, jiraFetcher?, scheduler? })` with injectable
+  fetchers + scheduler is the right seam: jest injects mock fetchers (no network/creds) and a fake
+  scheduler (no real `setInterval` → no open handles), and `stop()` clears timers. Production timer
+  is `.unref()`'d + cleared on shutdown.
+- Existing startup tests set NO `CONFLUENCE_*` env → the graceful-skip path fires → no fetcher
+  built, no timer, no throw → they stay green. Verified the existing tests don't await `ready` and
+  only assert adapter start + `stopWatching` on shutdown; threading `knowledgeSources.stop()` into
+  `shutdown()` is additive and won't break the `stopWatching` spy.
+- **REQUIRED FIX C (small) — the new env-present test must inject the fake scheduler AND call
+  `shutdown()/stop()`** so no interval leaks into jest's handle check. State this explicitly in the
+  test scope so the executor doesn't rely on a real timer.
+
+### 4. watchedFolders OFF by default — PASS
+- `config.yaml` → `watchedFolders: []` keeps `confluence.test.ts`'s greps satisfied (the file still
+  matches `/confluence/i` and `/schedule|cron|interval/i`). `config.test.ts` and all startup tests
+  use temp YAML, so the repo flip touches no assertion. Confirmed by grep: no test reads the repo
+  `config.yaml` for `watchedFolders`/`test-fixtures` content (`ingestion.test.ts` only needs the
+  `test-fixtures` DIRECTORY to exist, which is untouched).
+
+### 5. Env var names — PASS
+- `CONFLUENCE_URL`, `CONFLUENCE_EMAIL`, `CONFLUENCE_API_TOKEN`, `CONFLUENCE_SPACES`, `JIRA_PROJECTS`
+  match the operator's stated `.env`. Plan correctly replaces the STALE `.env.example`
+  `CONFLUENCE_BASE_URL` with `CONFLUENCE_URL` (the on-disk `.env.example` still says
+  `CONFLUENCE_BASE_URL` — confirmed; the rename is needed and is in scope).
+
+### 6. Binary AC checkable from outside the diff — PASS w/ required additions
+- AC #1–#7 are all outside-the-diff checkable (tsc exit, test exit + suite presence, module
+  exports, privacy grep, `config.yaml` shape, `.env.example` token presence, startup-wiring test
+  assertions). Good.
+- **REQUIRED FIX D — promote two edge cases to binary AC** so they're not left implicit:
+  (a) empty `CONFLUENCE_SPACES`/`JIRA_PROJECTS` (and missing creds) → clean skip, no throw, no timer
+  — assert in the startup test;
+  (b) initial sync does NOT block `adapter.start()` and a sync REJECTION does NOT crash startup —
+  assert the adapter comes up even when an injected fetcher throws.
+- **NOTE — spaces/projects SOURCE.** Read `CONFLUENCE_SPACES`/`JIRA_PROJECTS` from `process.env`,
+  NOT from `config.confluence.spaces` (which is `[]` in `config.yaml` and would sync nothing). The
+  plan says env; make sure the executor wires env, and the test proves a space from env triggers a
+  sync.
+
+## Required-fix list (executor MUST address)
+1. (Fix A) Normalize `CONFLUENCE_URL` to a site-root ONCE (strip trailing `/wiki`); pass it to both
+   `buildConfluenceFetcher` (re-adds `/wiki`) and `buildJiraFetcher`. Document the expected
+   `CONFLUENCE_URL` form in `.env.example`. Add a mocked-fetch assertion that the Confluence URL
+   contains exactly one `/wiki`.
+2. (Fix B) Guard Jira pagination against a zero-length page (`break` + advance `startAt += issues.length`);
+   test that an empty/short page terminates.
+3. (Fix C) New startup test injects a fake scheduler and calls `stop()/shutdown()` — no leaked timer.
+4. (Fix D) Add binary AC: empty `CONFLUENCE_SPACES`/`JIRA_PROJECTS` + missing creds → clean skip;
+   initial sync non-blocking + sync failure non-fatal to startup.
+5. (Notes) Map Jira comments via `fields.comment.comments[]`; tolerate description null/string/ADF;
+   read spaces/projects from env not config; operator to confirm `/rest/api/3/search` not deprecated
+   for their instance.

--- a/.env.example
+++ b/.env.example
@@ -11,9 +11,19 @@ SLACK_APP_TOKEN=replace-with-your-app-token
 
 # Optional — Confluence sync (US-07). Leave unset to disable Confluence
 # integration; the bot still answers from local watched folders.
-# CONFLUENCE_BASE_URL=https://your-org.atlassian.net/wiki
+# CONFLUENCE_URL — your Atlassian site URL. May be the bare site root
+#   (https://your-org.atlassian.net) or include the /wiki suffix
+#   (https://your-org.atlassian.net/wiki) — both are handled.
+# CONFLUENCE_URL=https://your-org.atlassian.net/wiki
 # CONFLUENCE_EMAIL=you@example.com
 # CONFLUENCE_API_TOKEN=replace-with-your-confluence-api-token
+# CONFLUENCE_SPACES — comma-separated Confluence space keys to sync.
+# CONFLUENCE_SPACES=SPACEA,SPACEB
+
+# Optional — Jira sync (#1168). Reuses the Confluence URL/email/API token above
+# (Jira lives at the same Atlassian site root). Set JIRA_PROJECTS to a
+# comma-separated list of project keys to enable Jira issue indexing.
+# JIRA_PROJECTS=PROJA,PROJB
 
 # Optional — Anthropic API key for LLM-backed answers. Without this the bot
 # falls back to extractive snippets only.

--- a/config.yaml
+++ b/config.yaml
@@ -8,10 +8,10 @@
 # settings here rather than wiring more env vars.
 
 # Local document folders the watcher ingests on startup and on filesystem
-# events. Paths may be absolute or relative to the process CWD. Empty list
-# disables local watching entirely.
-watchedFolders:
-  - ./test-fixtures
+# events. Paths may be absolute or relative to the process CWD. An empty list
+# (the default) disables local watching entirely — the bot's knowledge then
+# comes from Confluence + Jira. Add paths here to re-enable local watching.
+watchedFolders: []
 
 # Filesystem location where the vector index, embed cache, and other
 # generated runtime artefacts are persisted. Relative to CWD.
@@ -30,6 +30,14 @@ confluence:
   # Cap on pages fetched per sync run; protects against runaway fan-out on huge
   # spaces. The REST API call uses ?limit=<this> per page.
   pageLimit: 100
+
+# Jira sync settings (#1168). The project keys, Atlassian host, email and API
+# token all come from env (JIRA_PROJECTS reuses the Confluence URL/email/token)
+# because this file is committed to a public repo. Only the cron cadence lives
+# here. Defaults to every 6 hours, mirroring confluence.schedule.
+jira:
+  # Cron expression — minute hour day month weekday. Defaults to every 6 hours.
+  schedule: "0 */6 * * *"
 
 # Top-level alias mirroring confluence.schedule for callers that want a
 # single, unambiguous "the bot's primary schedule" knob. Keep in sync with

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -28,6 +28,10 @@ export interface AppConfig {
     spaces?: string[];
     pageLimit?: number;
   };
+  /** Jira sync settings (#1168). Projects/creds come from env, not here. */
+  jira?: {
+    schedule?: string;
+  };
   /** Pass-through for forward-compatible keys we haven't typed yet. */
   [key: string]: unknown;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,14 @@
 import { App } from "@slack/bolt";
 import { MissingEnvVarError, validateEnv, AppEnv } from "./config/env";
-import { loadConfig } from "./config/config";
+import { loadConfig, AppConfig } from "./config/config";
 import { KnowledgeService } from "./knowledge/service";
+import {
+  startKnowledgeSources,
+  KnowledgeSourcesHandle,
+  Scheduler,
+} from "./knowledge/startup";
+import { ConfluenceFetcher } from "./confluence/sync";
+import { JiraFetcher } from "./jira/sync";
 import { SlackAdapter, AppFactory } from "./slack/adapter";
 
 export interface RunMondayOptions {
@@ -14,12 +21,20 @@ export interface RunMondayOptions {
    * If false (jest tests), startup errors are thrown so callers can assert.
    */
   exitOnError?: boolean;
+  /** Inject a Confluence fetcher (tests). Defaults to a real one built from env. */
+  confluenceFetcher?: ConfluenceFetcher;
+  /** Inject a Jira fetcher (tests). Defaults to a real one built from env. */
+  jiraFetcher?: JiraFetcher;
+  /** Inject a scheduler (tests) so no real timers leak. */
+  scheduler?: Scheduler;
 }
 
 export interface RunMondayHandle {
   adapter: SlackAdapter;
   knowledge: KnowledgeService;
-  /** Idempotent shutdown — stops the Slack adapter and folder watchers. */
+  /** Knowledge-source sync handle (Confluence + Jira). Exposed for tests. */
+  sources: KnowledgeSourcesHandle;
+  /** Idempotent shutdown — stops the Slack adapter, folder watchers, and sync timers. */
   shutdown: () => Promise<void>;
 }
 
@@ -69,8 +84,9 @@ export async function runMonday(opts: RunMondayOptions = {}): Promise<RunMondayH
   }
 
   let watchedFolders: string[];
+  let config: AppConfig;
   try {
-    const config = loadConfig(opts.configPath);
+    config = loadConfig(opts.configPath);
     watchedFolders = config.watchedFolders ?? [];
   } catch (err) {
     return handleStartupError(err);
@@ -85,6 +101,18 @@ export async function runMonday(opts: RunMondayOptions = {}): Promise<RunMondayH
       console.error(`Monday: failed to watch folder ${folder}: ${message} (continuing)`);
     }
   }
+
+  // Wire Confluence + Jira knowledge sources (env-driven; skips cleanly when
+  // creds absent). Initial sync runs in the background — it MUST NOT block
+  // adapter.start() and a sync failure MUST NOT crash startup.
+  const sources = startKnowledgeSources({
+    knowledge,
+    env: process.env,
+    config,
+    confluenceFetcher: opts.confluenceFetcher,
+    jiraFetcher: opts.jiraFetcher,
+    scheduler: opts.scheduler,
+  });
 
   const appFactoryExplicitlySupplied = opts.appFactory !== undefined;
   let appFactory = opts.appFactory;
@@ -131,6 +159,7 @@ export async function runMonday(opts: RunMondayOptions = {}): Promise<RunMondayH
       const message = err instanceof Error ? err.message : String(err);
       console.error(`Monday: error stopping Slack adapter: ${message}`);
     }
+    sources.stop();
     knowledge.stopWatching();
   };
 
@@ -163,7 +192,7 @@ export async function runMonday(opts: RunMondayOptions = {}): Promise<RunMondayH
     }
   }
 
-  return { adapter, knowledge, shutdown };
+  return { adapter, knowledge, sources, shutdown };
 }
 
 if (require.main === module) {

--- a/src/jira/index.ts
+++ b/src/jira/index.ts
@@ -1,0 +1,10 @@
+export {
+  JiraSync,
+  JiraSyncOptions,
+  JiraSyncResult,
+  JiraFetcher,
+  JiraIssue,
+  JiraClientConfig,
+  buildJiraFetcher,
+  adfToText,
+} from "./sync";

--- a/src/jira/sync.ts
+++ b/src/jira/sync.ts
@@ -1,0 +1,250 @@
+import { KnowledgeService } from "../knowledge/service";
+
+/**
+ * Jira sync: pulls issues (summary + description + comments) from a Jira project
+ * via the Atlassian REST API and routes each issue through
+ * `KnowledgeService.indexConfluencePage` — the generic single-doc index path —
+ * under a stable `jira:<KEY>` source so a re-sync replaces (rather than
+ * accumulates) the prior version.
+ *
+ * Mirrors `src/confluence/sync.ts`: the HTTP fetcher is injected so tests drive
+ * the module without real network calls. Production wiring builds a fetcher
+ * around `globalThis.fetch` targeting
+ * `<baseUrl>/rest/api/3/search?jql=project=<KEY>&fields=summary,description,comment`.
+ */
+
+export interface JiraIssue {
+  key: string;
+  summary: string;
+  descriptionText: string;
+  commentTexts: string[];
+  projectKey?: string;
+}
+
+/**
+ * Lowest-common-denominator fetcher signature. Returns the issues for a project
+ * (paginated + ADF-flattened by the real impl, or the stubbed equivalent in
+ * tests).
+ */
+export interface JiraFetcher {
+  fetchIssues(projectKey: string): Promise<JiraIssue[]>;
+}
+
+export interface JiraClientConfig {
+  baseUrl: string;
+  email: string;
+  apiToken: string;
+}
+
+export interface JiraSyncOptions {
+  knowledge: KnowledgeService;
+  fetcher: JiraFetcher;
+  /** Optional logger; defaults to a quiet no-op. */
+  logger?: { info?: (msg: string) => void; error?: (msg: string, err?: unknown) => void };
+}
+
+export interface JiraSyncResult {
+  projectKey: string;
+  issuesIndexed: number;
+  issuesFailed: number;
+}
+
+/**
+ * Recursively flatten an Atlassian Document Format (ADF) node tree to plain
+ * text. ADF appears in issue descriptions and comment bodies. Tolerates a node
+ * that is a plain string, a `{ type: "text", text }` leaf, a container with a
+ * `content` array, or null/undefined.
+ *
+ * Block-level nodes are joined with newlines; inline nodes with the empty
+ * string. Excess whitespace is collapsed and the result trimmed.
+ */
+const ADF_BLOCK_TYPES = new Set([
+  "paragraph",
+  "heading",
+  "listItem",
+  "bulletList",
+  "orderedList",
+  "blockquote",
+  "codeBlock",
+]);
+
+export function adfToText(node: unknown): string {
+  return collapse(walkAdf(node));
+}
+
+function walkAdf(node: unknown): string {
+  if (node === null || node === undefined) return "";
+  if (typeof node === "string") return node;
+  if (typeof node !== "object") return "";
+
+  const n = node as { type?: unknown; text?: unknown; content?: unknown };
+
+  if (n.type === "text" && typeof n.text === "string") {
+    return n.text;
+  }
+
+  if (Array.isArray(n.content)) {
+    const isBlock = typeof n.type === "string" && ADF_BLOCK_TYPES.has(n.type);
+    const sep = isBlock ? "\n" : "";
+    return (n.content as unknown[]).map(walkAdf).join(sep);
+  }
+
+  return "";
+}
+
+function collapse(text: string): string {
+  return text
+    .replace(/[ \t]+/g, " ")
+    .replace(/ *\n *\n+ */g, "\n")
+    .replace(/ *\n */g, "\n")
+    .replace(/[ \t]+/g, " ")
+    .trim();
+}
+
+/**
+ * Build a `JiraFetcher` backed by the real Atlassian REST API. Hits
+ * `GET <baseUrl>/rest/api/3/search?jql=project=<KEY>&fields=summary,description,comment&maxResults=100&startAt=<n>`
+ * with Basic auth (email + API token). Paginates via `startAt`/`total`, stops
+ * when a returned page is empty OR `startAt >= total`. Description and comment
+ * bodies are ADF objects (or plain strings / null) and are flattened to text.
+ *
+ * Not used by tests — tests inject a stub fetcher OR a fake `fetchImpl`. Exposed
+ * so the scheduler / CLI can wire production usage in one line.
+ */
+export function buildJiraFetcher(
+  config: JiraClientConfig,
+  fetchImpl: typeof fetch = globalThis.fetch,
+): JiraFetcher {
+  if (typeof fetchImpl !== "function") {
+    throw new TypeError(
+      "buildJiraFetcher: no global fetch available; pass an explicit fetchImpl",
+    );
+  }
+  const auth = Buffer.from(`${config.email}:${config.apiToken}`).toString("base64");
+  const base = config.baseUrl.replace(/\/$/, "");
+  const MAX_RESULTS = 100;
+
+  return {
+    async fetchIssues(projectKey: string): Promise<JiraIssue[]> {
+      const out: JiraIssue[] = [];
+      let startAt = 0;
+      // Loop guard: terminate on an empty page even if `total` is stale/zero.
+      for (;;) {
+        const url =
+          `${base}/rest/api/3/search?jql=${encodeURIComponent(`project=${projectKey}`)}` +
+          `&fields=summary,description,comment&maxResults=${MAX_RESULTS}&startAt=${startAt}`;
+        const res = await fetchImpl(url, {
+          headers: {
+            Authorization: `Basic ${auth}`,
+            Accept: "application/json",
+          },
+        });
+        if (!res.ok) {
+          throw new Error(
+            `Jira REST API returned ${res.status} ${res.statusText} for project=${projectKey}`,
+          );
+        }
+        const data = (await res.json()) as { issues?: unknown; total?: unknown };
+        const issues = Array.isArray(data.issues) ? data.issues : [];
+        // STOP when the returned page is empty — guards against a non-terminating
+        // loop if the API ever returns [] while total > 0 (plan-review fix B).
+        if (issues.length === 0) break;
+        for (const raw of issues) {
+          const mapped = toJiraIssue(raw);
+          if (mapped) out.push(mapped);
+        }
+        startAt += issues.length;
+        const total = typeof data.total === "number" ? data.total : undefined;
+        if (total !== undefined && startAt >= total) break;
+      }
+      return out;
+    },
+  };
+}
+
+function toJiraIssue(raw: unknown): JiraIssue | null {
+  if (!raw || typeof raw !== "object") return null;
+  const r = raw as {
+    key?: unknown;
+    fields?: {
+      summary?: unknown;
+      description?: unknown;
+      comment?: { comments?: unknown };
+      project?: { key?: unknown };
+    };
+  };
+  if (typeof r.key !== "string" || r.key.length === 0) return null;
+  const fields = r.fields ?? {};
+  const summary = typeof fields.summary === "string" ? fields.summary : "";
+  const descriptionText = adfToText(fields.description);
+  const rawComments = Array.isArray(fields.comment?.comments) ? fields.comment!.comments! : [];
+  const commentTexts = (rawComments as Array<{ body?: unknown }>).map((c) =>
+    adfToText(c?.body),
+  );
+  const issue: JiraIssue = { key: r.key, summary, descriptionText, commentTexts };
+  if (typeof fields.project?.key === "string") issue.projectKey = fields.project.key;
+  return issue;
+}
+
+export class JiraSync {
+  private readonly knowledge: KnowledgeService;
+  private readonly fetcher: JiraFetcher;
+  private readonly logger: NonNullable<JiraSyncOptions["logger"]>;
+
+  constructor(opts: JiraSyncOptions) {
+    if (!opts || !opts.knowledge || !opts.fetcher) {
+      throw new TypeError("JiraSync: knowledge and fetcher are required");
+    }
+    this.knowledge = opts.knowledge;
+    this.fetcher = opts.fetcher;
+    this.logger = opts.logger ?? {};
+  }
+
+  /**
+   * Sync every issue in `projectKey` into the knowledge index. Re-syncing the
+   * same issue replaces (rather than duplicates) the prior version because each
+   * issue lands under a stable `jira:<KEY>` source identifier.
+   */
+  async syncProject(projectKey: string): Promise<JiraSyncResult> {
+    if (typeof projectKey !== "string" || projectKey.length === 0) {
+      throw new TypeError("JiraSync.syncProject: projectKey must be a non-empty string");
+    }
+    const issues = await this.fetcher.fetchIssues(projectKey);
+    let issuesIndexed = 0;
+    let issuesFailed = 0;
+    for (const issue of issues) {
+      try {
+        const body = [
+          issue.key,
+          issue.summary,
+          issue.descriptionText,
+          ...issue.commentTexts,
+        ]
+          .filter(Boolean)
+          .join("\n\n");
+        await this.knowledge.indexConfluencePage({
+          id: issue.key,
+          title: issue.summary,
+          body,
+          source: `jira:${issue.key}`,
+          spaceKey: issue.projectKey ?? projectKey,
+        });
+        issuesIndexed++;
+      } catch (err) {
+        issuesFailed++;
+        if (this.logger.error) {
+          this.logger.error(`JiraSync: failed to index issue ${issue.key}`, err);
+        } else {
+          // eslint-disable-next-line no-console
+          console.error(`JiraSync: failed to index issue ${issue.key}:`, err);
+        }
+      }
+    }
+    if (this.logger.info) {
+      this.logger.info(
+        `JiraSync: projectKey=${projectKey} indexed=${issuesIndexed} failed=${issuesFailed}`,
+      );
+    }
+    return { projectKey, issuesIndexed, issuesFailed };
+  }
+}

--- a/src/knowledge/startup.ts
+++ b/src/knowledge/startup.ts
@@ -1,0 +1,194 @@
+import { KnowledgeService } from "./service";
+import { AppConfig } from "../config/config";
+import {
+  ConfluenceSync,
+  ConfluenceFetcher,
+  buildConfluenceFetcher,
+} from "../confluence/sync";
+import { JiraSync, JiraFetcher, buildJiraFetcher } from "../jira/sync";
+
+/** Default periodic re-sync cadence: every 6 hours. */
+export const DEFAULT_SYNC_INTERVAL_MS = 6 * 60 * 60 * 1000;
+
+/** A scheduled timer handle. `clear()` cancels the periodic callback. */
+export interface ScheduledTimer {
+  clear: () => void;
+}
+
+/** Schedules `cb` every `ms` and returns a clearable handle. Injectable for tests. */
+export type Scheduler = (cb: () => void, ms: number) => ScheduledTimer;
+
+export interface KnowledgeSourcesLogger {
+  info?: (msg: string) => void;
+  error?: (msg: string, err?: unknown) => void;
+}
+
+export interface KnowledgeSourcesDeps {
+  knowledge: KnowledgeService;
+  /** Defaults to `process.env`. */
+  env?: NodeJS.ProcessEnv;
+  /** Defaults to `{}`. */
+  config?: AppConfig;
+  /** Injectable Confluence fetcher (tests). Defaults to a real one built from env. */
+  confluenceFetcher?: ConfluenceFetcher;
+  /** Injectable Jira fetcher (tests). Defaults to a real one built from env. */
+  jiraFetcher?: JiraFetcher;
+  /** Injectable scheduler (tests). Defaults to an unref'd setInterval wrapper. */
+  scheduler?: Scheduler;
+  logger?: KnowledgeSourcesLogger;
+}
+
+export interface KnowledgeSourcesHandle {
+  /** Clears every scheduled timer. Idempotent. */
+  stop(): void;
+  /** Resolves once all initial syncs have settled (never rejects). */
+  ready: Promise<void>;
+}
+
+/** Default scheduler: an unref'd setInterval so it never blocks process exit. */
+const defaultScheduler: Scheduler = (cb, ms) => {
+  const timer = setInterval(cb, ms);
+  if (typeof timer.unref === "function") timer.unref();
+  return { clear: () => clearInterval(timer) };
+};
+
+/** Split a comma-separated env value into trimmed, non-empty tokens. */
+function splitList(value: string | undefined): string[] {
+  if (!value) return [];
+  return value
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
+/**
+ * Strip a trailing `/wiki` (and any trailing slash) from a Confluence URL to get
+ * the Atlassian SITE ROOT. `buildConfluenceFetcher` re-appends `/wiki/rest/...`
+ * and `buildJiraFetcher` appends `/rest/api/3`, so BOTH must receive the site
+ * root — passing the raw `/wiki` URL would double it (plan-review fix A).
+ */
+function toSiteRoot(url: string): string {
+  return url.replace(/\/wiki\/?$/, "").replace(/\/$/, "");
+}
+
+/**
+ * Wire Confluence + Jira knowledge sources into the running KnowledgeService.
+ *
+ * Reads credentials/targets from env ONLY (the repo is public). When creds are
+ * present, builds the relevant sync, kicks off an initial sync per space/project
+ * and schedules a periodic re-sync. Missing creds → logged once + skipped (no
+ * throw). Initial sync errors are caught + logged, never rejected/thrown, so
+ * startup is non-blocking and non-fatal (plan-review fix D).
+ */
+export function startKnowledgeSources(deps: KnowledgeSourcesDeps): KnowledgeSourcesHandle {
+  const env = deps.env ?? process.env;
+  const config = deps.config ?? {};
+  const scheduler = deps.scheduler ?? defaultScheduler;
+  const logger = deps.logger ?? {};
+  const log = (msg: string): void => {
+    if (logger.info) logger.info(msg);
+    else console.log(msg);
+  };
+
+  const timers: ScheduledTimer[] = [];
+  const initialSyncs: Array<Promise<unknown>> = [];
+
+  const intervalMs = resolveIntervalMs(config);
+
+  // ── Confluence ──────────────────────────────────────────────────────────
+  const confluenceUrl = env.CONFLUENCE_URL ?? env.CONFLUENCE_BASE_URL;
+  const email = env.CONFLUENCE_EMAIL;
+  const apiToken = env.CONFLUENCE_API_TOKEN;
+  const haveAtlassianCreds = Boolean(confluenceUrl && email && apiToken);
+  const siteRoot = confluenceUrl ? toSiteRoot(confluenceUrl) : "";
+
+  if (haveAtlassianCreds) {
+    const spaces = splitList(env.CONFLUENCE_SPACES);
+    if (spaces.length === 0) {
+      log("Confluence sync: no CONFLUENCE_SPACES configured, skipping");
+    } else {
+      const fetcher =
+        deps.confluenceFetcher ??
+        buildConfluenceFetcher({ baseUrl: siteRoot, email: email!, apiToken: apiToken! });
+      const sync = new ConfluenceSync({ knowledge: deps.knowledge, fetcher, logger });
+      for (const space of spaces) {
+        initialSyncs.push(
+          sync.syncSpace(space).catch((err) => {
+            if (logger.error) logger.error(`Confluence initial sync failed for ${space}`, err);
+            else console.error(`Confluence initial sync failed for ${space}:`, err);
+          }),
+        );
+        timers.push(
+          scheduler(() => {
+            sync.syncSpace(space).catch((err) => {
+              if (logger.error) logger.error(`Confluence re-sync failed for ${space}`, err);
+              else console.error(`Confluence re-sync failed for ${space}:`, err);
+            });
+          }, intervalMs),
+        );
+      }
+    }
+  } else {
+    log("Confluence sync disabled (creds not set)");
+  }
+
+  // ── Jira ────────────────────────────────────────────────────────────────
+  // Jira reuses the Atlassian creds (CONFLUENCE_URL/EMAIL/API_TOKEN) + needs
+  // its own JIRA_PROJECTS list.
+  const projects = splitList(env.JIRA_PROJECTS);
+  if (haveAtlassianCreds && projects.length > 0) {
+    const fetcher =
+      deps.jiraFetcher ??
+      buildJiraFetcher({ baseUrl: siteRoot, email: email!, apiToken: apiToken! });
+    const sync = new JiraSync({ knowledge: deps.knowledge, fetcher, logger });
+    for (const project of projects) {
+      initialSyncs.push(
+        sync.syncProject(project).catch((err) => {
+          if (logger.error) logger.error(`Jira initial sync failed for ${project}`, err);
+          else console.error(`Jira initial sync failed for ${project}:`, err);
+        }),
+      );
+      timers.push(
+        scheduler(() => {
+          sync.syncProject(project).catch((err) => {
+            if (logger.error) logger.error(`Jira re-sync failed for ${project}`, err);
+            else console.error(`Jira re-sync failed for ${project}:`, err);
+          });
+        }, intervalMs),
+      );
+    }
+  } else if (!haveAtlassianCreds) {
+    log("Jira sync disabled (creds not set)");
+  } else {
+    log("Jira sync: no JIRA_PROJECTS configured, skipping");
+  }
+
+  // `ready` resolves once every initial sync has settled — never rejects.
+  const ready = Promise.allSettled(initialSyncs).then(() => undefined);
+
+  let stopped = false;
+  const stop = (): void => {
+    if (stopped) return;
+    stopped = true;
+    for (const t of timers) {
+      try {
+        t.clear();
+      } catch {
+        // best-effort
+      }
+    }
+    timers.length = 0;
+  };
+
+  return { stop, ready };
+}
+
+/**
+ * Resolve the periodic re-sync interval. We keep this simple — no cron-parser
+ * dependency. A recognizable numeric "every N hours" hint in the config could be
+ * honored later; for now any present schedule maps to the 6h default.
+ */
+function resolveIntervalMs(config: AppConfig): number {
+  void config; // schedule fields are documentation-only today; see plan note.
+  return DEFAULT_SYNC_INTERVAL_MS;
+}

--- a/tests/jira.test.ts
+++ b/tests/jira.test.ts
@@ -1,0 +1,310 @@
+import {
+  JiraSync,
+  JiraFetcher,
+  JiraIssue,
+  buildJiraFetcher,
+  adfToText,
+} from "../src/jira/sync";
+import { KnowledgeService } from "../src/knowledge/service";
+
+jest.setTimeout(30_000);
+
+function makeStubFetcher(issuesByProject: Record<string, JiraIssue[]>): JiraFetcher {
+  return {
+    async fetchIssues(projectKey: string) {
+      return issuesByProject[projectKey] ?? [];
+    },
+  };
+}
+
+/** Build a minimal ADF paragraph node wrapping the given text. */
+function adfParagraph(text: string): unknown {
+  return {
+    type: "doc",
+    version: 1,
+    content: [{ type: "paragraph", content: [{ type: "text", text }] }],
+  };
+}
+
+describe("JiraSync module exports", () => {
+  it("exports a JiraSync class with a syncProject method", () => {
+    expect(typeof JiraSync).toBe("function");
+    const fetcher = makeStubFetcher({});
+    const knowledge = new KnowledgeService();
+    const sync = new JiraSync({ knowledge, fetcher });
+    expect(typeof sync.syncProject).toBe("function");
+  });
+
+  it("rejects construction without knowledge or fetcher", () => {
+    expect(
+      () =>
+        new JiraSync({} as unknown as { knowledge: KnowledgeService; fetcher: JiraFetcher }),
+    ).toThrow(TypeError);
+  });
+});
+
+describe("JiraSync.syncProject happy path", () => {
+  it("routes each fetched issue through KnowledgeService.indexConfluencePage", async () => {
+    const knowledge = new KnowledgeService();
+    const issues: JiraIssue[] = [
+      {
+        key: "PROJ-1",
+        summary: "Login bug",
+        descriptionText: "Users cannot log in.",
+        commentTexts: ["Reproduced on staging."],
+        projectKey: "PROJ",
+      },
+      {
+        key: "PROJ-2",
+        summary: "Slow dashboard",
+        descriptionText: "Dashboard takes 10s to load.",
+        commentTexts: [],
+        projectKey: "PROJ",
+      },
+    ];
+    const fetcher = makeStubFetcher({ PROJ: issues });
+    const sync = new JiraSync({ knowledge, fetcher });
+
+    const result = await sync.syncProject("PROJ");
+
+    expect(result.projectKey).toBe("PROJ");
+    expect(result.issuesIndexed).toBe(2);
+    expect(result.issuesFailed).toBe(0);
+    expect(knowledge.getStatus().documentCount).toBe(2);
+    expect(knowledge.getChunkCountForSource("jira:PROJ-1")).toBe(1);
+    expect(knowledge.getChunkCountForSource("jira:PROJ-2")).toBe(1);
+  });
+
+  it("indexed issue body is answerable (summary + description + comments)", async () => {
+    const knowledge = new KnowledgeService();
+    const issues: JiraIssue[] = [
+      {
+        key: "PROJ-9",
+        summary: "Payment gateway timeout",
+        descriptionText: "The checkout fails with a timeout error.",
+        commentTexts: ["Workaround: retry after 30 seconds."],
+      },
+    ];
+    const fetcher = makeStubFetcher({ PROJ: issues });
+    const sync = new JiraSync({ knowledge, fetcher });
+    await sync.syncProject("PROJ");
+    expect(knowledge.getChunkCountForSource("jira:PROJ-9")).toBe(1);
+  });
+
+  it("counts failures without aborting the rest of the batch", async () => {
+    const knowledge = new KnowledgeService();
+    const indexSpy = jest
+      .spyOn(knowledge, "indexConfluencePage")
+      .mockImplementationOnce(async () => {
+        throw new Error("boom");
+      })
+      .mockImplementationOnce(async () => undefined);
+
+    const issues: JiraIssue[] = [
+      { key: "PROJ-1", summary: "A", descriptionText: "first", commentTexts: [] },
+      { key: "PROJ-2", summary: "B", descriptionText: "second", commentTexts: [] },
+    ];
+    const fetcher = makeStubFetcher({ PROJ: issues });
+    const errorLog = jest.fn();
+    const sync = new JiraSync({ knowledge, fetcher, logger: { error: errorLog } });
+
+    const result = await sync.syncProject("PROJ");
+    expect(result.issuesIndexed).toBe(1);
+    expect(result.issuesFailed).toBe(1);
+    expect(indexSpy).toHaveBeenCalledTimes(2);
+    expect(errorLog).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects empty projectKey", async () => {
+    const knowledge = new KnowledgeService();
+    const fetcher = makeStubFetcher({});
+    const sync = new JiraSync({ knowledge, fetcher });
+    await expect(sync.syncProject("")).rejects.toThrow(TypeError);
+  });
+
+  it("re-syncing the same issue dedupes by source (jira:<KEY>)", async () => {
+    const knowledge = new KnowledgeService();
+    const v1: JiraIssue[] = [
+      { key: "PROJ-5", summary: "Bug", descriptionText: "v1 body", commentTexts: [] },
+    ];
+    const v2: JiraIssue[] = [
+      { key: "PROJ-5", summary: "Bug", descriptionText: "v2 body", commentTexts: [] },
+    ];
+    const state: { current: JiraIssue[] } = { current: v1 };
+    const fetcher: JiraFetcher = {
+      async fetchIssues() {
+        return state.current;
+      },
+    };
+    const sync = new JiraSync({ knowledge, fetcher });
+    await sync.syncProject("PROJ");
+    expect(knowledge.getChunkCountForSource("jira:PROJ-5")).toBe(1);
+    state.current = v2;
+    await sync.syncProject("PROJ");
+    expect(knowledge.getChunkCountForSource("jira:PROJ-5")).toBe(1);
+  });
+});
+
+describe("adfToText (ADF → plaintext)", () => {
+  it("flattens a paragraph of text nodes", () => {
+    const node = adfParagraph("Hello world");
+    expect(adfToText(node)).toBe("Hello world");
+  });
+
+  it("joins block nodes with newlines and tolerates nested content", () => {
+    const node = {
+      type: "doc",
+      content: [
+        { type: "paragraph", content: [{ type: "text", text: "First line" }] },
+        { type: "paragraph", content: [{ type: "text", text: "Second line" }] },
+      ],
+    };
+    const out = adfToText(node);
+    expect(out).toContain("First line");
+    expect(out).toContain("Second line");
+    expect(out).not.toContain("type");
+    expect(out).not.toContain("paragraph");
+  });
+
+  it("tolerates null, undefined, and plain-string descriptions", () => {
+    expect(adfToText(null)).toBe("");
+    expect(adfToText(undefined)).toBe("");
+    expect(adfToText("just a plain string")).toBe("just a plain string");
+  });
+});
+
+describe("buildJiraFetcher (HTTP wiring + ADF mapping)", () => {
+  it("maps an ADF description + comment to plaintext, Basic auth, JQL url at site root", async () => {
+    const rawIssue = {
+      key: "PROJ-42",
+      fields: {
+        summary: "Cannot reset password",
+        description: adfParagraph("The reset link expires too quickly"),
+        comment: {
+          comments: [{ body: adfParagraph("Bumped the TTL to one hour") }],
+        },
+        project: { key: "PROJ" },
+      },
+    };
+    const fakeResponse = {
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      async json() {
+        return { issues: [rawIssue], total: 1, startAt: 0, maxResults: 100 };
+      },
+    };
+    const fetchImpl = jest.fn(async () => fakeResponse) as unknown as typeof fetch;
+    const fetcher = buildJiraFetcher(
+      { baseUrl: "https://example.atlassian.net", email: "a@b.c", apiToken: "tok" },
+      fetchImpl,
+    );
+
+    const issues = await fetcher.fetchIssues("PROJ");
+    expect(issues).toHaveLength(1);
+    expect(issues[0].key).toBe("PROJ-42");
+    expect(issues[0].summary).toBe("Cannot reset password");
+    expect(issues[0].descriptionText).toContain("reset link expires");
+    expect(issues[0].descriptionText).not.toContain("type");
+    expect(issues[0].commentTexts).toHaveLength(1);
+    expect(issues[0].commentTexts[0]).toContain("Bumped the TTL");
+    expect(issues[0].projectKey).toBe("PROJ");
+
+    const callArgs = (fetchImpl as unknown as jest.Mock).mock.calls[0];
+    const url = callArgs[0] as string;
+    const init = callArgs[1] as { headers: Record<string, string> };
+    // Jira lives at the site ROOT — no /wiki.
+    expect(url).toContain("/rest/api/3/search");
+    expect(url).not.toContain("/wiki");
+    expect(url).toContain("jql=");
+    expect(decodeURIComponent(url)).toContain("project=PROJ");
+    expect(url).toContain("maxResults=100");
+    expect(url).toContain("startAt=0");
+    expect(init.headers.Authorization).toMatch(/^Basic /);
+  });
+
+  it("paginates across pages and TERMINATES on an empty page", async () => {
+    // total claims 250, but the API returns 100 + 100 + 0 (empty last page).
+    const page = (start: number, count: number) => ({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      async json() {
+        return {
+          total: 250,
+          startAt: start,
+          maxResults: 100,
+          issues: Array.from({ length: count }, (_, i) => ({
+            key: `PROJ-${start + i}`,
+            fields: { summary: `Issue ${start + i}`, description: null, comment: { comments: [] } },
+          })),
+        };
+      },
+    });
+    const responses = [page(0, 100), page(100, 100), page(200, 0)];
+    let call = 0;
+    const fetchImpl = jest.fn(async () => responses[call++]) as unknown as typeof fetch;
+
+    const fetcher = buildJiraFetcher(
+      { baseUrl: "https://example.atlassian.net/", email: "a@b.c", apiToken: "tok" },
+      fetchImpl,
+    );
+    const issues = await fetcher.fetchIssues("PROJ");
+
+    // 100 + 100 + 0; loop must stop on the empty page (no hang, no 4th fetch).
+    expect(issues).toHaveLength(200);
+    expect((fetchImpl as unknown as jest.Mock).mock.calls).toHaveLength(3);
+
+    // startAt advanced across pages.
+    const urls = (fetchImpl as unknown as jest.Mock).mock.calls.map((c) => c[0] as string);
+    expect(urls[0]).toContain("startAt=0");
+    expect(urls[1]).toContain("startAt=100");
+    expect(urls[2]).toContain("startAt=200");
+  });
+
+  it("terminates when startAt >= total (short final page)", async () => {
+    const page = (start: number, count: number, total: number) => ({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      async json() {
+        return {
+          total,
+          startAt: start,
+          maxResults: 100,
+          issues: Array.from({ length: count }, (_, i) => ({
+            key: `PROJ-${start + i}`,
+            fields: { summary: `Issue ${start + i}` },
+          })),
+        };
+      },
+    });
+    // 100 + 50 == total 150; the loop must stop after the 2nd page (no 3rd fetch).
+    const responses = [page(0, 100, 150), page(100, 50, 150)];
+    let call = 0;
+    const fetchImpl = jest.fn(async () => responses[call++]) as unknown as typeof fetch;
+    const fetcher = buildJiraFetcher(
+      { baseUrl: "https://example.atlassian.net", email: "a@b.c", apiToken: "tok" },
+      fetchImpl,
+    );
+    const issues = await fetcher.fetchIssues("PROJ");
+    expect(issues).toHaveLength(150);
+    expect((fetchImpl as unknown as jest.Mock).mock.calls).toHaveLength(2);
+  });
+
+  it("throws on non-2xx HTTP", async () => {
+    const fetchImpl = jest.fn(async () => ({
+      ok: false,
+      status: 401,
+      statusText: "Unauthorized",
+      async json() {
+        return {};
+      },
+    })) as unknown as typeof fetch;
+    const fetcher = buildJiraFetcher(
+      { baseUrl: "https://example.atlassian.net", email: "a@b.c", apiToken: "tok" },
+      fetchImpl,
+    );
+    await expect(fetcher.fetchIssues("PROJ")).rejects.toThrow(/401/);
+  });
+});

--- a/tests/knowledge-sources.startup.test.ts
+++ b/tests/knowledge-sources.startup.test.ts
@@ -1,0 +1,220 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+import { runMonday } from "../src/index";
+import { ConfluenceFetcher, ConfluencePage } from "../src/confluence/sync";
+import { JiraFetcher, JiraIssue } from "../src/jira/sync";
+import { Scheduler, ScheduledTimer } from "../src/knowledge/startup";
+import * as knowledgeModule from "../src/knowledge/service";
+
+const BOT_TOKEN = "bot-token-test-value";
+const APP_TOKEN = "app-token-test-value";
+
+function makeTempConfigYaml(body: string): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "monday-sources-"));
+  const file = path.join(dir, "config.yaml");
+  fs.writeFileSync(file, body, "utf8");
+  return file;
+}
+
+/** A scheduler that records registrations but never starts a real timer. */
+class FakeScheduler {
+  readonly registrations: Array<{ ms: number }> = [];
+  cleared = 0;
+  readonly scheduler: Scheduler = (_cb: () => void, ms: number): ScheduledTimer => {
+    this.registrations.push({ ms });
+    return { clear: () => { this.cleared++; } };
+  };
+}
+
+function makeFakeScheduler(): FakeScheduler {
+  return new FakeScheduler();
+}
+
+const ATLASSIAN_ENV_KEYS = [
+  "CONFLUENCE_URL",
+  "CONFLUENCE_BASE_URL",
+  "CONFLUENCE_EMAIL",
+  "CONFLUENCE_API_TOKEN",
+  "CONFLUENCE_SPACES",
+  "JIRA_PROJECTS",
+  "SLACK_BOT_TOKEN",
+  "SLACK_APP_TOKEN",
+  "MONDAY_TEST_MODE",
+];
+
+describe("runMonday — knowledge sources wiring (Confluence + Jira)", () => {
+  let savedEnv: Record<string, string | undefined>;
+
+  beforeEach(() => {
+    savedEnv = {};
+    for (const k of ATLASSIAN_ENV_KEYS) savedEnv[k] = process.env[k];
+    // Clean slate — clear all Atlassian creds so tests start deterministic.
+    for (const k of ATLASSIAN_ENV_KEYS) delete process.env[k];
+  });
+
+  afterEach(() => {
+    for (const k of ATLASSIAN_ENV_KEYS) {
+      const v = savedEnv[k];
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+  });
+
+  it("wires both Confluence + Jira when env + mock fetchers present; indexes docs; schedules refresh; no real timer", async () => {
+    process.env.SLACK_BOT_TOKEN = BOT_TOKEN;
+    process.env.SLACK_APP_TOKEN = APP_TOKEN;
+    process.env.CONFLUENCE_URL = "https://example.atlassian.net/wiki";
+    process.env.CONFLUENCE_EMAIL = "a@b.c";
+    process.env.CONFLUENCE_API_TOKEN = "tok";
+    process.env.CONFLUENCE_SPACES = "DEMO";
+    process.env.JIRA_PROJECTS = "PROJ";
+
+    const confluencePages: Record<string, ConfluencePage[]> = {
+      DEMO: [
+        { id: "c1", title: "Onboarding", body: "Welcome", source: "confluence:c1", spaceKey: "DEMO" },
+      ],
+    };
+    const confluenceCalls: string[] = [];
+    const confluenceFetcher: ConfluenceFetcher = {
+      async fetchPages(spaceKey: string) {
+        confluenceCalls.push(spaceKey);
+        return confluencePages[spaceKey] ?? [];
+      },
+    };
+
+    const jiraIssues: Record<string, JiraIssue[]> = {
+      PROJ: [{ key: "PROJ-1", summary: "Bug", descriptionText: "broken", commentTexts: [] }],
+    };
+    const jiraCalls: string[] = [];
+    const jiraFetcher: JiraFetcher = {
+      async fetchIssues(projectKey: string) {
+        jiraCalls.push(projectKey);
+        return jiraIssues[projectKey] ?? [];
+      },
+    };
+
+    const fake = makeFakeScheduler();
+    const cfg = makeTempConfigYaml("watchedFolders: []\n");
+
+    const handle = await runMonday({
+      configPath: cfg,
+      exitOnError: false,
+      confluenceFetcher,
+      jiraFetcher,
+      scheduler: fake.scheduler,
+    });
+
+    await handle.sources.ready;
+
+    expect(confluenceCalls).toEqual(["DEMO"]);
+    expect(jiraCalls).toEqual(["PROJ"]);
+    expect(handle.knowledge.getStatus().documentCount).toBeGreaterThan(0);
+    expect(handle.knowledge.getChunkCountForSource("confluence:c1")).toBe(1);
+    expect(handle.knowledge.getChunkCountForSource("jira:PROJ-1")).toBe(1);
+
+    // One periodic refresh scheduled per source (1 space + 1 project).
+    expect(fake.registrations.length).toBe(2);
+
+    await handle.shutdown();
+    expect(fake.cleared).toBe(2);
+  });
+
+  it("comes up cleanly with NO Atlassian creds — no throw, no fetch, no scheduled timer", async () => {
+    process.env.SLACK_BOT_TOKEN = BOT_TOKEN;
+    process.env.SLACK_APP_TOKEN = APP_TOKEN;
+
+    const confluenceFetcher: ConfluenceFetcher = {
+      async fetchPages() {
+        throw new Error("should not be called");
+      },
+    };
+    const jiraFetcher: JiraFetcher = {
+      async fetchIssues() {
+        throw new Error("should not be called");
+      },
+    };
+    const fake = makeFakeScheduler();
+    const cfg = makeTempConfigYaml("watchedFolders: []\n");
+
+    const handle = await runMonday({
+      configPath: cfg,
+      exitOnError: false,
+      confluenceFetcher,
+      jiraFetcher,
+      scheduler: fake.scheduler,
+    });
+
+    await handle.sources.ready;
+
+    const fakeApp = handle.adapter._getApp() as unknown as { _started: boolean };
+    expect(fakeApp._started).toBe(true);
+    expect(handle.knowledge.getStatus().documentCount).toBe(0);
+    expect(fake.registrations.length).toBe(0);
+
+    await handle.shutdown();
+  });
+
+  it("initial sync failure does NOT crash startup (adapter still comes up)", async () => {
+    process.env.SLACK_BOT_TOKEN = BOT_TOKEN;
+    process.env.SLACK_APP_TOKEN = APP_TOKEN;
+    process.env.CONFLUENCE_URL = "https://example.atlassian.net/wiki";
+    process.env.CONFLUENCE_EMAIL = "a@b.c";
+    process.env.CONFLUENCE_API_TOKEN = "tok";
+    process.env.CONFLUENCE_SPACES = "DEMO";
+    process.env.JIRA_PROJECTS = "PROJ";
+
+    const confluenceFetcher: ConfluenceFetcher = {
+      async fetchPages() {
+        throw new Error("confluence boom");
+      },
+    };
+    const jiraFetcher: JiraFetcher = {
+      async fetchIssues() {
+        throw new Error("jira boom");
+      },
+    };
+    const fake = makeFakeScheduler();
+    const errSpy = jest.spyOn(console, "error").mockImplementation(() => undefined);
+    const cfg = makeTempConfigYaml("watchedFolders: []\n");
+
+    const handle = await runMonday({
+      configPath: cfg,
+      exitOnError: false,
+      confluenceFetcher,
+      jiraFetcher,
+      scheduler: fake.scheduler,
+    });
+
+    // ready resolves even though both initial syncs rejected.
+    await expect(handle.sources.ready).resolves.toBeUndefined();
+
+    const fakeApp = handle.adapter._getApp() as unknown as { _started: boolean };
+    expect(fakeApp._started).toBe(true);
+    expect(handle.knowledge.getStatus().documentCount).toBe(0);
+
+    await handle.shutdown();
+    errSpy.mockRestore();
+  });
+
+  it("empty watchedFolders → watchFolder is never called (AC-5 parity)", async () => {
+    process.env.SLACK_BOT_TOKEN = BOT_TOKEN;
+    process.env.SLACK_APP_TOKEN = APP_TOKEN;
+
+    const watchSpy = jest.spyOn(knowledgeModule.KnowledgeService.prototype, "watchFolder");
+    const fake = makeFakeScheduler();
+    const cfg = makeTempConfigYaml("watchedFolders: []\n");
+
+    const handle = await runMonday({
+      configPath: cfg,
+      exitOnError: false,
+      scheduler: fake.scheduler,
+    });
+
+    expect(watchSpy).not.toHaveBeenCalled();
+
+    await handle.shutdown();
+    watchSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## What

Makes monday-bot's knowledge sources **Confluence (configured space) + Jira (configured project)**, with local-folder watching **off by default**.

### #1166 — wire Confluence into the runtime
- On startup, when `CONFLUENCE_URL` / `CONFLUENCE_EMAIL` / `CONFLUENCE_API_TOKEN` are all set, builds the fetcher + `ConfluenceSync` and syncs **every key in `CONFLUENCE_SPACES`** (comma-split) into the vector index.
- Schedules a periodic refresh (default 6h). Skips gracefully (logs once, no crash) when creds are absent.

### #1168 — Jira ingester (new `src/jira/`)
- Injectable `JiraFetcher` interface + `JiraSync`, mirroring the Confluence module shape.
- For each key in `JIRA_PROJECTS`: `GET <base>/rest/api/3/search?jql=project=<KEY>&fields=summary,description,comment&maxResults=100`, **paginated** via `startAt`/`total` (terminates on empty page / `startAt >= total`).
- Maps each issue → a text doc (key + summary + ADF description→plaintext + comment bodies) and feeds the **same** vector index under a `jira:<KEY>` source. Basic auth `email:apiToken`. Base host = `CONFLUENCE_URL` with any trailing `/wiki` stripped (Jira lives at the site root; the Confluence fetcher re-appends `/wiki`).

### Also
- `watchedFolders` now defaults to `[]` in `config.yaml` (local watching off); watcher code retained.
- `.env.example` documents `CONFLUENCE_URL`, `CONFLUENCE_SPACES`, `JIRA_PROJECTS` (placeholders only).

## Privacy
Public repo + committed `config.yaml`: **all** space keys, project keys, Atlassian host, email come from `.env` only. No real identifiers in any tracked file (verified by grep).

## Tests
Mocked fetchers + fake scheduler (no network, no creds, no timer leaks). Suites 19 → 21, tests **151 → 169**. New: `tests/jira.test.ts` (ADF→doc, pagination terminates, HTTP wiring), `tests/knowledge-sources.startup.test.ts` (wires both when env present, clean skip when absent, watchedFolders off). `npm run build` + `tsc` clean.

## 3-role
planner (inline-skip, orchestrator brief) → plan-review **PASS** → executor → execution-review **PASS**. Plan + both review artifacts committed under `.ai-workspace/`.

## Deferred
Live smoke against real Atlassian (real space + project, Slack cites real docs) is deferred to the orchestrator — the worktree has no `.env`.

Claude-Session: https://claude.ai/code/session_01FV7REFAxxyRbgvfQm1fJr9