### PR TITLE
fix: migrate Jira ingester to /rest/api/3/search/jql (410 Gone) (#1168)

### DIFF
--- a/.ai-workspace/plans/2026-06-23-1168-jira-search-jql-migration.md
+++ b/.ai-workspace/plans/2026-06-23-1168-jira-search-jql-migration.md
@@ -1,0 +1,129 @@
+# #1168 — Jira ingester migrate to /rest/api/3/search/jql + per-source index-count log
+
+## ELI5
+The robot used to ask Jira for tickets through an old door (`/rest/api/3/search`).
+Atlassian bricked that door — now it answers "410 Gone", so the live sync breaks.
+We point the robot at the new door (`/rest/api/3/search/jql`). The new door hands
+back pages using a "next-page ticket" (`nextPageToken`) instead of counting from a
+total, so we change how we flip through pages. We also add one tiny status line per
+source at startup ("confluence:SPACE indexed N pages" / "jira:KEY indexed M issues")
+so the operator can confirm BOTH sources came up by reading stdout.
+
+## Execution model
+- **subagent** (knob A = `delegate`, knob B = `test-oracle` + `reviewer`). Single coherent
+  surface (2 src files + 2 test files), briefable, exact fix specified by the operator.
+  Planner inline-skipped (orchestrator brief gives the exact contract); plan-review,
+  executor, and execution-review run as REAL stateless subagents per the 3-role model.
+  Rationale: >10 LOC across 4 files -> above trivial-skip, so it is delegated, not inlined.
+
+## Context / cairn
+- CONFIRMED-LIVE contract (operator-verified, do not second-guess):
+  - OLD `GET <base>/rest/api/3/search?jql=...&startAt=N&maxResults=100` -> HTTP 410 Gone (removed).
+  - NEW `GET <base>/rest/api/3/search/jql?jql=<encoded>&fields=summary,description,comment&maxResults=100`
+    -> 200. Shape `{ issues: [...], nextPageToken: string|undefined, isLast: boolean }`.
+    Token pagination: pass `&nextPageToken=<token>` on subsequent pages; STOP on
+    `isLast === true` OR no `nextPageToken`. NO `total` field.
+- cairn: no hits for "jira search jql 410" (plan-reviewer subagent to re-run `node skills/cairn/bin/cairn-find.mjs`).
+- Files: src/jira/sync.ts (fetcher), src/knowledge/startup.ts (count log), tests/jira.test.ts,
+  tests/knowledge-sources.startup.test.ts.
+
+## Changes
+
+### FIX 1 — src/jira/sync.ts `buildJiraFetcher.fetchIssues`
+- URL -> `<base>/rest/api/3/search/jql?jql=<encoded project=KEY>&fields=summary,description,comment&maxResults=100`;
+  append `&nextPageToken=<token>` ONLY on pages after the first.
+- Replace startAt/total loop with token pagination:
+  - `let token: string | undefined; const out = []; let pages = 0;`
+  - loop: build url (+token if set), fetch, !res.ok -> throw (keep existing message),
+    parse `{ issues?, nextPageToken?, isLast? }`, map+push issues,
+    `token = resp.nextPageToken`, `pages++`.
+  - break when `resp.isLast === true || !token`.
+  - infinite-loop guards: cap pages at a sane max (e.g. 1000) AND break if a page
+    returns 0 issues with no token.
+- Keep Basic auth, ADF->text mapping (`toJiraIssue`/`adfToText`), `jira:<KEY>` source id.
+- Update stale doc comments (~line 13 module doc, ~106-108 buildJiraFetcher doc) to new
+  endpoint + token pagination (remove startAt/total wording).
+
+### FIX 2 — src/knowledge/startup.ts (observability)
+- After each source's initial sync resolves, log a one-liner via the existing `log()`
+  helper (logger.info -> console.log fallback; same interface already used):
+  - Confluence: `.then((res) => log(\`confluence:${space} indexed ${res.pagesIndexed} pages\`))`
+    before the existing `.catch`.
+  - Jira: `.then((res) => log(\`jira:${project} indexed ${res.issuesIndexed} issues\`))`
+    before the existing `.catch`.
+- Existing caught-error logs stay. No new console.log noise outside the logger abstraction.
+
+## Tests
+- tests/jira.test.ts (rewrite the `buildJiraFetcher` HTTP block):
+  - (a) request URL hits `/rest/api/3/search/jql` and NOT the bare old `/search?`;
+    first call has NO `nextPageToken`.
+  - (b) token pagination across >=2 pages: page1 `{issues, nextPageToken:"t1", isLast:false}`,
+    page2 `{issues, nextPageToken:undefined, isLast:true}`; assert 2 fetches, 2nd url
+    contains `nextPageToken=t1`, stops (no 3rd fetch), all issues accumulated.
+  - keep: single-page ADF map test (now returns `{issues, isLast:true}`), non-2xx throw test.
+  - drop the startAt/total-specific tests (contract removed).
+- tests/knowledge-sources.startup.test.ts:
+  - extend the "wires both" test to spy on `console.log` and assert it received
+    `confluence:DEMO indexed 1 pages` and `jira:PROJ indexed 1 issues`.
+
+## Binary AC
+- `npm run build` exits 0 (tsc clean).
+- `npm test` exits 0 (full suite green).
+- `grep -n "search/jql" src/jira/sync.ts` matches; `grep -nE "/search\?|startAt|\.total" src/jira/sync.ts` returns nothing.
+- `grep -nE "indexed .* pages|indexed .* issues" src/knowledge/startup.ts` matches both lines.
+
+## Out of scope
+- No change to ADF mapping, auth, source-id, or scheduling.
+
+## Deferred-follow-ups:
+- Live Jira smoke against the real GET project (GET-798) + confirm both per-source
+  counts from stdout — DEFERRED to the orchestrator post-merge (no .env in worktree).
+  -> orchestrator owns; not a code task.
+- none others.
+
+## Review
+
+Reviewed by stateless plan-reviewer (3ROLE_TASK:1168 ROLE:plan-review).
+
+### Verified against source
+- **Endpoint migration matches reality.** `src/jira/sync.ts:132-159` currently builds the
+  REMOVED `/rest/api/3/search?...&startAt=N` URL and paginates on `startAt`/`total`. The plan's
+  FIX 1 (swap to `/rest/api/3/search/jql`, token pagination on `nextPageToken`/`isLast`, drop
+  `startAt`/`total`) is the correct delta. Stale doc comments DO exist at module-doc line 13 and
+  `buildJiraFetcher` doc lines 106-108 — the plan calls them out explicitly. Good.
+- **Token-pagination design is correct + loop-safe.** Stop on `isLast === true || !token`, plus
+  two independent infinite-loop guards (page cap ~1000 AND break on a 0-issue page with no token).
+  Adequate for a server that misbehaves (never sets `isLast`, keeps echoing a token).
+- **Preserved invariants confirmed.** ADF mapping (`adfToText`/`toJiraIssue`), Basic auth header,
+  `fields=summary,description,comment`, and the `jira:<KEY>` source id all live OUTSIDE the
+  paginate loop body the plan rewrites — none are touched. `JiraFetcher.fetchIssues(projectKey)
+  -> JiraIssue[]` signature is unchanged, so `JiraSync` and all stub-fetcher tests stay valid.
+- **FIX 2 is feasible as written.** `JiraSyncResult.issuesIndexed` (sync.ts:48) and
+  `ConfluenceSyncResult.pagesIndexed` (confluence/sync.ts:36-38, returned at :178) both exist, so
+  `.then((res) => log(...))` reads real fields. The `log()` helper (startup.ts:88-91) routes through
+  `logger.info` else `console.log` — no rogue `console.log`. The `.then` is chained BEFORE the
+  existing `.catch`, so a count line is emitted only on a RESOLVED initial sync (correct: never
+  claim "indexed N" on a failure). Scheduled re-syncs intentionally get no count line.
+- **Test plan proves the change.** (a) URL hits `/search/jql`, first call has no `nextPageToken`;
+  (b) ≥2-page token pagination asserts the 2nd URL carries `nextPageToken=t1`, stops on
+  `isLast:true`, accumulates all issues; ADF single-page + non-2xx-throw retained; startAt/total
+  tests dropped (contract removed). Startup test spies `console.log` for both count lines — note the
+  "wires both" test passes NO `logger`, so `log()` falls to `console.log` and the spy fires (the
+  sibling failure test already spies `console.error`, no conflict).
+
+### Binary AC sanity
+- `grep -nE "/search\?|startAt|\.total"` returns nothing AFTER the fix: the new URL is
+  `/search/jql?` (does NOT contain the literal `/search?`), and `startAt`/`total` leave both code
+  and the rewritten doc comment. Internally consistent.
+
+### Notes for the executor (non-blocking)
+1. Add the `console.log` spy to the "wires both" startup test only; restore it (`mockRestore`) in
+   that test to avoid leaking the spy into siblings.
+2. Keep the existing non-2xx throw message verbatim so the `rejects.toThrow(/401/)` test still passes.
+3. When rewriting the `buildJiraFetcher` doc comment, scrub EVERY `startAt`/`total` token there — the
+   grep AC reads the whole file, comments included.
+
+cairn: no hits for "jira pagination" / "nextPageToken" / "atlassian 410" (only an unrelated #94
+backlog-triage line and substring noise in session-notes) — no prior art to reconcile.
+
+Decision: PASS

--- a/.ai-workspace/reviews/1168-execution-review.md
+++ b/.ai-workspace/reviews/1168-execution-review.md
@@ -1,0 +1,29 @@
+# Execution Review — #1168 Jira search/jql migration + per-source index-count log
+
+Tag: 3ROLE_TASK:1168 ROLE:execution-review (stateless, independent — did not author this code).
+
+## Build + Test (independently run)
+- `npm run build` → exit 0 (tsc clean).
+- `npm test` → exit 0. **21 suites passed / 21 total; 168 tests passed / 168 total.** (console.log noise is pre-existing pdfjs-dist canvas-polyfill warnings, unrelated to this change.)
+
+## Contract verification (src/jira/sync.ts)
+- **New endpoint**: URL is `${base}/rest/api/3/search/jql?...` (sync.ts:143). The removed `/rest/api/3/search?` form is gone from code AND comments.
+- **Cursor on later pages only**: `let token: string | undefined` starts undefined; `if (token) url += \`&nextPageToken=${encodeURIComponent(token)}\`` (sync.ts:145) → first request omits the token, subsequent requests append it. Token is URL-encoded.
+- **Response shape**: parsed as `{ issues?, nextPageToken?, isLast? }` (sync.ts:157-161). No `total` field read anywhere.
+- **Stop conditions + loop guards**: primary stop `if (data.isLast === true || !token) break;` (sync.ts:169); plus `if (pages >= MAX_PAGES) break;` (cap 1000) and `if (issues.length === 0) break;`. Traced all termination cases: isLast true ✓, no token ✓, never-isLast-with-token → page cap ✓, 0-issue page that still echoes a token → falls through primary check, caught by the final 0-issue guard ✓. Terminates in every case.
+- **Preserved invariants**: Basic auth header (built outside the loop, unchanged), ADF→text mapping via `toJiraIssue`/`adfToText` (untouched), `jira:<KEY>` source id (untouched), non-2xx throw with the verbatim message (sync.ts:153-155) — all intact.
+- **Residue check**: `grep -nE "/search\?|startAt|\.total"` returns nothing in src/jira/sync.ts (the only matches in a broader grep were `nextPageToken` lines). Stale doc comments scrubbed of startAt/total wording.
+
+## Contract verification (src/knowledge/startup.ts)
+- Both count lines emitted via the existing `log()` abstraction (`logger.info` else `console.log`, startup.ts:88-91): `confluence:${space} indexed ${res.pagesIndexed} pages` (line 118) and `jira:${project} indexed ${res.issuesIndexed} issues` (line 151).
+- **Chained BEFORE `.catch`**: `sync.syncProject(...).then((res) => log(...)).catch(...)` — the count line fires ONLY on a resolved initial sync, never on a failed one. Correct (won't claim "indexed N" on failure).
+- No rogue `console.log` in the changed source paths. The only `console.log` in startup.ts is the `log()` helper's fallback (the logger abstraction itself), which is legitimate. Other repo `console.log`s (index.ts, slack/commands.ts) are pre-existing and untouched.
+
+## Tests assert the change
+- tests/jira.test.ts: URL hits `/rest/api/3/search/jql` and NOT `/wiki`; first call has NO `nextPageToken`; ≥2-page token pagination asserts exactly 2 fetches, 2nd URL carries `nextPageToken=t1`, stops on `isLast:true` (no 3rd fetch), all 200 issues accumulated; ADF single-page test retained (now `{issues, isLast:true}`); non-2xx throw retained. startAt/total-specific tests removed (contract gone).
+- tests/knowledge-sources.startup.test.ts: spies `console.log` (no logger passed → falls back), asserts `confluence:DEMO indexed 1 pages` and `jira:PROJ indexed 1 issues`; spy restored via `mockRestore`.
+
+## Defects
+None. Build + test green, contract fully satisfied.
+
+Decision: PASS

--- a/src/jira/sync.ts
+++ b/src/jira/sync.ts
@@ -10,7 +10,8 @@ import { KnowledgeService } from "../knowledge/service";
  * Mirrors `src/confluence/sync.ts`: the HTTP fetcher is injected so tests drive
  * the module without real network calls. Production wiring builds a fetcher
  * around `globalThis.fetch` targeting
- * `<baseUrl>/rest/api/3/search?jql=project=<KEY>&fields=summary,description,comment`.
+ * `<baseUrl>/rest/api/3/search/jql?jql=project=<KEY>&fields=summary,description,comment`
+ * and flips through pages via the `nextPageToken` cursor the endpoint returns.
  */
 
 export interface JiraIssue {
@@ -103,10 +104,13 @@ function collapse(text: string): string {
 
 /**
  * Build a `JiraFetcher` backed by the real Atlassian REST API. Hits
- * `GET <baseUrl>/rest/api/3/search?jql=project=<KEY>&fields=summary,description,comment&maxResults=100&startAt=<n>`
- * with Basic auth (email + API token). Paginates via `startAt`/`total`, stops
- * when a returned page is empty OR `startAt >= total`. Description and comment
- * bodies are ADF objects (or plain strings / null) and are flattened to text.
+ * `GET <baseUrl>/rest/api/3/search/jql?jql=project=<KEY>&fields=summary,description,comment&maxResults=100`
+ * with Basic auth (email + API token). Paginates via the `nextPageToken` cursor:
+ * the first request omits the token, each response returns
+ * `{ issues, nextPageToken, isLast }`, and subsequent requests append
+ * `&nextPageToken=<token>`. Stops when `isLast === true` OR no token is returned.
+ * Description and comment bodies are ADF objects (or plain strings / null) and
+ * are flattened to text.
  *
  * Not used by tests — tests inject a stub fetcher OR a fake `fetchImpl`. Exposed
  * so the scheduler / CLI can wire production usage in one line.
@@ -123,16 +127,22 @@ export function buildJiraFetcher(
   const auth = Buffer.from(`${config.email}:${config.apiToken}`).toString("base64");
   const base = config.baseUrl.replace(/\/$/, "");
   const MAX_RESULTS = 100;
+  // Hard cap on pages walked — defends against a server that never sets
+  // `isLast` and keeps echoing a cursor (1000 pages * 100 = 100k issues).
+  const MAX_PAGES = 1000;
 
   return {
     async fetchIssues(projectKey: string): Promise<JiraIssue[]> {
       const out: JiraIssue[] = [];
-      let startAt = 0;
-      // Loop guard: terminate on an empty page even if `total` is stale/zero.
+      let token: string | undefined;
+      let pages = 0;
+      // Cursor pagination: the first request omits the token; each response
+      // returns the next page's cursor. Stop on `isLast === true` OR no token.
       for (;;) {
-        const url =
-          `${base}/rest/api/3/search?jql=${encodeURIComponent(`project=${projectKey}`)}` +
-          `&fields=summary,description,comment&maxResults=${MAX_RESULTS}&startAt=${startAt}`;
+        let url =
+          `${base}/rest/api/3/search/jql?jql=${encodeURIComponent(`project=${projectKey}`)}` +
+          `&fields=summary,description,comment&maxResults=${MAX_RESULTS}`;
+        if (token) url += `&nextPageToken=${encodeURIComponent(token)}`;
         const res = await fetchImpl(url, {
           headers: {
             Authorization: `Basic ${auth}`,
@@ -144,18 +154,24 @@ export function buildJiraFetcher(
             `Jira REST API returned ${res.status} ${res.statusText} for project=${projectKey}`,
           );
         }
-        const data = (await res.json()) as { issues?: unknown; total?: unknown };
+        const data = (await res.json()) as {
+          issues?: unknown;
+          nextPageToken?: unknown;
+          isLast?: unknown;
+        };
         const issues = Array.isArray(data.issues) ? data.issues : [];
-        // STOP when the returned page is empty — guards against a non-terminating
-        // loop if the API ever returns [] while total > 0 (plan-review fix B).
-        if (issues.length === 0) break;
         for (const raw of issues) {
           const mapped = toJiraIssue(raw);
           if (mapped) out.push(mapped);
         }
-        startAt += issues.length;
-        const total = typeof data.total === "number" ? data.total : undefined;
-        if (total !== undefined && startAt >= total) break;
+        token = typeof data.nextPageToken === "string" ? data.nextPageToken : undefined;
+        pages++;
+        // Primary stop: the server says this was the last page, or no cursor.
+        if (data.isLast === true || !token) break;
+        // Loop guards (server misbehaving): bail after a sane page cap, and on a
+        // 0-issue page that still hands back a token (would otherwise spin).
+        if (pages >= MAX_PAGES) break;
+        if (issues.length === 0) break;
       }
       return out;
     },

--- a/src/knowledge/startup.ts
+++ b/src/knowledge/startup.ts
@@ -113,10 +113,13 @@ export function startKnowledgeSources(deps: KnowledgeSourcesDeps): KnowledgeSour
       const sync = new ConfluenceSync({ knowledge: deps.knowledge, fetcher, logger });
       for (const space of spaces) {
         initialSyncs.push(
-          sync.syncSpace(space).catch((err) => {
-            if (logger.error) logger.error(`Confluence initial sync failed for ${space}`, err);
-            else console.error(`Confluence initial sync failed for ${space}:`, err);
-          }),
+          sync
+            .syncSpace(space)
+            .then((res) => log(`confluence:${space} indexed ${res.pagesIndexed} pages`))
+            .catch((err) => {
+              if (logger.error) logger.error(`Confluence initial sync failed for ${space}`, err);
+              else console.error(`Confluence initial sync failed for ${space}:`, err);
+            }),
         );
         timers.push(
           scheduler(() => {
@@ -143,10 +146,13 @@ export function startKnowledgeSources(deps: KnowledgeSourcesDeps): KnowledgeSour
     const sync = new JiraSync({ knowledge: deps.knowledge, fetcher, logger });
     for (const project of projects) {
       initialSyncs.push(
-        sync.syncProject(project).catch((err) => {
-          if (logger.error) logger.error(`Jira initial sync failed for ${project}`, err);
-          else console.error(`Jira initial sync failed for ${project}:`, err);
-        }),
+        sync
+          .syncProject(project)
+          .then((res) => log(`jira:${project} indexed ${res.issuesIndexed} issues`))
+          .catch((err) => {
+            if (logger.error) logger.error(`Jira initial sync failed for ${project}`, err);
+            else console.error(`Jira initial sync failed for ${project}:`, err);
+          }),
       );
       timers.push(
         scheduler(() => {

--- a/tests/jira.test.ts
+++ b/tests/jira.test.ts
@@ -191,7 +191,7 @@ describe("buildJiraFetcher (HTTP wiring + ADF mapping)", () => {
       status: 200,
       statusText: "OK",
       async json() {
-        return { issues: [rawIssue], total: 1, startAt: 0, maxResults: 100 };
+        return { issues: [rawIssue], isLast: true };
       },
     };
     const fetchImpl = jest.fn(async () => fakeResponse) as unknown as typeof fetch;
@@ -213,27 +213,31 @@ describe("buildJiraFetcher (HTTP wiring + ADF mapping)", () => {
     const callArgs = (fetchImpl as unknown as jest.Mock).mock.calls[0];
     const url = callArgs[0] as string;
     const init = callArgs[1] as { headers: Record<string, string> };
-    // Jira lives at the site ROOT — no /wiki.
-    expect(url).toContain("/rest/api/3/search");
+    // New JQL search endpoint at the site ROOT — no /wiki, not the removed /search?.
+    expect(url).toContain("/rest/api/3/search/jql");
     expect(url).not.toContain("/wiki");
     expect(url).toContain("jql=");
     expect(decodeURIComponent(url)).toContain("project=PROJ");
     expect(url).toContain("maxResults=100");
-    expect(url).toContain("startAt=0");
+    // First request carries no cursor.
+    expect(url).not.toContain("nextPageToken");
     expect(init.headers.Authorization).toMatch(/^Basic /);
   });
 
-  it("paginates across pages and TERMINATES on an empty page", async () => {
-    // total claims 250, but the API returns 100 + 100 + 0 (empty last page).
-    const page = (start: number, count: number) => ({
+  it("paginates via nextPageToken and STOPS on isLast:true", async () => {
+    const page = (
+      start: number,
+      count: number,
+      nextPageToken: string | undefined,
+      isLast: boolean,
+    ) => ({
       ok: true,
       status: 200,
       statusText: "OK",
       async json() {
         return {
-          total: 250,
-          startAt: start,
-          maxResults: 100,
+          nextPageToken,
+          isLast,
           issues: Array.from({ length: count }, (_, i) => ({
             key: `PROJ-${start + i}`,
             fields: { summary: `Issue ${start + i}`, description: null, comment: { comments: [] } },
@@ -241,7 +245,8 @@ describe("buildJiraFetcher (HTTP wiring + ADF mapping)", () => {
         };
       },
     });
-    const responses = [page(0, 100), page(100, 100), page(200, 0)];
+    // Page 1 hands back cursor "t1"; page 2 is the last page (no cursor).
+    const responses = [page(0, 100, "t1", false), page(100, 100, undefined, true)];
     let call = 0;
     const fetchImpl = jest.fn(async () => responses[call++]) as unknown as typeof fetch;
 
@@ -251,45 +256,14 @@ describe("buildJiraFetcher (HTTP wiring + ADF mapping)", () => {
     );
     const issues = await fetcher.fetchIssues("PROJ");
 
-    // 100 + 100 + 0; loop must stop on the empty page (no hang, no 4th fetch).
+    // 100 + 100 accumulated; loop stops on isLast:true (no 3rd fetch).
     expect(issues).toHaveLength(200);
-    expect((fetchImpl as unknown as jest.Mock).mock.calls).toHaveLength(3);
-
-    // startAt advanced across pages.
-    const urls = (fetchImpl as unknown as jest.Mock).mock.calls.map((c) => c[0] as string);
-    expect(urls[0]).toContain("startAt=0");
-    expect(urls[1]).toContain("startAt=100");
-    expect(urls[2]).toContain("startAt=200");
-  });
-
-  it("terminates when startAt >= total (short final page)", async () => {
-    const page = (start: number, count: number, total: number) => ({
-      ok: true,
-      status: 200,
-      statusText: "OK",
-      async json() {
-        return {
-          total,
-          startAt: start,
-          maxResults: 100,
-          issues: Array.from({ length: count }, (_, i) => ({
-            key: `PROJ-${start + i}`,
-            fields: { summary: `Issue ${start + i}` },
-          })),
-        };
-      },
-    });
-    // 100 + 50 == total 150; the loop must stop after the 2nd page (no 3rd fetch).
-    const responses = [page(0, 100, 150), page(100, 50, 150)];
-    let call = 0;
-    const fetchImpl = jest.fn(async () => responses[call++]) as unknown as typeof fetch;
-    const fetcher = buildJiraFetcher(
-      { baseUrl: "https://example.atlassian.net", email: "a@b.c", apiToken: "tok" },
-      fetchImpl,
-    );
-    const issues = await fetcher.fetchIssues("PROJ");
-    expect(issues).toHaveLength(150);
     expect((fetchImpl as unknown as jest.Mock).mock.calls).toHaveLength(2);
+
+    const urls = (fetchImpl as unknown as jest.Mock).mock.calls.map((c) => c[0] as string);
+    // First request omits the cursor; second carries nextPageToken=t1.
+    expect(urls[0]).not.toContain("nextPageToken");
+    expect(urls[1]).toContain("nextPageToken=t1");
   });
 
   it("throws on non-2xx HTTP", async () => {

--- a/tests/knowledge-sources.startup.test.ts
+++ b/tests/knowledge-sources.startup.test.ts
@@ -97,6 +97,9 @@ describe("runMonday — knowledge sources wiring (Confluence + Jira)", () => {
 
     const fake = makeFakeScheduler();
     const cfg = makeTempConfigYaml("watchedFolders: []\n");
+    // No `logger` is passed, so `log()` falls back to console.log — spy on it to
+    // assert the per-source index-count lines are emitted after initial sync.
+    const logSpy = jest.spyOn(console, "log").mockImplementation(() => undefined);
 
     const handle = await runMonday({
       configPath: cfg,
@@ -114,11 +117,16 @@ describe("runMonday — knowledge sources wiring (Confluence + Jira)", () => {
     expect(handle.knowledge.getChunkCountForSource("confluence:c1")).toBe(1);
     expect(handle.knowledge.getChunkCountForSource("jira:PROJ-1")).toBe(1);
 
+    const logged = logSpy.mock.calls.map((c) => String(c[0]));
+    expect(logged).toContain("confluence:DEMO indexed 1 pages");
+    expect(logged).toContain("jira:PROJ indexed 1 issues");
+
     // One periodic refresh scheduled per source (1 space + 1 project).
     expect(fake.registrations.length).toBe(2);
 
     await handle.shutdown();
     expect(fake.cleared).toBe(2);
+    logSpy.mockRestore();
   });
 
   it("comes up cleanly with NO Atlassian creds — no throw, no fetch, no scheduled timer", async () => {


### PR DESCRIPTION
## What
The Jira knowledge ingester called `GET /rest/api/3/search`, which Atlassian **permanently removed** — the live sync now gets **HTTP 410 Gone**. This migrates `buildJiraFetcher.fetchIssues` to the replacement endpoint.

## Changes
- **`src/jira/sync.ts`** — swap to `GET /rest/api/3/search/jql?jql=<encoded>&fields=summary,description,comment&maxResults=100`. The new endpoint paginates with a **`nextPageToken` cursor** and returns `{ issues, nextPageToken, isLast }` (no `total`), so the old `startAt`/`total` paging is replaced with token pagination: append `&nextPageToken=<token>` on pages after the first, stop on `isLast === true || !token`. Infinite-loop guards added (page cap + empty-page break). Basic auth, ADF→text mapping, and the `jira:<KEY>` source id are unchanged. Stale doc comments updated.
- **`src/knowledge/startup.ts`** — log a per-source initial-sync index count via the existing logger: `confluence:<space> indexed <N> pages` and `jira:<KEY> indexed <M> issues`, so a live smoke can confirm both sources from stdout.

## Tests
- `tests/jira.test.ts` — assert the request hits `/rest/api/3/search/jql` (not the old `/search`), token pagination follows `nextPageToken` across ≥2 pages and stops on `isLast`, and ADF→doc mapping still holds.
- `tests/knowledge-sources.startup.test.ts` — assert the two new count-log lines.
- Full suite green (21 suites / 168 tests), `tsc` clean.

## Notes
Live Jira smoke (real GET project) is deferred to post-merge — the worktree has no `.env`.

3-role: planner (inline-skip, exact fix specified) → plan-review PASS → executor → execution-review PASS. Plan + review committed under `.ai-workspace/`.

https://claude.ai/code/session_01FV7REFAxxyRbgvfQm1fJr9