### PR TITLE
chore: release 0.12.7 (#199)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to monday-bot will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.12.7](https://github.com/ziyilam3999/monday-bot/compare/v0.12.6...v0.12.7) (2026-06-22)
+
+### Features
+
+* wire Confluence into the runtime and add Jira as a knowledge source (#199)
+
 ## [0.12.6](https://github.com/ziyilam3999/monday-bot/compare/v0.12.5...v0.12.6) (2026-06-22)
 
 ### Bug Fixes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "monday-bot",
-  "version": "0.12.6",
+  "version": "0.12.7",
   "description": "Team Slack knowledge assistant \u2014 answers from internal documents with cited, fact-based summaries.",
   "private": true,
   "type": "commonjs",


### PR DESCRIPTION
Cuts **v0.12.7** — bumps `package.json` and prepends the CHANGELOG entry for the #1166 + #1168 work (wire Confluence into the runtime and add Jira as a knowledge source), merged in #199.

Claude-Session: https://claude.ai/code/session_01FV7REFAxxyRbgvfQm1fJr9