### PR TITLE
fix(1066): rename Slack-reserved slash commands /status,/feedback to /status-monday,/feedback-monday

### DIFF
--- a/.ai-workspace/plans/2026-06-23-1066-rename-reserved-slash-commands.md
+++ b/.ai-workspace/plans/2026-06-23-1066-rename-reserved-slash-commands.md
@@ -60,7 +60,7 @@ command names are generic. Run a privacy grep over the diff before push.
 - `git grep -n '"/status-monday"'` and `git grep -n '"/feedback-monday"'` over `src/` each
   return at least the adapter registration + the commands.ts AVAILABLE_COMMANDS entry.
 - `/ask`, `/sync-confluence`, `/reindex`, `/help` strings are unchanged in `src/`.
-- Privacy grep `git grep -iE 'burrox|getspace|<employer-host>'` over the diff returns ZERO hits.
+- Privacy grep over the diff for the regulated employer-brand / host tokens returns ZERO hits (the exact denylist patterns are kept out of this public-repo artifact; the orchestrator supplied them out-of-band).
 
 ## Review
 

--- a/.ai-workspace/plans/2026-06-23-1066-rename-reserved-slash-commands.md
+++ b/.ai-workspace/plans/2026-06-23-1066-rename-reserved-slash-commands.md
@@ -1,0 +1,67 @@
+# 1066 — Rename two slash commands that collide with Slack reserved words
+
+## ELI5
+
+Slack reserves some slash-command names for its own built-ins. Two of our bot's
+admin commands — `/status` and `/feedback` — clash with those reserved words, so
+Slack can swallow or shadow them. The fix is a pure rename: call them
+`/status-monday` and `/feedback-monday` instead. Nothing about how the commands
+WORK changes — only the text of the command name. The other commands (`/ask`,
+`/sync-confluence`, `/reindex`, `/help`) are NOT reserved and stay exactly as they are.
+
+## Execution model
+
+**subagent.** Knob A = `delegate` (one fresh executor subagent), Knob B = `reviewer`
+(stateless execution-review subagent) plus the build+test oracle. Rationale: the change
+is fully specified (exact edit sites + Binary AC) but spans 2 source files + docs, which
+is above the trivial-skip threshold (single file AND <10 LOC), so the canonical 3-role
+loop applies: planner is inline-skipped (the orchestrator brief already encodes the plan
+and AC; there is no design decision to delegate), plan-review + executor + execution-review
+run as real subagents.
+
+## Scope
+
+Mechanical string rename only. No logic change, no new behavior, no test changes
+expected (the orchestrator already grepped — there are no test references to the
+old command strings).
+
+### Renames
+- `/status` → `/status-monday`
+- `/feedback` → `/feedback-monday`
+
+### Leave UNCHANGED
+- `/ask`, `/sync-confluence`, `/reindex`, `/help` (not Slack-reserved).
+- The internal `commandHandlers` registry keys (`status`, `feedback`, …) — these are
+  code identifiers, not user-facing slash tokens, and the AC tests key on them.
+
+## Edit sites (already located by the orchestrator)
+
+1. `src/slack/adapter.ts` — `registerAdminCommand("/status", …)` → `"/status-monday"`.
+2. `src/slack/adapter.ts` — `registerAdminCommand("/feedback", …)` → `"/feedback-monday"`.
+3. `src/slack/commands.ts` — `AVAILABLE_COMMANDS` `{ name: "/status", … }` → `"/status-monday"` (drives `/help`).
+4. `src/slack/commands.ts` — `{ name: "/feedback <message>", … }` → `"/feedback-monday <message>"`.
+5. `src/slack/commands.ts` — usage string `"Usage: /feedback <message> — …"` → `/feedback-monday`.
+6. Cosmetic doc-comments referencing the old names in both files — update for consistency.
+7. `README.md` / `CHANGELOG.md` / `.env.example` — update only user-facing slash-command
+   tokens `/status` and `/feedback`; do NOT touch the unrelated prose word "status", and do
+   NOT rewrite historical CHANGELOG entries (immutable release records).
+
+## Privacy (public repo)
+
+No employer brand / host / Confluence space key / Jira project key introduced. The new
+command names are generic. Run a privacy grep over the diff before push.
+
+## Binary AC
+
+- `npm run build` exits 0 (tsc clean).
+- `npm test` all suites green.
+- `git grep -n '"/status"'` and `git grep -n '"/feedback"'` over `src/` return ZERO hits
+  (the two registered command strings are renamed).
+- `git grep -n '"/status-monday"'` and `git grep -n '"/feedback-monday"'` over `src/` each
+  return at least the adapter registration + the commands.ts AVAILABLE_COMMANDS entry.
+- `/ask`, `/sync-confluence`, `/reindex`, `/help` strings are unchanged in `src/`.
+- Privacy grep `git grep -iE 'burrox|getspace|<employer-host>'` over the diff returns ZERO hits.
+
+## Review
+
+(plan-review subagent fills this in)

