### PR TITLE
chore: release 0.12.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to monday-bot will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.12.8](https://github.com/ziyilam3999/monday-bot/compare/v0.12.7...v0.12.8) (2026-06-23)
+
+### Bug Fixes
+
+* migrate Jira ingester to /rest/api/3/search/jql after Atlassian removed /rest/api/3/search (HTTP 410 Gone); switch to nextPageToken cursor pagination + add per-source index-count startup log (#1168) (#201)
+
 ## [0.12.7](https://github.com/ziyilam3999/monday-bot/compare/v0.12.6...v0.12.7) (2026-06-22)
 
 ### Features

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "monday-bot",
-  "version": "0.12.7",
-  "description": "Team Slack knowledge assistant \u2014 answers from internal documents with cited, fact-based summaries.",
+  "version": "0.12.8",
+  "description": "Team Slack knowledge assistant — answers from internal documents with cited, fact-based summaries.",
   "private": true,
   "type": "commonjs",
   "main": "dist/index.js",


### PR DESCRIPTION
Release 0.12.8.

- bump package.json 0.12.7 -> 0.12.8
- prepend CHANGELOG entry for #1168 (Jira /rest/api/3/search/jql migration + per-source index-count log, merged in #201)

https://claude.ai/code/session_01FV7REFAxxyRbgvfQm1fJr9