### PR TITLE
feat: add macOS launchd LaunchAgent to run the bot 24/7 locally (#1167)

### DIFF
--- a/.ai-workspace/plans/2026-06-23-1167-launchd-launchagent.md
+++ b/.ai-workspace/plans/2026-06-23-1167-launchd-launchagent.md
@@ -1,0 +1,106 @@
+# Task #1167 — Run monday-bot 24/7 on macOS via a launchd LaunchAgent
+
+## ELI5
+
+The operator's Mac is on 24/7 and always logged in. They want Monday (the Slack
+bot) to start automatically, stay running, and restart itself if it crashes —
+without babysitting a terminal and without PM2. macOS's native supervisor for
+this is **launchd**: you hand it a small `.plist` describing what to run, where,
+and "keep it alive", and the OS does the rest.
+
+The repo is PUBLIC, so the plist can't contain the operator's real home path,
+username, node path, or hostname. So we ship a **template** full of
+`<PLACEHOLDER>` tokens plus an **install script** that resolves the real values
+on the operator's machine at install time and writes the filled plist into
+`~/Library/LaunchAgents/`. We do NOT load the agent ourselves — `launchctl
+bootstrap` is the operator's blessed activation step (one command).
+
+## Execution model
+
+**3-role, orchestrated.** Planner inline (this doc, per the #1167 brief).
+plan-review, executor (build of template+script+docs+test), and execution-review
+are real ledger roles. Code delta is shell + a plist template + a README section +
+one jest test (no TS source change), but the brief mandates the full loop.
+Artifacts committed (force-added, `.ai-workspace/` is gitignored) so the ledger
+`--artifact` paths survive on master.
+
+## What changes (new/modified files)
+
+1. **`deploy/launchd/com.monday-bot.plist.template`** (new) — LaunchAgent plist with
+   placeholder tokens:
+   - `Label` = `com.monday-bot`
+   - `ProgramArguments` = [`<NODE_PATH>`, `<REPO_DIR>/dist/index.js`]
+   - `WorkingDirectory` = `<REPO_DIR>`
+   - `RunAtLoad` = true, `KeepAlive` = true (restart on crash)
+   - `StandardOutPath` = `<LOG_DIR>/monday-bot.out.log`,
+     `StandardErrorPath` = `<LOG_DIR>/monday-bot.err.log`
+   - `EnvironmentVariables` → `PATH` = `<PATH_VALUE>` (so node + tools resolve under
+     launchd's minimal env). `.env` itself is still self-loaded by the bot
+     (v0.12.6 `process.loadEnvFile()` from `WorkingDirectory`), so no secrets in
+     the plist.
+   - `ProcessType` = Background (headless service, per plan-review nit), `ThrottleInterval` = 10 (crash-loop backoff).
+
+2. **`scripts/install-launchd.sh`** (new, shellcheck-clean, idempotent) —
+   - `set -euo pipefail`; resolves: `NODE_PATH=$(command -v node)`, `REPO_DIR` =
+     repo root via `git rev-parse --show-toplevel` (fallback to script's `../`),
+     `LOG_DIR="$HOME/Library/Logs"`, `PATH_VALUE` = dirname(node) prepended to a
+     sane default PATH.
+   - FAIL LOUDLY (exit 1, named cause) if: node missing, `dist/index.js` missing
+     (hint `npm run build`), `.env` missing (hint: populate it).
+   - Fills the template with `sed`/parameter expansion → writes
+     `~/Library/LaunchAgents/com.monday-bot.plist` (mkdir -p the dir first).
+   - PRINTS the activation commands and, for the non-`--print-only` path, performs
+     idempotent (re)install: `launchctl bootout` (ignore error if not loaded) →
+     `bootstrap` → `enable` → `kickstart -k`. Activation is gated behind an
+     explicit confirm/flag so it's operator-confirmable; default prints + asks.
+   - Subcommands: `install` (default), `--print-only`, `uninstall` (bootout +
+     remove plist), `status` (`launchctl print`), `--help`. Tail-logs hint shown.
+
+3. **`README.md`** — new "Run 24/7 on macOS (launchd)" section: prerequisites
+   (`npm run build`, populated `.env`), the one command
+   (`bash scripts/install-launchd.sh`), status/logs, update (rebuild + kickstart),
+   uninstall. CAVEAT documented: a LaunchAgent runs only while the user is logged
+   in (fine for an always-on logged-in Mac); a LaunchDaemon would be needed for
+   pre-login/headless. PM2 / `ecosystem.config.js` section kept intact.
+
+4. **`tests/install-launchd.test.ts`** (new) — cross-platform jest spec:
+   - template contains all required plist keys + every placeholder token, and
+     contains NO real-path/username leakage (`/Users/`, literal home, hostname).
+   - script: contains `set -euo pipefail`, the fail-loud guards, the launchctl
+     verbs, and is `bash -n` clean (guarded to skip the `bash -n` spawn on win32).
+
+## Non-goals
+
+- Do NOT delete / alter `ecosystem.config.js` (PM2 = future cloud path).
+- Do NOT run `launchctl bootstrap` from CI or from the agent — operator's step.
+- No TS source change; no new npm dependency.
+- No LaunchDaemon (documented as the headless alternative only).
+
+## Privacy (PUBLIC repo)
+
+No real home path, username, node path, or hostname in any tracked file. Template
+uses `<PLACEHOLDER>` tokens; script resolves at runtime. Run ai-brain privacy
+denylist + a `git grep` for `/Users/<user>` / `$USER` literal / hostname before
+push.
+
+## Binary AC (checkable from outside the diff)
+
+- AC1: `npm run build` exits 0 (tsc clean) — unchanged TS.
+- AC2: `npm test` exits 0 — existing suite + new install-launchd test green.
+- AC3: `bash -n scripts/install-launchd.sh` exits 0; shellcheck (if available) clean.
+- AC4: `grep -c "<NODE_PATH>\|<REPO_DIR>\|<LOG_DIR>\|<PATH_VALUE>"` on the template
+  ≥ 4; `git grep -n "/Users/"` over tracked files = 0 matches in the new files.
+- AC5: template has `KeepAlive`, `RunAtLoad`, `Label`, `ProgramArguments`,
+  `WorkingDirectory`, `StandardOutPath`, `StandardErrorPath`, `EnvironmentVariables`.
+
+## Critical files
+
+- `deploy/launchd/com.monday-bot.plist.template` (new)
+- `scripts/install-launchd.sh` (new)
+- `README.md` (Deployment area)
+- `tests/install-launchd.test.ts` (new)
+- `ecosystem.config.js` (must stay untouched)
+
+## Review
+
+(plan-review verdict in .ai-workspace/reviews/2026-06-23-1167-plan-review.md)

--- a/.ai-workspace/reviews/2026-06-23-1167-execution-review.md
+++ b/.ai-workspace/reviews/2026-06-23-1167-execution-review.md
@@ -1,0 +1,78 @@
+# Execution Review — Task #1167 (macOS launchd LaunchAgent)
+
+Stateless review of the on-disk implementation in `/tmp/mb-1167` against the
+contract `.ai-workspace/plans/2026-06-23-1167-launchd-launchagent.md`.
+
+## Verdict summary: PASS
+
+All six review dimensions and the plan's Binary AC (AC1–AC5) verified mechanically.
+No blocking issues. One cosmetic nit noted.
+
+## Evidence (commands run)
+
+- `shellcheck scripts/install-launchd.sh` → exit 0 (clean).
+- `bash -n scripts/install-launchd.sh` → exit 0.
+- `npx jest tests/install-launchd.test.ts` → 8/8 pass (incl. win32-guarded `bash -n`).
+- `npm run build` (tsc) → exit 0; `dist/index.js` produced.
+- `git diff --quiet -- ecosystem.config.js` → UNCHANGED (not in changeset).
+- Rendered plist (throwaway empty `.env`, removed after) → `plutil -lint` → **OK**.
+- `git status --short` after render → 0 `.env` entries (throwaway cleaned up).
+
+## Dimension-by-dimension
+
+1. **Plist validity / keys** — PASS. Rendered output lints clean (`plutil -lint OK`).
+   `Label`=com.monday-bot; `RunAtLoad`/`KeepAlive` both `<true/>`;
+   `ProgramArguments`=[`/opt/homebrew/bin/node`, `<REPO_DIR>/dist/index.js`] (absolute
+   node + entrypoint); `WorkingDirectory`=`<REPO_DIR>` (so `process.loadEnvFile()` finds
+   `.env`); `EnvironmentVariables`→`PATH` present (plus `NODE_ENV=production`);
+   `ProcessType`=`Background`; bonus `ThrottleInterval`=10. The template itself is
+   intentionally not standalone-XML (`<NODE_PATH>` reads as a bare tag) — correct by
+   design; only the rendered result is parsed and it is valid.
+
+2. **Privacy (PUBLIC repo)** — PASS. `git grep "/Users/"` and grep for the local
+   username / `/home/` over the new tracked files (template, script, test, README) = 0 matches.
+   Hostname is generic `Mac`; the two README "Mac" hits are the English word in prose,
+   not a host identifier. Real `/Users/...`, real node path, and repo path appear ONLY
+   in the runtime-rendered plist written to the untracked `~/Library/LaunchAgents/` —
+   allowed per contract. Tracked template carries only `<PLACEHOLDER>` tokens.
+
+3. **install-launchd.sh** — PASS. `set -euo pipefail`; fails loudly (named-cause `die`,
+   exit 1) on missing node / `dist/index.js` / `.env`. Idempotent: `activate()` runs
+   `launchctl bootout … || true` BEFORE `bootstrap`. Subcommands install (default) /
+   `--activate` / `--print-only` / status / uninstall / `--help`/`-h` all routed in
+   `main`. `--print-only` → render to stdout only, never calls `write_plist` (writes
+   nothing). Token replacement uses bash `${content//<TOKEN>/${VAL}}` (no sed `/`
+   delimiter hazard; `<`/`>` are not glob metachars; no token is a substring of
+   another). `REPO_DIR` via `git rev-parse --show-toplevel` with `${SCRIPT_DIR}/..`
+   fallback. Domain `gui/$(id -u)`, service target `gui/<uid>/com.monday-bot`.
+
+4. **Activation operator-gated** — PASS. The agent/CI never runs `bootstrap` unbidden.
+   Default path prompts `[y/N]` only when interactive; in a non-interactive shell
+   (`[ ! -t 0 ]`) it prints "NOT activated" and returns WITHOUT calling `activate()`.
+   Activation requires an interactive `y` or explicit `--activate`. The jest test never
+   invokes `launchctl`.
+
+5. **Cross-platform test** — PASS. All assertions are fs-content reads; the sole
+   subprocess (`bash -n`) is guarded via `process.platform === "win32" ? it.skip : it`.
+
+6. **ecosystem.config.js untouched** — PASS. `git diff --quiet` clean; not in changeset.
+
+## Binary AC
+
+- AC1 — `npm run build` exit 0 ✓
+- AC2 — new test 8/8 pass; TS source unchanged ✓
+- AC3 — `bash -n` exit 0; `shellcheck` exit 0 ✓
+- AC4 — template token count = 8 (≥4); `git grep "/Users/"` on new files = 0 ✓
+- AC5 — template has Label, ProgramArguments, WorkingDirectory, RunAtLoad, KeepAlive,
+  StandardOutPath, StandardErrorPath, EnvironmentVariables ✓
+
+## Non-blocking nit
+
+- Rendered `PATH` duplicates `/opt/homebrew/bin` (node's bin dir is prepended to a
+  default list that already contains it). Cosmetic; irrelevant to resolution.
+
+## Blocking issues
+
+None.
+
+Decision: PASS

--- a/.ai-workspace/reviews/2026-06-23-1167-gate-output.txt
+++ b/.ai-workspace/reviews/2026-06-23-1167-gate-output.txt
@@ -1,0 +1,13 @@
+# Task #1167 execution-review oracle — gate results (verbatim)
+
+npm run build: exit 0 (tsc clean)
+bash -n scripts/install-launchd.sh: clean
+shellcheck scripts/install-launchd.sh: clean (exit 0)
+plutil -lint (rendered plist): OK
+privacy denylist: CLEAN; git grep /Users|home|user|uid in new files: 0
+
+jest full suite:
+
+VERDICT: PASS
+Test Suites: 22 passed, 22 total
+Tests:       176 passed, 176 total

--- a/.ai-workspace/reviews/2026-06-23-1167-plan-review.md
+++ b/.ai-workspace/reviews/2026-06-23-1167-plan-review.md
@@ -1,0 +1,80 @@
+# Plan review — #1167 launchd LaunchAgent (24/7 macOS)
+
+Reviewer: stateless plan reviewer
+Plan: `.ai-workspace/plans/2026-06-23-1167-launchd-launchagent.md`
+Scope: plist template + install shell + README section + one jest test. No TS source change.
+
+## 1. launchd approach — CORRECT
+
+- **LaunchAgent (not LaunchDaemon)** is the right choice: the bot needs the operator's
+  `$HOME` (`.env`, `~/Library/LaunchAgents`, `~/Library/Logs`) and the machine is always
+  logged in. The login-required caveat and the "LaunchDaemon for headless/pre-login"
+  alternative are documented. Good.
+- **`gui/$(id -u)` domain** is the correct bootstrap target for a per-user LaunchAgent
+  (matches the brief). `bootout` → `bootstrap` → `enable` → `kickstart -k` is the right
+  idempotent activation sequence.
+- **`RunAtLoad=true` + `KeepAlive=true`** = start now and restart on exit, which is exactly
+  "run 24/7, restart on crash". `KeepAlive=true` also restarts on clean exit — desired for
+  an always-on bot. `ThrottleInterval=10` gives crash-loop backoff. Fine.
+- **`EnvironmentVariables.PATH`** is correctly included: launchd hands jobs a minimal env,
+  so any subprocess the bot spawns needs PATH; node itself is also pinned by ABSOLUTE path
+  in `ProgramArguments`, so node resolution does not depend on PATH. Belt-and-suspenders, good.
+- **Critical correctness link is right:** `WorkingDirectory=<REPO_DIR>` is what makes the bot's
+  `process.loadEnvFile()` (resolves `cwd()/.env`) find the repo's `.env`. Plan sets it. node
+  also resolves `node_modules` relative to `dist/index.js`, not cwd, so modules load regardless.
+  This is the linchpin and the plan gets it right — no secrets in the plist, `.env` self-loaded.
+
+## 2. Privacy (PUBLIC repo) — SATISFIED
+
+- Template ships only `<NODE_PATH>/<REPO_DIR>/<LOG_DIR>/<PATH_VALUE>` placeholder tokens; the
+  install script resolves real values at runtime and writes the filled plist to
+  `~/Library/LaunchAgents/` — OUTSIDE the repo. Logs go to `$HOME/Library/Logs` — also outside
+  the repo. No real home/username/node-path/hostname lands in any tracked file.
+- AC4 (`git grep "/Users/"` = 0 in new files) + the test's leakage assertions + the ai-brain
+  privacy denylist cover this on three axes. Good.
+
+## 3. Idempotency + fail-loud — SATISFIED
+
+- `set -euo pipefail`; `bootout` tolerates "not loaded"; re-running the installer overwrites
+  the plist and re-bootstraps cleanly.
+- Fail-loud guards on missing node / missing `dist/index.js` (hint `npm run build`) / missing
+  `.env` — these are exactly the three failure modes that would otherwise crash-loop silently
+  under launchd. Named-cause exit 1 is correct.
+- `git rev-parse --show-toplevel` with `../` fallback handles run-outside-git.
+
+## 4. Cross-platform jest (CI = ubuntu + windows) — SATISFIED
+
+- The test asserts on FILE CONTENTS read via `fs` (placeholder presence, required keys, leakage,
+  `set -euo pipefail`, launchctl verbs) — all platform-independent.
+- The only subprocess (`bash -n` lint) is explicitly guarded to skip on `win32`. This matches the
+  existing repo convention (`tests/index.loadenv.test.ts` uses `execSync` for the same reason;
+  `anthropicClient.test.ts` already pattern-matches `process.platform`). Good.
+- The test does NOT execute the install path, so CI never runs `launchctl` (which does not exist
+  on the runners anyway). Consistent with "agent/CI must not bootstrap".
+
+## 5. "Agent must NOT run `launchctl bootstrap`" — UPHELD (note)
+
+The install SCRIPT contains bootstrap logic, gated behind an explicit operator confirm/flag, and
+that is the operator's blessed one-command activation — allowed. The constraint binds the AGENT
+(build/CI): the jest test only does `bash -n` + content greps and never invokes the activation
+path, so neither the executor nor CI will bootstrap. Keep it that way — the executor must not run
+`scripts/install-launchd.sh` (install path) during the build, only `bash -n` it.
+
+## Nits (non-blocking)
+
+- **`ProcessType=Interactive`** is a slight mis-classification for a headless network bot;
+  `Background` (throttled I/O, lower priority) or `Standard` is the more conventional pick.
+  Interactive is harmless (just avoids throttling) — optional to revisit.
+- **Log growth:** launchd does not rotate `StandardOutPath`/`StandardErrorPath`; the files grow
+  unbounded. Out of scope, but a one-line README note (or a `newsyslog.d` pointer) would be kind.
+- Confirm `--print-only` truly writes nothing OR only echoes (no `~/Library/LaunchAgents` write)
+  so a dry-run is side-effect-free — the plan says "prints + asks" by default; make the no-op
+  path unambiguous.
+- PM2 `ecosystem.config.js` is correctly listed as untouched; README keeps the PM2 section. Good.
+
+## Verdict
+
+Approach is correct, privacy-safe, idempotent, fail-loud, and cross-platform. Binary AC are
+checkable from outside the diff. Only minor nits, none blocking.
+
+Decision: PASS

--- a/README.md
+++ b/README.md
@@ -99,6 +99,70 @@ pm2 logs monday             # tail logs
 pm2 restart monday          # manual restart
 ```
 
+### Run 24/7 on macOS (launchd)
+
+For an always-on, always-logged-in Mac, you can run Monday under macOS's native
+service supervisor **launchd** instead of PM2 — no extra global install. launchd
+starts Monday at login, keeps it alive, and restarts it on crash.
+
+The repo is public, so it ships a placeholder **template**
+([`deploy/launchd/com.monday-bot.plist.template`](./deploy/launchd/com.monday-bot.plist.template))
+plus an installer that resolves the real node path / repo dir / log dir on your
+machine and writes the filled plist to `~/Library/LaunchAgents/`.
+
+**Prerequisites:** `npm run build` (produces `dist/`) and a populated `.env` in
+the repo root (Monday self-loads `.env` at startup — v0.12.6+ — so no secrets go
+into the plist).
+
+```bash
+npm run build
+bash scripts/install-launchd.sh          # writes the plist, then prompts to activate
+```
+
+The installer prints the exact `launchctl` activation commands and (with your
+confirmation) runs them:
+
+```text
+launchctl bootout    gui/$(id -u)/com.monday-bot 2>/dev/null || true
+launchctl bootstrap  gui/$(id -u) ~/Library/LaunchAgents/com.monday-bot.plist
+launchctl enable     gui/$(id -u)/com.monday-bot
+launchctl kickstart -k gui/$(id -u)/com.monday-bot
+```
+
+It fails loudly if `node`, `dist/index.js`, or `.env` is missing, and it is
+idempotent — re-running tears down the old instance (`bootout`) before
+re-bootstrapping. Use `bash scripts/install-launchd.sh --print-only` to preview
+the rendered plist without writing anything.
+
+**Status & logs:**
+
+```bash
+bash scripts/install-launchd.sh status                                  # launchctl print
+tail -f ~/Library/Logs/monday-bot.out.log ~/Library/Logs/monday-bot.err.log
+```
+
+> launchd does not rotate these log files. If they grow large, truncate them
+> (e.g. `: > ~/Library/Logs/monday-bot.out.log`) — the running agent keeps appending.
+
+**Update** (after pulling new code):
+
+```bash
+npm run build
+launchctl kickstart -k gui/$(id -u)/com.monday-bot   # restart with the new dist/
+```
+
+**Uninstall:**
+
+```bash
+bash scripts/install-launchd.sh uninstall            # bootout + remove the plist
+```
+
+> **Caveat:** a **LaunchAgent** runs only while the user is logged in — which is
+> exactly right for an always-on, logged-in Mac. For pre-login / headless
+> operation you would instead need a **LaunchDaemon** in `/Library/LaunchDaemons/`
+> (installed as root, no access to the user session). That is out of scope here;
+> the cloud/headless path remains PM2 ([`ecosystem.config.js`](./ecosystem.config.js)).
+
 ### ARM Linux compatibility
 
 All runtime dependencies are pure-JS or ship ARM-compatible prebuilds:

--- a/deploy/launchd/com.monday-bot.plist.template
+++ b/deploy/launchd/com.monday-bot.plist.template
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  LaunchAgent template for running Monday (the Slack knowledge bot) 24/7 on macOS.
+
+  This file is a TEMPLATE. The repo is PUBLIC, so it intentionally contains only
+  <PLACEHOLDER> tokens — never a real home path, username, node path, or hostname.
+  Do NOT hand-edit and load this file directly. Run:
+
+      bash scripts/install-launchd.sh
+
+  which resolves the real values on your machine and writes the filled plist to
+  ~/Library/LaunchAgents/com.monday-bot.plist.
+
+  Secrets stay OUT of this plist: Monday self-loads .env via process.loadEnvFile()
+  (v0.12.6+) from its WorkingDirectory, so launchd only needs to start node in the
+  repo dir. Set credentials in <REPO_DIR>/.env, not here.
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.monday-bot</string>
+
+    <!-- ProgramArguments: [ absolute node, absolute entrypoint ].
+         launchd does NOT use your shell's PATH, so node must be an absolute path. -->
+    <key>ProgramArguments</key>
+    <array>
+        <string><NODE_PATH></string>
+        <string><REPO_DIR>/dist/index.js</string>
+    </array>
+
+    <!-- Run from the repo root so process.loadEnvFile() finds <REPO_DIR>/.env
+         and relative config paths (config.yaml) resolve. -->
+    <key>WorkingDirectory</key>
+    <string><REPO_DIR></string>
+
+    <!-- Start at login and keep it alive — relaunch on crash or clean exit. -->
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <true/>
+
+    <!-- Background service (headless long-running process), not a UI app. -->
+    <key>ProcessType</key>
+    <string>Background</string>
+
+    <!-- Crash-loop backoff: wait at least 10s between relaunches. -->
+    <key>ThrottleInterval</key>
+    <integer>10</integer>
+
+    <!-- launchd starts with a minimal environment. Give node + any child tools a
+         usable PATH (node's own bin dir prepended to a sane default). -->
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string><PATH_VALUE></string>
+        <key>NODE_ENV</key>
+        <string>production</string>
+    </dict>
+
+    <!-- Logs. These files are NOT rotated by launchd — see the README note on
+         truncating them if they grow large. -->
+    <key>StandardOutPath</key>
+    <string><LOG_DIR>/monday-bot.out.log</string>
+    <key>StandardErrorPath</key>
+    <string><LOG_DIR>/monday-bot.err.log</string>
+</dict>
+</plist>

--- a/scripts/install-launchd.sh
+++ b/scripts/install-launchd.sh
@@ -1,0 +1,193 @@
+#!/usr/bin/env bash
+#
+# install-launchd.sh — install Monday (the Slack knowledge bot) as a macOS
+# launchd LaunchAgent so it runs 24/7 while you are logged in and restarts on
+# crash. Native alternative to PM2 (ecosystem.config.js stays for the cloud path).
+#
+# This resolves the real node path / repo dir / log dir on THIS machine, fills
+# deploy/launchd/com.monday-bot.plist.template, and writes the result to
+# ~/Library/LaunchAgents/com.monday-bot.plist. It then PRINTS the launchctl
+# activation commands and (with your confirmation) runs them. The repo is public,
+# so no real paths live in tracked files — only the placeholder template does.
+#
+# Usage:
+#   bash scripts/install-launchd.sh              # install + prompt to activate
+#   bash scripts/install-launchd.sh --activate   # install + activate, no prompt
+#   bash scripts/install-launchd.sh --print-only  # write nothing, just print plist + commands
+#   bash scripts/install-launchd.sh status       # launchctl print of the agent
+#   bash scripts/install-launchd.sh uninstall    # stop + remove the agent
+#   bash scripts/install-launchd.sh --help
+#
+set -euo pipefail
+
+LABEL="com.monday-bot"
+PLIST_NAME="${LABEL}.plist"
+
+# --- locate the repo, regardless of where the script is invoked from ----------
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if REPO_DIR="$(git -C "${SCRIPT_DIR}" rev-parse --show-toplevel 2>/dev/null)"; then
+    :
+else
+    # Fallback: scripts/ lives one level under the repo root.
+    REPO_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+fi
+
+TEMPLATE="${REPO_DIR}/deploy/launchd/${PLIST_NAME}.template"
+LAUNCH_AGENTS_DIR="${HOME}/Library/LaunchAgents"
+PLIST_DST="${LAUNCH_AGENTS_DIR}/${PLIST_NAME}"
+LOG_DIR="${HOME}/Library/Logs"
+DOMAIN="gui/$(id -u)"
+SERVICE_TARGET="${DOMAIN}/${LABEL}"
+
+die() {
+    echo "ERROR: $*" >&2
+    exit 1
+}
+
+note() { echo "  $*"; }
+
+require_macos() {
+    [ "$(uname -s)" = "Darwin" ] || die "this installer is for macOS (launchd) only; on Linux use PM2 (see ecosystem.config.js / README)."
+}
+
+# --- resolve + validate prerequisites, failing loudly -------------------------
+resolve_prereqs() {
+    NODE_PATH="$(command -v node || true)"
+    [ -n "${NODE_PATH}" ] || die "node not found on PATH. Install Node 18+ and retry."
+
+    [ -f "${TEMPLATE}" ] || die "plist template not found at ${TEMPLATE}."
+
+    [ -f "${REPO_DIR}/dist/index.js" ] || die "dist/index.js not found — run 'npm run build' first (tsc -> dist/)."
+
+    [ -f "${REPO_DIR}/.env" ] || die ".env not found in ${REPO_DIR}. Populate it (SLACK_BOT_TOKEN, SLACK_APP_TOKEN, ...) before installing; the bot self-loads it at startup."
+
+    # launchd starts with a minimal env; give node's own bin dir priority, then a
+    # conventional default PATH so child tools still resolve.
+    local node_bin_dir
+    node_bin_dir="$(dirname "${NODE_PATH}")"
+    PATH_VALUE="${node_bin_dir}:/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+}
+
+# --- render the template to stdout (no side effects) --------------------------
+render_plist() {
+    local content
+    content="$(cat "${TEMPLATE}")"
+    content="${content//<NODE_PATH>/${NODE_PATH}}"
+    content="${content//<REPO_DIR>/${REPO_DIR}}"
+    content="${content//<LOG_DIR>/${LOG_DIR}}"
+    content="${content//<PATH_VALUE>/${PATH_VALUE}}"
+    printf '%s\n' "${content}"
+}
+
+print_activation_commands() {
+    echo "Activation commands (idempotent — safe to re-run):"
+    note "launchctl bootout    ${SERVICE_TARGET} 2>/dev/null || true"
+    note "launchctl bootstrap  ${DOMAIN} \"${PLIST_DST}\""
+    note "launchctl enable     ${SERVICE_TARGET}"
+    note "launchctl kickstart -k ${SERVICE_TARGET}"
+    echo
+    echo "Check status:  bash scripts/install-launchd.sh status"
+    echo "Tail logs:     tail -f \"${LOG_DIR}/monday-bot.out.log\" \"${LOG_DIR}/monday-bot.err.log\""
+    echo "Uninstall:     bash scripts/install-launchd.sh uninstall"
+}
+
+write_plist() {
+    mkdir -p "${LAUNCH_AGENTS_DIR}"
+    render_plist > "${PLIST_DST}"
+    echo "Wrote ${PLIST_DST}"
+}
+
+activate() {
+    # Idempotent: tear down any existing instance before (re)bootstrapping.
+    launchctl bootout "${SERVICE_TARGET}" 2>/dev/null || true
+    launchctl bootstrap "${DOMAIN}" "${PLIST_DST}"
+    launchctl enable "${SERVICE_TARGET}"
+    launchctl kickstart -k "${SERVICE_TARGET}"
+    echo "Activated ${SERVICE_TARGET}. It will start at login and restart on crash."
+    echo "Tail logs: tail -f \"${LOG_DIR}/monday-bot.out.log\" \"${LOG_DIR}/monday-bot.err.log\""
+}
+
+cmd_install() {
+    local auto_activate="${1:-prompt}"
+    require_macos
+    resolve_prereqs
+    write_plist
+    echo
+    print_activation_commands
+    echo
+
+    if [ "${auto_activate}" = "activate" ]; then
+        activate
+        return
+    fi
+
+    if [ ! -t 0 ]; then
+        echo "Non-interactive shell — plist written but NOT activated."
+        echo "Run the commands above, or re-run with: bash scripts/install-launchd.sh --activate"
+        return
+    fi
+
+    printf 'Activate the LaunchAgent now (runs the launchctl commands above)? [y/N] '
+    read -r reply
+    case "${reply}" in
+        y | Y | yes | YES) activate ;;
+        *) echo "Skipped activation. The plist is in place; run the commands above when ready." ;;
+    esac
+}
+
+cmd_print_only() {
+    require_macos
+    resolve_prereqs
+    echo "# Rendered plist (NOT written — --print-only):"
+    echo "# would be written to: ${PLIST_DST}"
+    render_plist
+    echo
+    print_activation_commands
+}
+
+cmd_status() {
+    require_macos
+    launchctl print "${SERVICE_TARGET}" 2>/dev/null \
+        || die "agent ${SERVICE_TARGET} not loaded. Install it with: bash scripts/install-launchd.sh"
+}
+
+cmd_uninstall() {
+    require_macos
+    launchctl bootout "${SERVICE_TARGET}" 2>/dev/null || echo "Agent was not loaded (nothing to stop)."
+    if [ -f "${PLIST_DST}" ]; then
+        rm -f "${PLIST_DST}"
+        echo "Removed ${PLIST_DST}"
+    else
+        echo "No plist at ${PLIST_DST} (already removed)."
+    fi
+    echo "Uninstalled. Logs remain in ${LOG_DIR} (delete manually if desired)."
+}
+
+usage() {
+    cat <<EOF
+install-launchd.sh — run Monday 24/7 on macOS via a launchd LaunchAgent.
+
+  (no args)      Install: write ~/Library/LaunchAgents/${PLIST_NAME}, then prompt to activate.
+  --activate     Install and activate without prompting.
+  --print-only   Print the rendered plist + activation commands; write nothing.
+  status         Show 'launchctl print' for the agent.
+  uninstall      Stop (bootout) and remove the agent plist.
+  --help, -h     This help.
+
+Prerequisites: 'npm run build' (produces dist/) and a populated .env in the repo root.
+EOF
+}
+
+main() {
+    case "${1:-install}" in
+        install | "") cmd_install prompt ;;
+        --activate) cmd_install activate ;;
+        --print-only) cmd_print_only ;;
+        status) cmd_status ;;
+        uninstall) cmd_uninstall ;;
+        --help | -h) usage ;;
+        *) usage; die "unknown argument: $1" ;;
+    esac
+}
+
+main "$@"

--- a/tests/install-launchd.test.ts
+++ b/tests/install-launchd.test.ts
@@ -1,0 +1,90 @@
+/**
+ * #1167 — macOS launchd LaunchAgent assets.
+ *
+ * Validates the committed, PUBLIC-repo-safe artifacts:
+ *   - deploy/launchd/com.monday-bot.plist.template
+ *   - scripts/install-launchd.sh
+ *
+ * These checks are CONTENT-based (fs reads) so they run identically on the CI
+ * ubuntu + windows matrix. The only subprocess — `bash -n` syntax check — is
+ * guarded to skip on win32, mirroring tests/index.loadenv.test.ts's convention.
+ * CI never runs `launchctl`; the install path is the operator's blessed step.
+ */
+
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const REPO_ROOT = join(__dirname, "..");
+const TEMPLATE = join(REPO_ROOT, "deploy", "launchd", "com.monday-bot.plist.template");
+const SCRIPT = join(REPO_ROOT, "scripts", "install-launchd.sh");
+
+const template = readFileSync(TEMPLATE, "utf8");
+const script = readFileSync(SCRIPT, "utf8");
+
+describe("launchd plist template", () => {
+  it("declares all required LaunchAgent keys", () => {
+    for (const key of [
+      "Label",
+      "ProgramArguments",
+      "WorkingDirectory",
+      "RunAtLoad",
+      "KeepAlive",
+      "StandardOutPath",
+      "StandardErrorPath",
+      "EnvironmentVariables",
+    ]) {
+      expect(template).toContain(`<key>${key}</key>`);
+    }
+  });
+
+  it("uses the com.monday-bot label and KeepAlive/RunAtLoad true", () => {
+    expect(template).toContain("<string>com.monday-bot</string>");
+    // RunAtLoad + KeepAlive must be enabled (start at login, restart on crash).
+    expect(template).toMatch(/<key>RunAtLoad<\/key>\s*<true\/>/);
+    expect(template).toMatch(/<key>KeepAlive<\/key>\s*<true\/>/);
+  });
+
+  it("carries every placeholder token the installer resolves", () => {
+    for (const token of ["<NODE_PATH>", "<REPO_DIR>", "<LOG_DIR>", "<PATH_VALUE>"]) {
+      expect(template).toContain(token);
+    }
+    // Entrypoint + WorkingDirectory are derived from <REPO_DIR>.
+    expect(template).toContain("<REPO_DIR>/dist/index.js");
+    // PATH is set so node resolves under launchd's minimal env.
+    expect(template).toContain("<key>PATH</key>");
+  });
+
+  it("leaks NO real machine paths (PUBLIC repo)", () => {
+    // No real home dir, username, or absolute /Users path may be baked in.
+    expect(template).not.toMatch(/\/Users\//);
+    expect(template).not.toMatch(/\/home\/[a-z]/);
+  });
+});
+
+describe("install-launchd.sh", () => {
+  it("is strict-mode and fails loudly on missing prerequisites", () => {
+    expect(script).toContain("set -euo pipefail");
+    expect(script).toContain("dist/index.js"); // build guard
+    expect(script).toContain(".env"); // env guard
+    expect(script).toMatch(/command -v node/); // node-path resolution
+  });
+
+  it("drives launchctl idempotently (bootout before bootstrap) and offers status/uninstall", () => {
+    expect(script).toContain("launchctl bootout");
+    expect(script).toContain("launchctl bootstrap");
+    expect(script).toContain("launchctl enable");
+    expect(script).toContain("launchctl kickstart");
+    expect(script).toContain("launchctl print"); // status
+  });
+
+  it("does not bake in a real /Users path", () => {
+    expect(script).not.toMatch(/\/Users\//);
+  });
+
+  // Syntax-only; bash isn't guaranteed on the Windows CI runner.
+  const maybe = process.platform === "win32" ? it.skip : it;
+  maybe("passes `bash -n` (syntax check)", () => {
+    expect(() => execFileSync("bash", ["-n", SCRIPT], { stdio: "pipe" })).not.toThrow();
+  });
+});


### PR DESCRIPTION
## What

Adds a native macOS **launchd** path so Monday runs 24/7 on an always-logged-in Mac and restarts on crash — the operator's preferred alternative to PM2. `ecosystem.config.js` (PM2) is left intact for the future cloud path.

## Deliverables

- **`deploy/launchd/com.monday-bot.plist.template`** — LaunchAgent plist with `<PLACEHOLDER>` tokens (the repo is PUBLIC — no real paths/usernames/hosts in tracked files). `Label=com.monday-bot`, `RunAtLoad`+`KeepAlive`, `ProgramArguments=[<NODE_PATH>, <REPO_DIR>/dist/index.js]`, `WorkingDirectory=<REPO_DIR>` (so the bot's `process.loadEnvFile()` finds `.env`), `EnvironmentVariables.PATH`, `ProcessType=Background`, `ThrottleInterval` backoff, logs under `~/Library/Logs`.
- **`scripts/install-launchd.sh`** — resolves the absolute node path / repo dir / log dir, fills the template, writes `~/Library/LaunchAgents/com.monday-bot.plist`. Fails loudly if `node`/`dist/`/`.env` is missing; idempotent (bootout before bootstrap); subcommands `install` / `--activate` / `--print-only` / `status` / `uninstall` / `--help`. Prints the `launchctl` activation commands and gates the actual `bootstrap` behind an operator confirm (or explicit `--activate`). shellcheck + `bash -n` clean.
- **README** — "Run 24/7 on macOS (launchd)" section: prereqs, the one command, status/logs, update, uninstall, and the LaunchAgent-only-while-logged-in caveat (LaunchDaemon noted as the headless alternative).
- **`tests/install-launchd.test.ts`** — cross-platform jest specs (content asserts + win32-guarded `bash -n`).
- **`.ai-workspace/`** — 3-role plan + plan-review + execution-review + gate-output (committed so the ledger artifact paths survive on master).

## Operator activation (one command)

```bash
npm run build && bash scripts/install-launchd.sh
```

`launchctl bootstrap` is the operator's blessed activation step — not run in CI or by the agent.

## Tests / checks

- `npm run build` + `tsc` clean; `npm test` → 22 suites / 176 tests green (incl. the new launchd test).
- `bash -n` + `shellcheck` clean; `plutil -lint` OK on the rendered plist.
- Privacy: ai-brain denylist clean; `git grep` for real `/Users` paths / username / uid in new files = 0.

https://claude.ai/code/session_01FV7REFAxxyRbgvfQm1fJr9