--- a/.ai-workspace/reviews/1066-execution-review.md
+++ b/.ai-workspace/reviews/1066-execution-review.md
@@ -1,0 +1,43 @@
+# Task 1066 — Execution Review (stateless, independent reviewer)
+
+Rename Slack reserved-word slash commands: `/status` -> `/status-monday` and
+`/feedback` -> `/feedback-monday`. Leave `/ask`, `/sync-confluence`, `/reindex`,
+`/help` unchanged. Pure string-literal + comment rename, no logic change.
+Internal `commandHandlers` registry keys (`status`, `feedback`) must be unchanged.
+
+## Review
+
+Diff reviewed: `git diff origin/master..HEAD -- src/ README.md CHANGELOG.md .env.example`.
+The diff touches only `src/slack/adapter.ts` and `src/slack/commands.ts` — every
+hunk is a string literal or a doc comment. No control flow, conditions, function
+bodies, or signatures changed.
+
+Mechanical verification (`git grep ... HEAD -- src/`):
+- `"/status"` → EMPTY (old string gone).
+- `"/feedback"` → EMPTY (old string gone).
+- `/status-monday` → PRESENT: adapter registration (`adapter.ts:196 registerAdminCommand("/status-monday", ...)`), AVAILABLE_COMMANDS entry (`commands.ts:40`), plus doc comments.
+- `/feedback-monday` → PRESENT: adapter registration (`adapter.ts:202`), AVAILABLE_COMMANDS entry (`commands.ts:44`), and the usage string (`commands.ts:127 "Usage: /feedback-monday <message> ..."`).
+- `"/ask" | "/sync-confluence" | "/reindex" | "/help"` → UNCHANGED (still registered at adapter.ts:160/197/200/201; listed in commands.ts:42/43).
+
+Registry keys (`src/slack/commands.ts` `export const commandHandlers`):
+```
+status: statusCommand,
+syncConfluence: syncConfluenceCommand,
+reindex: reindexCommand,
+help: helpCommand,
+feedback: feedbackCommand,
+```
+Keys `status` and `feedback` are UNCHANGED — only the user-facing slash-command
+strings were renamed, exactly as intended.
+
+Logic change: NONE. String literals + comments only.
+
+Build + test (oracle):
+- `npm run build` (tsc) → clean, no errors.
+- `npm test` → Test Suites: 22 passed, 22 total; Tests: 176 passed, 176 total. GREEN.
+
+Privacy (public repo): `git grep -inE 'burrox|getspace' HEAD -- .` → PRIVACY CLEAN (zero hits).
+
+cairn: "[T1] ...slash commands (including `/compact`) are parsed CLIENT-SIDE by the..." — prior hits concern Claude Code client-side slash-command parsing, not Slack command registration; no directly applicable lesson for this rename.
+
+Decision: PASS

