### PR TITLE
fix: scrub regulated denylist tokens from #1066 execution-review artifact

### DIFF
--- a/.ai-workspace/reviews/1066-execution-review.md
+++ b/.ai-workspace/reviews/1066-execution-review.md
@@ -36,7 +36,7 @@ Build + test (oracle):
 - `npm run build` (tsc) → clean, no errors.
 - `npm test` → Test Suites: 22 passed, 22 total; Tests: 176 passed, 176 total. GREEN.
 
-Privacy (public repo): `git grep -inE 'burrox|getspace' HEAD -- .` → PRIVACY CLEAN (zero hits).
+Privacy (public repo): grepped the final tree for the regulated employer-brand / host denylist tokens (patterns kept out of this public-repo artifact) → PRIVACY CLEAN (zero hits).
 
 cairn: "[T1] ...slash commands (including `/compact`) are parsed CLIENT-SIDE by the..." — prior hits concern Claude Code client-side slash-command parsing, not Slack command registration; no directly applicable lesson for this rename.
 


### PR DESCRIPTION
## What

The execution-review artifact for #1066 (`.ai-workspace/reviews/1066-execution-review.md`) pasted the literal privacy-grep denylist patterns into a tracked file. Since this is a public repo, replace that line with a generic description of the privacy check. No code or behavior change.

## Verification

`git grep` for the regulated tokens over the branch tree returns zero hits.

https://claude.ai/code/session_01FV7REFAxxyRbgvfQm1fJr9