### PR TITLE
fix(1066): cited-only source list, lead-with-found prompt, sanitize source titles

### DIFF
--- a/.ai-workspace/plans/2026-06-23-1066-citation-answer-hygiene.md
+++ b/.ai-workspace/plans/2026-06-23-1066-citation-answer-hygiene.md
@@ -1,0 +1,120 @@
+# 1066 — Citation / Answer Hygiene (slice 1)
+
+## ELI5
+Right now the bot always shows the top 5 documents it looked at, even when the
+answer only really used 1 of them — and on "I couldn't find it" replies it still
+shows 5 unrelated documents, which makes it look like it's citing them. This
+change makes the bot show ONLY the documents it actually pointed at in the
+answer (the `[N]` tags), show NOTHING when it cited nothing, lead with what it
+DID find before mentioning gaps, and stop a weird-looking document title (one
+with stray `**` markdown) from breaking the Slack layout.
+
+## Execution model
+subagent (knob-A = `delegate`). Rationale: the work spans 2 source files + 2
+test files (>10 LOC, above trivial-skip) and is fully briefable as one coherent
+surface, so it is handed to a single fresh executor subagent; reviewed by a
+stateless plan-reviewer before and a stateless execution-reviewer after. Not
+inline (no live-session coupling), not parallel (one disjoint surface).
+
+## Scope
+- `src/llm/generate.ts` — cited-only citation filtering + system-prompt reorder.
+- `src/slack/formatter.ts` — sanitize source/heading text against stray markdown.
+- `tests/generate.test.ts`, `tests/slack-formatter.test.ts` — new + updated unit tests.
+
+In-scope only; the following are intentionally untouched (SCOPE GUARD): retrieval,
+the LLM model choice, admin commands, `src/slack/adapter.ts`,
+`src/slack/commands.ts` (concurrent rename PR owns those two files).
+
+## cairn
+cairn: ran `node skills/cairn/bin/cairn-find.mjs "citation"` / `"slack format"` —
+no monday-bot-specific hits; nearest applicable lesson is the parent-CLAUDE
+"eyeball the specific instance" + both-ends-testable discipline, applied here as
+pure-helper unit tests on the exact filter behavior.
+
+## Fix 1 — Cited-only source list (`generate.ts`)
+After the answer TEXT exists (BOTH the live-LLM path AND the `offlineAnswer`
+path), parse the set of `[N]` markers that actually appear in the answer and
+return ONLY those citations, KEEPING their original numbers (cite `[2]` and
+`[4]` → return citations numbered 2 and 4; never renumber to 1,2). No `[N]`
+markers (refusals / NO_CONTEXT_ANSWER) → empty citations array.
+
+- Add an exported pure helper `selectCitedCitations(answer, citations)` so the
+  filter is directly both-ends unit-testable (the anthropic stub only ever
+  cites `[1]`, so the [2]/[4] case can't be reached through `generateAnswer`).
+- Apply it in the live path (`{ answer: text, citations: selectCitedCitations(text, buildCitations(chunks)) }`)
+  and in `offlineAnswer` (`citations: selectCitedCitations(answer, buildCitations(chunks))`).
+- The empty-chunks short-circuit and the non-text-response branch already return
+  `citations: []` — leave them.
+
+### Known existing-test interaction (intended behavior change)
+`generate.test.ts` "chunks produce an answer plus a citations array keyed by
+source" passes 2 chunks through the LIVE path; the stub answer cites only `[1]`,
+so under cited-only filtering the result is exactly 1 citation (number 1), not 2.
+This existing test is UPDATED to assert the new cited-only contract (length 1,
+only citation 1). This is the intended fix, not a regression.
+
+## Fix 2 — Lead-with-found framing (`generate.ts`, prompt-only)
+Reorder `SYSTEM_PROMPT` so the model LEADS with what it found in context and
+cites it, and only notes any remaining gap AFTERWARD — while KEEPING the
+existing honesty rule ("if the context contains no relevant info, say you
+couldn't find it"). Prompt text only; no logic change. No test asserts the exact
+prompt string (verified), so this breaks nothing.
+
+## Fix 3 — Sanitize source/heading markdown (`formatter.ts`)
+A source/heading containing literal Slack mrkdwn (e.g. stray `**`) breaks the
+context-block layout. Add a small `sanitizeTitle(s)` that (a) escapes Slack's
+required HTML chars `& < >` and (b) strips the emphasis/code chars `* ~ `` `
+that have no legitimate place in a filename/heading and were the culprit. Leave
+`_` intact (legitimate in filenames; only italicizes in matched pairs). Apply to
+`c.source` and `c.heading` where the context line is built.
+
+## Binary AC
+1. `npm run build` exits 0 (tsc clean) in the worktree.
+2. `npm test` exits 0 with ALL specs green, INCLUDING:
+   - new: answer `"…foo [2] … bar [4]"` over 5 chunks → exactly citations `[2],[4]`.
+   - new: answer with NO `[N]` markers → `[]`.
+   - new: the `NO_CONTEXT_ANSWER` sentinel → `[]`.
+   - new: a source title containing `**` renders with no literal `**` in the
+     context-block element text.
+   - updated: the live-path 2-chunk test asserts cited-only (1 citation).
+3. `git grep` of the diff contains no regulated employer-brand token; the repo
+   privacy denylist gate passes on the PR.
+
+## Roles
+- planner: inline-skip (orchestrator) — the brief fully decomposes the work
+  (exact files, exact both-ends behavior, exact new tests); there is no
+  architectural discovery, only mechanical transcription of an already-specified
+  contract. Specific reason recorded for the gate.
+- plan-review: stateless write-capable subagent.
+- executor: stateless write-capable subagent.
+- execution-review: stateless write-capable subagent.
+
+## Deferred-follow-ups:
+- This is slice 1 of the #1066 UAT polish; the remaining UAT polish items (the
+  low-pri lowercase-"couldn't" refusal variance, any broader answer-quality
+  tuning) are NOT addressed here. → file a follow-up slice only if the live
+  re-UAT after this deploy still shows them; the prompt reorder in Fix 2 may
+  already resolve the lowercase variance. No load-bearing work is being silently
+  dropped — slice 1's three fixes are the full committed scope.
+
+## Review (plan)
+Decision: PASS — all three fixes verified implementable against source; both
+citation paths (live + offline) covered with original-number-preserving filter,
+exported pure helper is the correct both-ends approach (stub only cites [1]), no
+test asserts the system prompt text (grep-verified) so Fix 2 is safe, sanitize
+correctly strips `* ~ \`` while leaving the `*[N]*` bold wrapper intact, scope
+guard on adapter.ts/commands.ts confirmed, and Binary AC is observable from
+outside the diff. No required changes. Full review:
+.ai-workspace/reviews/1066-citation-plan-review.md
+
+## Review (execution)
+Decision: PASS — build exit 0; 22 suites / 183 tests green; privacy-clean;
+scope guard holds (adapter.ts/commands.ts untouched). All three fixes verified
+in code (cited-only filter at both live+offline paths with original-number
+preservation + defensive guard; prompt reorder keeps honesty/never-cite/concise
+rules; sanitizeTitle escapes &<> then strips *~` while preserving the `*[N]*`
+wrapper and `_`). The two AC-03 e2e assertion changes are a FAITHFUL, minimal
+re-expression of the parser-agnostic-parity intent at the index layer
+(documentCount) — necessary because cited-only filtering retires the old
+all-sources-cited proof vehicle — not an improper weakening. Full review:
+.ai-workspace/reviews/1066-citation-execution-review.md

--- a/.ai-workspace/reviews/1066-citation-execution-review.md
+++ b/.ai-workspace/reviews/1066-citation-execution-review.md
@@ -1,0 +1,87 @@
+# 1066 Citation/Answer Hygiene (slice 1) — Execution Review
+
+Decision: PASS
+
+Stateless execution review of the worktree diff for monday-bot #1066 slice 1
+(citation/answer hygiene). Reviewer did not write this code; verified by reading
+the diff and running the gates independently.
+
+## Gates (run by reviewer)
+- `npm run build` → exit 0 (tsc clean).
+- `npm test` → exit 0. **22 suites passed, 183 tests passed**, 0 failed.
+
+## Privacy
+Ran `git --no-pager diff | grep -i <regulated tokens>` plus a token-scan of every
+changed surface. **No regulated employer-brand token appears anywhere in the
+diff.** Repo-public-safe. PASS.
+
+## Scope guard
+`git diff --name-only` = exactly the 5 expected files
+(`src/llm/generate.ts`, `src/slack/formatter.ts`, `tests/generate.test.ts`,
+`tests/slack-formatter.test.ts`, `tests/integration.e2e.test.ts`).
+`src/slack/adapter.ts` and `src/slack/commands.ts` are NOT in the diff. PASS.
+
+## Fix-by-fix verification (read code, not claims)
+- **Fix 1 — `selectCitedCitations`**: parses distinct `[N]` markers via
+  `matchAll(/\[(\d+)\]/g)` into a `Set` (dedupe), returns `citations.filter`
+  keeping original list numbers/order, returns `[]` when `cited.size === 0`
+  (refusals / NO_CONTEXT_ANSWER), defensive guard `typeof answer !== "string"
+  || !Array.isArray(citations) -> []`. Applied at BOTH the live-LLM return
+  (generate.ts:170) AND `offlineAnswer` (generate.ts:69). Empty-chunks
+  short-circuit (:118) and non-text branch (:165) still return `citations: []`,
+  untouched. Exported and unit-tested. CORRECT.
+- **Fix 2 — SYSTEM_PROMPT reorder**: now leads "Lead with what you DID find …
+  cite it with inline [N] … only after stating what you found, note any
+  remaining gap." KEEPS the honesty rule ("If the context contains no relevant
+  information, say you couldn't find the information"), the never-cite-outside
+  rule ("Never cite outside the numbered list"), and the concise-Slack guidance.
+  Prompt-string only; no logic change. No test asserts the prompt string. CORRECT.
+- **Fix 3 — `sanitizeTitle`**: escapes `&`→`&amp;`, `<`→`&lt;`, `>`→`&gt;` in
+  that order (ampersand first, so `<`/`>` replacements aren't double-escaped),
+  then strips `[*~`]`. Leaves `_` intact. Applied to BOTH `c.source` and
+  `c.heading`. The `*[${n}]*` bold wrapper is built OUTSIDE the sanitize call,
+  so the wrapper asterisks survive. CORRECT.
+- **Tests**: `selectCitedCitations` suite covers `[2]/[4] -> 2,4`, no-markers
+  `-> []`, `NO_CONTEXT_ANSWER -> []`, plus dedupe and out-of-range and the
+  defensive cases. Formatter test asserts no literal `**` and no backtick
+  survive while visible words ("Important"/"Guide"/"code") remain. The updated
+  2-chunk live-path test now asserts cited-only (length 1, citation number 1)
+  and drops the stale 2nd-citation assertion. CORRECT.
+
+## e2e-weakening judgment (the item to scrutinize) — FAITHFUL, not a weakening
+The executor changed the two AC-03 parity assertions in
+`tests/integration.e2e.test.ts`. The original tests proved "format parity /
+parser-agnostic survival" by asserting the citation set contained EVERY source
+format (`expect(sources).toEqual(expect.arrayContaining([...all formats...]))`).
+That proof vehicle is exactly what slice-1 deliberately removes: under cited-only
+filtering the offline answer cites only `[1]`, so only the top-ranked source
+survives in the citation set. Keeping the old assertion would assert the OLD
+"all-sources-cited" contract that this slice is built to retire — it could not
+pass and would be self-contradictory.
+
+The re-expression relocates the SAME intent to the index layer:
+`expect(svc.getStatus().documentCount).toBe(2)` (and `.toBe(4)`) directly proves
+all N formats survived indexing — which IS the parser-agnostic property (a
+silently-dropped format would lower the unique-source count). It additionally
+KEEPS a meaningful citation invariant: every rendered source must be one of the
+declared parity formats (`for (const s of sources) expect([...]).toContain(s)`),
+so no foreign source can leak. Only the now-impossible `sources.length >= 2`
+assertion is relaxed to `>= 1`.
+
+Net: the change ADDS a more direct index-layer proof of parser-agnostic survival
+plus a no-foreign-source membership check, and only relaxes the one assertion the
+new contract makes mechanically impossible. This is a faithful, minimal
+preservation of original intent, NOT an improper weakening. The 183-green run
+confirms `getStatus().documentCount` is real (the new assertions are non-vacuous).
+
+## cairn
+`node skills/cairn/bin/cairn-find.mjs "test weaken"` / `"assertion contract"` —
+relevant hit: T1 (2026-05-27) "When testing a generated prompt or assembled
+string, assert on the runtime-captured output, not a source-grep of the
+generator." Applies to Fix 2: the prompt reorder is correctly verified via
+runtime behavior (no test asserts the prompt string), and the citation behavior
+is asserted on runtime output (selectCitedCitations results), not source greps.
+Consistent with this diff.
+
+## Findings
+None. No required changes.

--- a/.ai-workspace/reviews/1066-citation-plan-review.md
+++ b/.ai-workspace/reviews/1066-citation-plan-review.md
@@ -1,0 +1,49 @@
+# Plan Review — #1066 Citation / Answer Hygiene (slice 1)
+
+Decision: PASS
+
+Reviewer: stateless plan-review subagent. Scope: review only — no source/test files modified.
+Plan reviewed: `.ai-workspace/plans/2026-06-23-1066-citation-answer-hygiene.md`.
+
+> NOTE (filename collision): this file previously held the plan-review for the SEPARATE,
+> already-merged rename slice (`2026-06-23-1066-rename-reserved-slash-commands.md`, PR #205).
+> Both slices share task number 1066. That prior content remains in git history (commit
+> abfa99a / PR #205) and is recoverable; this write replaces the working-tree copy with the
+> citation-hygiene slice's review per the review brief's explicit path.
+
+cairn: ran `node skills/cairn/bin/cairn-find.mjs "citation"` and `"slack format"` — no monday-bot-specific hits (matches were memory-magnitude lessons + generic git/tool-failure notes, none applicable). Nearest applicable discipline is the both-ends-testable / "eyeball the specific instance" parent-CLAUDE pattern, which the plan already applies via the exported pure helper + direct unit tests. Consistent with the plan's own `cairn:` line.
+
+## Criteria findings
+
+### 1. Fix 1 — cited-only citations (PASS)
+- BOTH paths handled. Plan applies `selectCitedCitations` in the live-LLM path (`{ answer: text, citations: selectCitedCitations(text, buildCitations(chunks)) }`) and in `offlineAnswer`. Verified against `generate.ts`: these are the ONLY two sites that emit `citations: buildCitations(chunks)`. The empty-chunks short-circuit (line 95) and the non-text branch (line 142) already return `[]` and are correctly left untouched.
+- Original numbers kept (no renumber). Filtering the `buildCitations` array (numbered 1..N) by the set of `[N]` parsed from the answer preserves each citation's `number`. AC "foo [2] … bar [4] → exactly citations [2],[4]" pins this and is satisfied by citation-order filtering.
+- Empty when no markers. NO_CONTEXT_ANSWER / refusals contain no `[N]` → `[]`. Correct.
+- Existing-test interaction correctly identified. The live-path 2-chunk test ("chunks produce an answer plus a citations array…") currently asserts length 2; the stub answer cites only `[1]` (verified `tests/__stubs__/anthropic-sdk.js:42` — `…directly [1].`), so cited-only filtering yields exactly 1 citation `{number:1, source:"vpn-guide.txt", heading:"VPN Setup"}` — which equals `buildCitations(chunks)[0]`. Plan flags this as an intended UPDATE, not a regression. Sound.
+- Exported pure helper is the right both-ends approach. The stub only ever cites `[1]`, so the [2]/[4] multi-citation case is unreachable through `generateAnswer`; exporting `selectCitedCitations` makes the filter directly unit-testable. Correct.
+
+### 2. Fix 2 — prompt reorder (PASS)
+- Honesty rule preserved — plan keeps the "if context insufficient, say you couldn't find it" clause while leading with found-content framing.
+- No test asserts exact prompt text — VERIFIED: `grep -rn "SYSTEM_PROMPT|You answer factually|couldn't find the information" tests/` → zero matches. Prompt-only change breaks nothing. The `empty chunks` test matches a refusal regex on the ANSWER, not the prompt, so it is unaffected.
+
+### 3. Fix 3 — title sanitize (PASS)
+- Approach (escape `& < >`, strip `* ~ \``, keep `_`) is sound and non-destructive. `& < >` escaping is exactly Slack mrkdwn's required HTML-entity encoding; `* ~ \`` are emphasis/code chars with no legitimate place in a filename/heading and are the stray-`**` culprit. Keeping `_` is correct (legal in filenames; only italicizes in matched pairs).
+- Neutralizes the `**` problem. Stripping `*` from `c.source`/`c.heading` removes the literal `**`. The `*[${n}]*` bold wrapper around the citation NUMBER is NOT sanitized (sanitize applies only to source/heading), so `[N]` still renders bold. Correct seam.
+- Existing formatter tests stay green. All fixtures (`vpn-guide.txt`, `wfh.md`, `guide.md`, `hr-policy.txt`, heading `Setup`) contain no sanitized chars → unchanged output. Verified against `tests/slack-formatter.test.ts`.
+
+### 4. Scope guard (PASS)
+- Plan's Scope section explicitly lists `src/slack/adapter.ts` and `src/slack/commands.ts` as INTENTIONALLY untouched (concurrent rename PR owns them). Confirmed `adapter.ts` imports `generate` and consumes `citations`, but the cited-only behavior change flows through it WITHOUT editing it (adapter formats whatever citations it receives). No scope violation.
+
+### 5. Binary AC (PASS — observable)
+- AC1 `npm run build` exit 0, AC2 `npm test` exit 0, AC3 `git grep` privacy clean — all checkable from outside the diff via command exit codes. AC2's sub-bullets describe observable helper behaviors (new helper unit tests + the updated live-path assertion). Acceptable.
+
+### 6. Correctness traps / edge cases (none blocking)
+- LATENT-BUG FIX (positive). In `offlineAnswer`, when all chunk text is empty, `body.length===0` currently returns `NO_CONTEXT_ANSWER` WITH a non-empty `buildCitations(chunks)`. Under cited-only filtering that becomes `[]` (no `[N]` in the sentinel) — consistent with intent, not a regression.
+- Single-chunk offline test (`MONDAY_TEST_MODE=1`) stays green: answer appends `[1]`, citations=[{number:1}] → filter keeps it. Plan doesn't call this out explicitly but it remains green (confirmation, not a required change).
+- Citation ORDER: filtering the `buildCitations` array yields citation-number order (`[2],[4]`), matching the AC even if the answer mentions `[4]` before `[2]`. Duplicate `[1][1]` dedupes via a set; out-of-range markers (e.g. `[9]` with 5 chunks) safely drop. All handled by the natural impl.
+
+## Required changes
+None. Plan is implementable as written.
+
+## Optional (non-blocking) suggestions
+- Consider noting in the plan that the single-chunk offline test stays green and that the empty-body offline case now correctly returns `[]` — purely confirmatory, no action required.

--- a/src/llm/generate.ts
+++ b/src/llm/generate.ts
@@ -5,12 +5,35 @@ const MAX_TOKENS = 1024;
 
 const SYSTEM_PROMPT =
   "You answer factually from the provided context only. " +
-  "Use inline [N] citations that map to the numbered sources in the context block, " +
-  "never cite outside the numbered list, and if the context is insufficient say you couldn't find the information. " +
+  "Lead with what you DID find in the context and cite it with inline [N] citations that map to the numbered sources in the context block; " +
+  "only after stating what you found, note any remaining gap. " +
+  "Never cite outside the numbered list. " +
+  "If the context contains no relevant information, say you couldn't find the information. " +
   "Keep answers concise (target 50-400 words) and suitable for a Slack message.";
 
-const NO_CONTEXT_ANSWER =
+export const NO_CONTEXT_ANSWER =
   "I couldn't find any relevant information in the indexed documents to answer this question.";
+
+/**
+ * Pure helper: return ONLY the citations whose `number` actually appears as an
+ * inline `[N]` marker in `answer`, keeping their original numbers and order.
+ *
+ * - Parses the distinct `[N]` markers present in the answer text.
+ * - If no `[N]` markers appear (e.g. refusals / NO_CONTEXT_ANSWER), returns [].
+ * - Defensive: non-string `answer` or non-array `citations` -> [].
+ */
+export function selectCitedCitations(
+  answer: string,
+  citations: Citation[],
+): Citation[] {
+  if (typeof answer !== "string" || !Array.isArray(citations)) return [];
+  const cited = new Set<number>();
+  for (const m of answer.matchAll(/\[(\d+)\]/g)) {
+    cited.add(Number(m[1]));
+  }
+  if (cited.size === 0) return [];
+  return citations.filter((c) => cited.has(c.number));
+}
 
 /**
  * Offline / test-mode flag. When set (or when no Anthropic credentials are
@@ -43,7 +66,7 @@ function offlineAnswer(chunks: Chunk[]): AnswerResult {
       : NO_CONTEXT_ANSWER;
   return {
     answer,
-    citations: buildCitations(chunks),
+    citations: selectCitedCitations(answer, buildCitations(chunks)),
   };
 }
 
@@ -144,6 +167,6 @@ export async function generateAnswer(
 
   return {
     answer: text,
-    citations: buildCitations(chunks),
+    citations: selectCitedCitations(text, buildCitations(chunks)),
   };
 }

--- a/src/slack/formatter.ts
+++ b/src/slack/formatter.ts
@@ -64,6 +64,21 @@ function citationNumber(c: FormatterCitationInput): number {
 }
 
 /**
+ * Sanitize a source/heading title for safe rendering inside a Slack mrkdwn
+ * context line. Escapes Slack's required HTML chars (`& < >`, in that order)
+ * and strips the emphasis/code chars (`* ~` and backtick) that break layout
+ * when they appear unbalanced (e.g. a stray `**`). Underscore is left intact —
+ * it is legitimate in filenames and only italicizes in matched pairs.
+ */
+function sanitizeTitle(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/[*~`]/g, "");
+}
+
+/**
  * Format a `{ answer, citations }` payload into a Slack Block Kit message.
  *
  * Layout:
@@ -97,10 +112,13 @@ export function formatAnswer(input: FormatAnswerInput): SlackMessagePayload {
 
     const lines: SlackTextObject[] = citations.map((c) => {
       const n = citationNumber(c);
-      const heading = typeof c.heading === "string" && c.heading.length > 0 ? ` — ${c.heading}` : "";
+      const heading =
+        typeof c.heading === "string" && c.heading.length > 0
+          ? ` — ${sanitizeTitle(c.heading)}`
+          : "";
       return {
         type: "mrkdwn",
-        text: `*[${n}]* ${c.source}${heading}`,
+        text: `*[${n}]* ${sanitizeTitle(c.source)}${heading}`,
       };
     });
 

--- a/tests/generate.test.ts
+++ b/tests/generate.test.ts
@@ -12,7 +12,13 @@ jest.mock("node:os", () => {
   };
 });
 
-import { generateAnswer, Chunk } from "../src/llm/generate";
+import {
+  generateAnswer,
+  selectCitedCitations,
+  NO_CONTEXT_ANSWER,
+  Chunk,
+  Citation,
+} from "../src/llm/generate";
 
 describe("generateAnswer", () => {
   const originalEnv = process.env.ANTHROPIC_API_KEY;
@@ -52,13 +58,14 @@ describe("generateAnswer", () => {
     const result = await generateAnswer("How do I set up VPN?", chunks);
     expect(typeof result.answer).toBe("string");
     expect(result.answer.length).toBeGreaterThan(0);
-    expect(result.citations).toHaveLength(2);
+    // The stub answer only cites [1], so under cited-only filtering exactly one
+    // citation (number 1) survives — the uncited [2] source is dropped.
+    expect(result.citations).toHaveLength(1);
     expect(result.citations[0]).toEqual({
       number: 1,
       source: "vpn-guide.txt",
       heading: "VPN Setup",
     });
-    expect(result.citations[1]).toEqual({ number: 2, source: "vpn-guide.txt" });
   });
 
   test("stub-provided answer carries a [1] citation marker", async () => {
@@ -110,5 +117,50 @@ describe("generateAnswer", () => {
         heading: "Leave",
       });
     });
+  });
+});
+
+describe("selectCitedCitations", () => {
+  const five: Citation[] = [
+    { number: 1, source: "a.txt" },
+    { number: 2, source: "b.txt" },
+    { number: 3, source: "c.txt" },
+    { number: 4, source: "d.txt" },
+    { number: 5, source: "e.txt" },
+  ];
+
+  test("returns only the cited citations, original numbers and order", () => {
+    const result = selectCitedCitations("Foo [2] and bar [4].", five);
+    expect(result).toEqual([
+      { number: 2, source: "b.txt" },
+      { number: 4, source: "d.txt" },
+    ]);
+  });
+
+  test("returns [] when the answer has no [N] markers", () => {
+    expect(selectCitedCitations("I could not find it.", five)).toEqual([]);
+  });
+
+  test("returns [] for the NO_CONTEXT_ANSWER sentinel", () => {
+    expect(selectCitedCitations(NO_CONTEXT_ANSWER, five)).toEqual([]);
+  });
+
+  test("dedupes duplicate markers to a single citation", () => {
+    const result = selectCitedCitations("See [2] ... and again [2].", five);
+    expect(result).toEqual([{ number: 2, source: "b.txt" }]);
+  });
+
+  test("drops out-of-range markers", () => {
+    const result = selectCitedCitations("Refers to [9] only.", five);
+    expect(result).toEqual([]);
+  });
+
+  test("defensive: non-string answer or non-array citations -> []", () => {
+    expect(
+      selectCitedCitations(undefined as unknown as string, five),
+    ).toEqual([]);
+    expect(
+      selectCitedCitations("Foo [1].", undefined as unknown as Citation[]),
+    ).toEqual([]);
   });
 });

--- a/tests/integration.e2e.test.ts
+++ b/tests/integration.e2e.test.ts
@@ -134,18 +134,22 @@ describe("US-12 e2e: full query round-trip", () => {
       lower.includes("8.30") ||
       lower.includes("eight thirty");
 
-    // Either the LLM (jest stub) returned an answer that quotes the fact,
-    // OR the offline-fallback path concatenated chunk text directly. Either
-    // way, the citations must point back to both formats.
+    // Both formats are indexed and survive the pipeline (parity at the index
+    // layer). Under cited-only citation filtering, the rendered citations carry
+    // only the source(s) the answer actually pointed at with [N] markers — the
+    // stub answer cites [1], so exactly the top-ranked source appears, and it
+    // must be one of the two parity formats.
+    expect(svc.getStatus().documentCount).toBe(2);
     const sources = result.citations.map((c) => c.source);
-    expect(sources).toEqual(
-      expect.arrayContaining(["office-hours.txt", "office-hours.md"]),
-    );
+    expect(sources.length).toBeGreaterThanOrEqual(1);
+    for (const s of sources) {
+      expect(["office-hours.txt", "office-hours.md"]).toContain(s);
+    }
 
     // The Anthropic stub returns generic text that may not contain "8:30",
     // so we accept EITHER (a) the answer carries the fact, OR (b) the
-    // citation set carries both source formats — both prove parity.
-    expect(hasFact || sources.length >= 2).toBe(true);
+    // cited-only citation set still resolves to a parity source.
+    expect(hasFact || sources.length >= 1).toBe(true);
   });
 
   it("AC-03 supplement: PDF/DOCX format parity via indexChunks (parser-agnostic)", async () => {
@@ -162,11 +166,17 @@ describe("US-12 e2e: full query round-trip", () => {
     await svc.indexChunks(pages);
 
     const result = await svc.query("what time does the office open?");
+    // All four formats survive indexing regardless of parser (the parser-
+    // agnostic property), proven at the index layer by the unique-source count.
+    expect(svc.getStatus().documentCount).toBe(4);
+    // Under cited-only citation filtering the answer cites [1], so the rendered
+    // citations carry only the top-ranked source — which must be one of the
+    // four indexed formats.
     const sources = result.citations.map((c) => c.source);
-    // All four formats survive into the citation set.
-    expect(sources).toEqual(
-      expect.arrayContaining(["hours.txt", "hours.md", "hours.pdf", "hours.docx"]),
-    );
+    expect(sources.length).toBeGreaterThanOrEqual(1);
+    for (const s of sources) {
+      expect(["hours.txt", "hours.md", "hours.pdf", "hours.docx"]).toContain(s);
+    }
   });
 
   it("e2e: documentCount tracks unique sources after a mixed pipeline", async () => {

--- a/tests/slack-formatter.test.ts
+++ b/tests/slack-formatter.test.ts
@@ -88,6 +88,24 @@ describe("slack/formatter", () => {
     }
   });
 
+  it("sanitizes stray markdown in the source/heading title", () => {
+    const payload = formatAnswer({
+      answer: "See the doc. [1]",
+      citations: [{ num: 1, source: "**Important** Guide", heading: "`code`" }],
+    });
+    const ctx = payload.blocks.find((b) => b.type === "context");
+    expect(ctx).toBeDefined();
+    if (ctx && ctx.type === "context") {
+      const text = ctx.elements[0].text;
+      expect(text).not.toContain("**");
+      expect(text).not.toContain("`");
+      // Sanitized visible words survive.
+      expect(text).toContain("Important");
+      expect(text).toContain("Guide");
+      expect(text).toContain("code");
+    }
+  });
+
   it("throws TypeError on bad input", () => {
     expect(() => formatAnswer(undefined as never)).toThrow(TypeError);
     expect(() => formatAnswer({ answer: 123 as never })).toThrow(TypeError);


### PR DESCRIPTION
## What
UAT slice 1 for #1066 — answer/citation hygiene. The live UAT found the bot honest, grounded, and crash-resistant with zero hallucinations; the one recurring issue was that every reply listed the top-5 retrieved sources even when the answer cited only 0–1 of them (and refusals showed 5 unrelated sources, looking like it cited them).

## Fixes
1. **Cited-only source list** (`src/llm/generate.ts`): new exported pure helper `selectCitedCitations()` returns only the citations whose `[N]` marker actually appears in the answer, keeping original numbers. Refusals / `NO_CONTEXT_ANSWER` (no markers) → empty citations array, so the formatter renders no source list. Applied at both the live-LLM and `offlineAnswer` return sites.
2. **Lead-with-found framing** (`src/llm/generate.ts`, prompt-only): `SYSTEM_PROMPT` reordered to lead with what was found and cite it before noting any gap; the existing honesty rule is kept intact.
3. **Sanitize source titles** (`src/slack/formatter.ts`): `sanitizeTitle()` escapes `& < >` and strips `* ~ \`` so a stray `**` no longer breaks the Slack context block.

## Tests
New `selectCitedCitations` unit tests (`[2]/[4]`→2,4; no-markers→[]; `NO_CONTEXT_ANSWER`→[]; dedupe + out-of-range), a formatter no-literal-`**` test, and updated the live-path + two AC-03 e2e parity assertions to the cited-only contract (format parity re-proven at the index layer via `documentCount`). `npm run build` clean; 183 tests green on ubuntu + windows.

## Scope guard
Disjoint from the concurrent slash-command rename PR: this PR does NOT touch `src/slack/adapter.ts` or `src/slack/commands.ts`. Retrieval, the LLM model, and admin commands are untouched.

3-role: plan-review PASS, execution-review PASS (artifacts committed under `.ai-workspace/`).

index-check: none

https://claude.ai/code/session_01FV7REFAxxyRbgvfQm1fJr9