--- a/.ai-workspace/reviews/1066-plan-review.md
+++ b/.ai-workspace/reviews/1066-plan-review.md
@@ -1,0 +1,66 @@
+# 1066 Plan Review — Rename reserved slash commands
+
+Plan reviewed: `.ai-workspace/plans/2026-06-23-1066-rename-reserved-slash-commands.md`
+Reviewer: stateless plan-reviewer (independent). Change class: pure user-facing string rename
+(`/status` → `/status-monday`, `/feedback` → `/feedback-monday`), no logic change.
+
+## Review
+
+### Strengths
+
+- **Edit sites are real and exact.** I read both target files and confirmed every cited site:
+  - `src/slack/adapter.ts:196` — `registerAdminCommand("/status", …)` ✓
+  - `src/slack/adapter.ts:202` — `registerAdminCommand("/feedback", …)` ✓
+  - `src/slack/commands.ts:40` — `AVAILABLE_COMMANDS` `{ name: "/status", … }` ✓
+  - `src/slack/commands.ts:44` — `{ name: "/feedback <message>", … }` ✓
+  - `src/slack/commands.ts:127` — usage string `"Usage: /feedback <message> — …"` ✓
+  - Doc-comments in both files (adapter.ts:32-33, 95; commands.ts:5-6, 60, 120) ✓
+  The list is complete for `src/` — a repo-wide grep surfaced no other `src/` occurrences.
+
+- **Registry keys correctly left UNCHANGED.** The plan explicitly preserves the
+  `commandHandlers` registry keys (`status`, `feedback`, … at `commands.ts:155-161`) and the
+  named exports (`statusCommand`, `feedbackCommand`). These are code identifiers, the AC tests
+  key on the substrings, and they are NOT user-facing slash tokens. Confirmed against source —
+  this is the right call; renaming them would be an out-of-scope behavior change and would break
+  the adapter imports + tests.
+
+- **Binary AC is sound and checkable from OUTSIDE the diff.** `npm run build` exit 0, `npm test`
+  green, and the `git grep` counts are all observable without reading implementation logic. The
+  zero-hit greps are well-constructed: the pattern `'"/status"'` carries the CLOSING quote, so
+  after the rename to `"/status-monday"` the literal substring `"/status"` no longer appears
+  (the next char is `-`, not `"`) → the zero-hit assertion is genuinely satisfiable and will not
+  false-match the new name. The presence greps for `"/status-monday"` / `"/feedback-monday"`
+  pin the rename actually landed. The "untouched" assertions for `/ask`, `/sync-confluence`,
+  `/reindex`, `/help` lock the scope.
+
+- **Scope is right.** Leaving `/ask`, `/sync-confluence`, `/reindex`, `/help` unchanged is
+  correct — none collide with Slack reserved words, and the plan says so explicitly.
+
+### Gaps / risks (all non-blocking)
+
+1. **No Slack app manifest in the repo** (verified: `find` for `*manifest*` / `slack*.yml`
+   returned nothing). Good news — it means the rename is fully self-contained to code; there is
+   no external slash-command declaration that would silently drift out of sync. Worth stating so
+   the executor does not go hunting for one.
+
+2. **Historical doc `docs/PLAN_MONDAY_BOT.v1.1-how-heavy.bak.md`** references the old names
+   (lines 80-81, 130-134, 207, 789-814). This is a `.bak` snapshot of an old planning doc — the
+   same immutable-historical class as the CHANGELOG entry the plan already (correctly) refuses to
+   rewrite. The plan's edit-site 7 names only README / CHANGELOG / .env.example; recommend the
+   executor treat this `.bak` the same way (leave it). Non-blocking and consistent with the
+   plan's stated spirit.
+
+3. **README.md / .env.example carry NO `/status` or `/feedback` references** (repo-wide grep).
+   So edit-site 7's README/.env portions are moot — only the historical CHANGELOG matches, which
+   the plan correctly excludes. The "if present" phrasing is harmless; nothing actionable there.
+
+### Verdict rationale
+
+The plan is coherent, the edit sites are real and complete for the runtime surface, the registry
+keys the AC depends on are correctly preserved, and the Binary AC is observable from outside the
+diff and free of the false-match trap. The only findings are cosmetic/historical and non-blocking.
+Sound enough to execute as-is.
+
+Decision: PASS
+
+cairn: matched "monday-bot #53: PR created (fix/housekeep-53) — regex rename, 3 files" — confirms mechanical regex renames in this repo are routine/low-risk; no contrary lesson found for "slack command" or "rename".

--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/Users/ansonlam/coding_projects/monday-bot/node_modules

--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/Users/ansonlam/coding_projects/monday-bot/node_modules

--- a/src/slack/adapter.ts
+++ b/src/slack/adapter.ts
@@ -29,8 +29,8 @@ export interface SlackAdapterOptions {
   /** Knowledge service used to answer questions. Required. */
   knowledgeService: AnswerProvider | null | undefined;
   /**
-   * Optional admin surface used by /status, /sync-confluence, /reindex,
-   * /feedback. May be the same object as `knowledgeService` if it implements
+   * Optional admin surface used by /status-monday, /sync-confluence, /reindex,
+   * /feedback-monday. May be the same object as `knowledgeService` if it implements
    * both contracts. Missing methods degrade to "not configured" responses.
    */
   adminService?: AdminService;
@@ -92,7 +92,7 @@ export class SlackAdapter {
     this.appToken = opts.appToken.trim();
     this.knowledgeService = opts.knowledgeService;
     // Default: if the knowledgeService object also exposes admin methods (e.g.
-    // KnowledgeService's getStatus()), use it for /status. Otherwise the admin
+    // KnowledgeService's getStatus()), use it for /status-monday. Otherwise the admin
     // surface is empty and individual handlers degrade to "not configured".
     this.adminService = opts.adminService ?? (opts.knowledgeService as unknown as AdminService);
 
@@ -193,13 +193,13 @@ export class SlackAdapter {
       }
     });
 
-    this.registerAdminCommand("/status", (_args, _text) => statusCommand(this.adminService));
+    this.registerAdminCommand("/status-monday", (_args, _text) => statusCommand(this.adminService));
     this.registerAdminCommand("/sync-confluence", (_args, text) =>
       syncConfluenceCommand(this.adminService, text),
     );
     this.registerAdminCommand("/reindex", (_args, _text) => reindexCommand(this.adminService));
     this.registerAdminCommand("/help", (_args, _text) => helpCommand(this.adminService));
-    this.registerAdminCommand("/feedback", (_args, text) =>
+    this.registerAdminCommand("/feedback-monday", (_args, text) =>
       feedbackCommand(this.adminService, text),
     );
   }

--- a/src/slack/commands.ts
+++ b/src/slack/commands.ts
@@ -2,8 +2,8 @@
  * Admin slash command handlers for the Slack adapter (US-09).
  *
  * Each handler is a plain function so it can be unit-tested without the Bolt
- * runtime. The adapter wires them onto specific slash commands (`/status`,
- * `/sync-confluence`, `/reindex`, `/help`, `/feedback`).
+ * runtime. The adapter wires them onto specific slash commands (`/status-monday`,
+ * `/sync-confluence`, `/reindex`, `/help`, `/feedback-monday`).
  *
  * Handlers are intentionally tolerant of partial service shapes — the AC tests
  * pass `{}` or a minimal mock object — and never throw on missing methods.
@@ -37,11 +37,11 @@ export type CommandHandler = (
 
 const AVAILABLE_COMMANDS: ReadonlyArray<{ name: string; description: string }> = [
   { name: "/ask <question>", description: "Ask the bot a question against the indexed docs." },
-  { name: "/status", description: "Show document count, watcher status, and uptime." },
+  { name: "/status-monday", description: "Show document count, watcher status, and uptime." },
   { name: "/sync-confluence [space]", description: "Trigger a fresh sync of the Confluence space." },
   { name: "/reindex", description: "Re-index all watched files and Confluence pages." },
   { name: "/help", description: "Show this help message." },
-  { name: "/feedback <message>", description: "Send feedback to the bot maintainers." },
+  { name: "/feedback-monday <message>", description: "Send feedback to the bot maintainers." },
 ];
 
 function formatUptime(totalSeconds: number): string {
@@ -57,7 +57,7 @@ function formatUptime(totalSeconds: number): string {
 }
 
 /**
- * `/status` — synchronous, returns a one-line summary string. Reads from
+ * `/status-monday` — synchronous, returns a one-line summary string. Reads from
  * `service.getStatus()`. If the service is missing or doesn't expose
  * `getStatus`, returns a degraded but still well-formed string so the AC's
  * regexes still pass for callers that pass a richer mock.
@@ -117,14 +117,14 @@ export const helpCommand: CommandHandler = () => {
 };
 
 /**
- * `/feedback <message>` — capture user feedback. By default we log to stdout so
+ * `/feedback-monday <message>` — capture user feedback. By default we log to stdout so
  * operators can grep the bot logs; production wiring can supply
  * `service.recordFeedback` to forward to a ticket system.
  */
 export const feedbackCommand: CommandHandler = (service, message) => {
   const text = typeof message === "string" ? message.trim() : "";
   if (text.length === 0) {
-    return "Usage: /feedback <message> — please include a description of what was wrong.";
+    return "Usage: /feedback-monday <message> — please include a description of what was wrong.";
   }
   if (service && typeof service.recordFeedback === "function") {
     try {


### PR DESCRIPTION
## What

Rename two admin slash commands that collide with Slack's reserved built-in command words:

- `/status` → `/status-monday`
- `/feedback` → `/feedback-monday`

`/ask`, `/sync-confluence`, `/reindex`, `/help` are NOT reserved and stay unchanged.

## Why

Slack reserves `/status` and `/feedback` for its own built-ins, which can shadow or swallow the bot's admin commands. Renaming them with a `-monday` suffix avoids the collision.

## Scope

Pure mechanical string rename — no behavior change. The user-facing command tokens are renamed in the adapter registration, the `/help` command listing, and the `/feedback` usage string, plus matching doc-comments. The internal `commandHandlers` registry keys (`status`, `feedback`, …) are code identifiers and are left unchanged.

## Verification

- `npm run build` clean (tsc)
- `npm test` green: 22 suites / 176 tests
- Old command strings gone from `src/`; new `-monday` names present; other commands untouched

3-role loop (planner inline-skipped, plan-review + executor + execution-review as subagents) — artifacts under `.ai-workspace/`.

https://claude.ai/code/session_01FV7REFAxxyRbgvfQm1fJr9