### PR TITLE
fix(1171): wire /sync-confluence + /reindex admin slash commands to on-demand re-sync

### DIFF
--- a/.ai-workspace/plans/2026-06-23-1171-wire-admin-slash-commands.md
+++ b/.ai-workspace/plans/2026-06-23-1171-wire-admin-slash-commands.md
@@ -1,0 +1,80 @@
+# 1171 — Wire /sync-confluence + /reindex admin slash commands
+
+## ELI5
+The bot has two "buttons" in Slack: `/sync-confluence` (go re-read the wiki now) and
+`/reindex` (re-read everything now). Right now those buttons reply "not configured" —
+because the thing that answers admin buttons (the knowledge service) knows how to report
+status but was never taught how to *re-sync*. The auto-sync at boot already works; only the
+on-demand buttons are unwired. We give the boot-time sync wiring two new public methods
+(`syncConfluence`, `reindexAll`), build a small `adminService` in `index.ts` that forwards
+the buttons to those methods, and hand it to the Slack adapter. Status keeps working unchanged.
+
+## Execution model
+**subagent (delegate).** Single coherent write surface (3 src files + 3 test files, all disjoint
+from the in-flight #1066 PR which touches generate.ts/formatter.ts). Briefable from this plan +
+the verified root cause; no live-session coupling. Knob A = `delegate`, Knob B = `both`
+(real `npm test` oracle + a stateless execution-reviewer). Plan-review + execution-review are
+separate stateless subagents per the 3-role model.
+
+## Root cause (verified)
+`SlackAdapter` defaults its `adminService` to the `knowledgeService` (adapter.ts:97).
+`KnowledgeService` has `getStatus()` (so `/status-monday` works) but NO
+`syncConfluence()`/`reindex()` → `syncConfluenceCommand`/`reindexCommand` (commands.ts:80-108)
+hit their "not configured" guard. The constructed `ConfluenceSync`/`JiraSync` instances in
+`startKnowledgeSources` (startup.ts) are local-scoped and discarded after wiring the scheduler,
+so nothing exposes an on-demand re-sync.
+
+## Scope (must-do = items 1-3; item 4 = secondary, do if clean)
+1. **src/knowledge/startup.ts** — retain the `ConfluenceSync` + `JiraSync` instances and their
+   spaces/projects lists; expose two new methods on `KnowledgeSourcesHandle`:
+   - `syncConfluence(spaceKey?): Promise<string>` — re-sync one space (if given) or all configured
+     spaces; return a human summary; return "Confluence is not configured" when unconfigured.
+   - `reindexAll(): Promise<string>` — re-run every Confluence space + every Jira project; return a
+     summary. (No on-demand folder-rescan method exists on KnowledgeService — folder watchers keep
+     folders live continuously — so folders are intentionally out of reindexAll; noted, not silently dropped.)
+   Both non-throwing (catch → return an error summary), consistent with the existing non-blocking design.
+2. **src/index.ts** — build an `adminService`: `getStatus` delegates to `knowledge.getStatus()`
+   (unchanged `/status-monday`), `syncConfluence`/`reindex` delegate to the new handle methods.
+   Pass it to `new SlackAdapter({... adminService})`.
+3. **src/slack/adapter.ts** — already accepts optional `adminService` (line 36/97) and defaults to
+   knowledgeService for back-compat. Confirm it is used for admin commands. No name/handler changes.
+   (Likely zero-diff here beyond confirmation — adapter already supports the option.)
+4. **SECONDARY** — `adminService.recordFeedback(msg)` appends feedback to a durable file
+   (default `~/Library/Logs/monday-bot-feedback.log`, override via `MONDAY_FEEDBACK_LOG`; dir created
+   best-effort). Keep the existing stdout `[feedback] ` line. Skip + note if it balloons scope.
+
+## Privacy (public repo)
+No employer brand/host/space-key/project-key anywhere — read targets from env only (existing pattern).
+Privacy git-grep the diff before push.
+
+## Critical files
+- src/knowledge/startup.ts (primary change)
+- src/index.ts (adminService construction)
+- src/slack/adapter.ts (confirm; likely no change)
+- tests/knowledge-sources.startup.test.ts, tests/slack-adapter.test.ts, tests/commands.test.ts (tests)
+
+## Tests
+- Handle methods: mock fetchers → `syncConfluence`/`reindexAll` return the right summaries; the
+  "not configured" path (no creds / no spaces).
+- Adapter: `/sync-confluence` + `/reindex` invoke the adminService (NOT the "not configured" guard).
+- `npm run build` (tsc clean) + `npm test` all green.
+
+### Binary AC
+- `cd <worktree> && npm run build` exits 0 (tsc clean).
+- `cd <worktree> && npm test` exits 0 (all suites green, including new tests).
+- The new adapter test asserts a `/sync-confluence` dispatch with a configured adminService returns a
+  response that does NOT contain "not configured" and DOES contain the summary token.
+- A test calls `startKnowledgeSources({...mock fetchers}).syncConfluence()` and asserts the returned string
+  matches `/Re-synced confluence/`; and `.reindexAll()` matches `/Reindexed:/`; and the no-creds handle
+  returns `/not configured/i` from `syncConfluence`.
+
+## Review
+### Plan-review (stateless)
+Decision: PASS-WITH-NITS
+cairn: WM hit `2026-04-27-pr-114-monday-bot-us09-admin-commands.md:15` — "KnowledgeService.getStatus() already existed from prior work — no service-layer changes were needed; the adapter accepts an optional `adminService` opt that defaults to `knowledgeService` for the status path." (confirms the root cause + back-compat seam this plan extends).
+- BACK-COMPAT VERIFIED: adapter.ts:97 defaults adminService → knowledgeService; index.ts:125 currently omits adminService so /sync-confluence + /reindex hit the "not configured" guard (root cause is accurate). Plan's `adminService.getStatus → knowledge.getStatus()` preserves /status-monday with the real doc count (ServiceStatus already conforms to AdminServiceStatus — the existing default proves the shape matches; return it verbatim, don't reshape). index.ts bridges the `reindex`→`reindexAll` name gap correctly. Disjoint from #1066 (generate.ts/formatter.ts) — confirmed, zero file overlap.
+- NON-THROWING is sound + already defense-in-depth: commands.ts:84-90/101-107 try/catch AND adapter.ts:227-239 try/catch already wrap the call, so the handle's own catch→summary is a third layer (good, keep it consistent with the non-blocking startup design at startup.ts:119-122).
+- NOT-CONFIGURED branch (a) no-creds is covered by AC `/not configured/i`, but branch (b) creds-present-but-`spaces.length===0` (startup.ts:107) is a DISTINCT code path with NO AC. ADD a test: Atlassian creds set + CONFLUENCE_SPACES empty → `syncConfluence()` returns `/not configured/i`. Retain confluence-configured and jira-configured as SEPARATE flags so a jira-only deployment still reindexes jira while syncConfluence reports not-configured.
+- MISSING EDGE CASES to specify in scope (not just code): (1) `reindexAll` with jira-configured-but-confluence-not (and vice-versa) — must reindex the configured source and NOT emit "not configured"; pin the mixed/partial-config summary shape so `/Reindexed:/` still matches. (2) `syncConfluence("<arbitrary key not in CONFLUENCE_SPACES>")` — decide validate-against-list vs pass-through-to-a-live-fetch (an admin can trigger a fetch for any key); state the chosen behavior, since syncSpace will hit the real API for whatever string it gets.
+- ITEM 4 (secondary) cross-platform NIT: default `~/Library/Logs/monday-bot-feedback.log` is macOS-only; CI is ubuntu+windows. `mkdir(recursive)` won't fail there but pollutes `$HOME/Library/Logs`. Tests MUST pin `MONDAY_FEEDBACK_LOG` to an os.tmpdir() path (never assert the default path), and recordFeedback MUST swallow append errors (no throw) so a read-only FS can't flake CI. Plan's "skip if it balloons scope" guard is the right call — keep it strictly optional.
+- AC QUALITY: build/test exit-codes + the regex-on-summary assertions are checkable from outside the diff (test-run observable, per repo convention). The exact tokens `Re-synced confluence`/`Reindexed:` are slightly how-prescriptive but acceptable as the binary contract. Privacy OK: summaries echo space/project keys only as ephemeral Slack replies at runtime; committed tests use DEMO/PROJ fakes — nothing real is baked.

--- a/.ai-workspace/reviews/2026-06-23-1171-execution-review.md
+++ b/.ai-workspace/reviews/2026-06-23-1171-execution-review.md
@@ -1,0 +1,41 @@
+# Execution-review — 1171
+Decision: PASS
+Build: tsc exit 0 (no diagnostics)  Tests: 22 suites / 191 tests passed
+Privacy-grep: CLEAN
+
+## Scope
+- Diff touches ONLY: `src/index.ts`, `src/knowledge/startup.ts`, `tests/index.startup.test.ts`, `tests/knowledge-sources.startup.test.ts`, `tests/slack-adapter.test.ts`, plus the plan doc.
+- Does NOT touch `src/llm/generate.ts` or `src/slack/formatter.ts` (the in-flight #1066 files). Correct.
+- `src/slack/adapter.ts` / `src/slack/commands.ts` already carried the optional-adminService back-compat from a prior task; unchanged here, consistent with the brief.
+
+## End-to-end wiring (verified)
+- Slack dispatch `/sync-confluence` → `registerAdminCommand` → `syncConfluenceCommand(this.adminService, text)` → `adminService.syncConfluence(arg||undefined)` → `sources.syncConfluence(spaceKey)` → `ConfluenceSync.syncSpace`. Argument is forwarded; empty text normalized to `undefined` in BOTH commands.ts and startup.ts. Confirmed by the `syncArgs).toEqual(["DEMO"])` test.
+- `/reindex` → `reindexCommand` → `adminService.reindex` → `sources.reindexAll()`.
+- `adminService.getStatus → knowledge.getStatus()`; `/status-monday` handler unchanged (`statusCommand(this.adminService)`), so the real doc count is preserved.
+
+## Non-throwing (both layers)
+- `syncConfluence`/`reindexAll` each wrap the sync loop in try/catch and return a summary string on error (`"… failed: <message>"`). They never reject.
+- Defense-in-depth: `commands.ts` handlers ALSO try/catch, and `registerAdminCommand` has its own try/catch posting `DEFAULT_FALLBACK_TEXT`. Three layers — a throw cannot reach the Bolt event loop.
+
+## "Not configured" detection
+- `confluenceSync` is assigned ONLY inside the `haveAtlassianCreds && spaces.length > 0` branch (startup.ts ~133), so it stays `undefined` for BOTH (no creds) AND (creds-but-empty CONFLUENCE_SPACES). `syncConfluence` returns the exact string `"Confluence is not configured"` in both cases.
+- Both branches are exercised: the "NO creds" test and the dedicated "creds present but CONFLUENCE_SPACES empty → confluence not configured; reindex is jira-only" test (which also asserts the jira fetcher is hit and the confluence fetcher is NOT — it throws if called).
+
+## reindexAll partial config
+- Independent `if (confluenceSync)` / `if (jiraSync)` guards → confluence-only, jira-only, both, neither all produce a sensible summary; neither → `"Nothing configured to reindex"`. Tests cover both, jira-only, and neither. confluence-only is untested but symmetric to jira-only (nit, not a defect).
+
+## Back-compat
+- Adapter default: `adminService = opts.adminService ?? knowledgeService`. With NO adminService and a query-only fake, `/reindex` hits the `typeof service.reindex !== "function"` guard → "not configured". Proven by the back-compat test.
+
+## Item 4 — recordFeedbackToSink
+- stdout `[feedback] <message>` printed BEFORE the try block, so it survives any file error → the operator-grep line is preserved. No double-print: when wired, `feedbackCommand` calls `service.recordFeedback` (this sink) and skips its own `[feedback]` else-branch → exactly one line.
+- File I/O (`mkdirSync` + `appendFileSync`) fully inside try/catch that swallows → never throws. The "unwritable path" test (parent is a regular file) asserts `not.toThrow()`.
+- Tests pin `MONDAY_FEEDBACK_LOG` to an `os.tmpdir()` path and restore the prior env in `finally`. No macOS-only path dependency in the tests (the `~/Library/Logs` default is only the unset-env fallback, never reached in CI) → no ubuntu/windows flake.
+
+## Nits (non-blocking)
+- reindexAll aborts remaining sources if an earlier source's syncSpace/syncProject throws (e.g. confluence error skips jira), returning "Reindex failed". Acceptable under the non-throwing contract but a per-source try/catch would give a more complete summary.
+- `syncConfluence(spaceKey)` will attempt to sync an arbitrary spaceKey not in `confluenceSpaces`; harmless (fetcher returns empty or the error is caught), and matches "sync the given space" intent.
+- confluence-only reindex path has no dedicated test (symmetric coverage exists for jira-only).
+
+## Verdict
+PASS — logic is correct end-to-end, all required branches are tested, three layers guarantee non-throwing, privacy grep CLEAN, scope respected, build + 191 tests green.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,6 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
 import { App } from "@slack/bolt";
 import { MissingEnvVarError, validateEnv, AppEnv } from "./config/env";
 import { loadConfig, AppConfig } from "./config/config";
@@ -10,6 +13,7 @@ import {
 import { ConfluenceFetcher } from "./confluence/sync";
 import { JiraFetcher } from "./jira/sync";
 import { SlackAdapter, AppFactory } from "./slack/adapter";
+import { AdminService } from "./slack/commands";
 
 export interface RunMondayOptions {
   /** Override Bolt App factory (jest tests + AC-06 shell-spawn path). */
@@ -54,6 +58,27 @@ function createFakeAppFactory(): AppFactory {
       stop: async () => undefined,
     } as unknown as App;
   }) as AppFactory;
+}
+
+/**
+ * Durable feedback sink. Echoes to stdout (`[feedback] …`, unchanged) AND
+ * best-effort appends a timestamped line to a log file. Resolves the path from
+ * `MONDAY_FEEDBACK_LOG` (override) else `~/Library/Logs/monday-bot-feedback.log`.
+ * ALL file I/O is wrapped in try/catch that SWALLOWS errors — a read-only FS or
+ * a missing dir (ubuntu/windows CI) must never throw.
+ */
+export function recordFeedbackToSink(message: string): void {
+  // eslint-disable-next-line no-console
+  console.log(`[feedback] ${message}`);
+  try {
+    const logPath =
+      process.env.MONDAY_FEEDBACK_LOG ??
+      path.join(os.homedir(), "Library", "Logs", "monday-bot-feedback.log");
+    fs.mkdirSync(path.dirname(logPath), { recursive: true });
+    fs.appendFileSync(logPath, `${new Date().toISOString()} ${message}\n`);
+  } catch {
+    /* best-effort — never throw (read-only FS / CI must not break) */
+  }
 }
 
 export async function runMonday(opts: RunMondayOptions = {}): Promise<RunMondayHandle> {
@@ -120,12 +145,23 @@ export async function runMonday(opts: RunMondayOptions = {}): Promise<RunMondayH
     appFactory = createFakeAppFactory();
   }
 
+  // Admin surface for the Slack slash commands. /status-monday keeps its real
+  // doc count via knowledge.getStatus(); /sync-confluence + /reindex forward to
+  // the on-demand re-sync methods on the knowledge-sources handle.
+  const adminService: AdminService = {
+    getStatus: () => knowledge.getStatus(),
+    syncConfluence: (spaceKey?: string) => sources.syncConfluence(spaceKey),
+    reindex: () => sources.reindexAll(),
+    recordFeedback: (message: string) => recordFeedbackToSink(message),
+  };
+
   let adapter: SlackAdapter;
   try {
     adapter = new SlackAdapter({
       botToken: env.slackBotToken,
       appToken: env.slackAppToken,
       knowledgeService: knowledge,
+      adminService,
       appFactory,
     });
   } catch (err) {

--- a/src/knowledge/startup.ts
+++ b/src/knowledge/startup.ts
@@ -43,6 +43,20 @@ export interface KnowledgeSourcesHandle {
   stop(): void;
   /** Resolves once all initial syncs have settled (never rejects). */
   ready: Promise<void>;
+  /**
+   * On-demand Confluence re-sync. Re-syncs the given space (if provided) or all
+   * configured spaces. Returns a human-readable summary; never throws (errors
+   * are caught + returned as a summary). "Confluence is not configured" when no
+   * Confluence sync is wired (no creds OR no CONFLUENCE_SPACES).
+   */
+  syncConfluence(spaceKey?: string): Promise<string>;
+  /**
+   * Re-run every configured Confluence space + Jira project. Returns a summary;
+   * never throws. Note: watched folders are kept live continuously by the folder
+   * watchers and KnowledgeService exposes no on-demand folder-rescan method, so
+   * reindexAll intentionally covers Confluence + Jira only.
+   */
+  reindexAll(): Promise<string>;
 }
 
 /** Default scheduler: an unref'd setInterval so it never blocks process exit. */
@@ -93,6 +107,14 @@ export function startKnowledgeSources(deps: KnowledgeSourcesDeps): KnowledgeSour
   const timers: ScheduledTimer[] = [];
   const initialSyncs: Array<Promise<unknown>> = [];
 
+  // Hoisted so the returned handle can reach them for on-demand re-sync. These
+  // stay `undefined`/empty unless the corresponding source is actually wired
+  // (creds present AND a non-empty space/project list).
+  let confluenceSync: ConfluenceSync | undefined;
+  const confluenceSpaces: string[] = [];
+  let jiraSync: JiraSync | undefined;
+  const jiraProjects: string[] = [];
+
   const intervalMs = resolveIntervalMs(config);
 
   // ── Confluence ──────────────────────────────────────────────────────────
@@ -111,6 +133,8 @@ export function startKnowledgeSources(deps: KnowledgeSourcesDeps): KnowledgeSour
         deps.confluenceFetcher ??
         buildConfluenceFetcher({ baseUrl: siteRoot, email: email!, apiToken: apiToken! });
       const sync = new ConfluenceSync({ knowledge: deps.knowledge, fetcher, logger });
+      confluenceSync = sync;
+      confluenceSpaces.push(...spaces);
       for (const space of spaces) {
         initialSyncs.push(
           sync
@@ -144,6 +168,8 @@ export function startKnowledgeSources(deps: KnowledgeSourcesDeps): KnowledgeSour
       deps.jiraFetcher ??
       buildJiraFetcher({ baseUrl: siteRoot, email: email!, apiToken: apiToken! });
     const sync = new JiraSync({ knowledge: deps.knowledge, fetcher, logger });
+    jiraSync = sync;
+    jiraProjects.push(...projects);
     for (const project of projects) {
       initialSyncs.push(
         sync
@@ -186,7 +212,61 @@ export function startKnowledgeSources(deps: KnowledgeSourcesDeps): KnowledgeSour
     timers.length = 0;
   };
 
-  return { stop, ready };
+  /**
+   * On-demand Confluence re-sync — covers BOTH no-creds AND creds-but-no-spaces
+   * (confluenceSync stays undefined in both cases). Non-throwing.
+   */
+  const syncConfluence = async (spaceKey?: string): Promise<string> => {
+    if (!confluenceSync) return "Confluence is not configured";
+    const sync = confluenceSync;
+    const targets = spaceKey && spaceKey.length > 0 ? [spaceKey] : confluenceSpaces;
+    try {
+      const parts: string[] = [];
+      for (const space of targets) {
+        const res = await sync.syncSpace(space);
+        parts.push(`${space} (${res.pagesIndexed} pages)`);
+      }
+      return `Re-synced confluence: ${parts.join(", ")}`;
+    } catch (err) {
+      return `Confluence sync failed: ${(err as Error)?.message ?? "unknown error"}`;
+    }
+  };
+
+  /**
+   * Re-run every configured Confluence space + Jira project. Handles partial
+   * config (confluence-only / jira-only) and reports each configured source.
+   * Non-throwing. Watched folders are intentionally excluded — folder watchers
+   * keep them live continuously and KnowledgeService exposes no folder-rescan.
+   */
+  const reindexAll = async (): Promise<string> => {
+    try {
+      const parts: string[] = [];
+      if (confluenceSync) {
+        const sync = confluenceSync;
+        let pages = 0;
+        for (const space of confluenceSpaces) {
+          const res = await sync.syncSpace(space);
+          pages += res.pagesIndexed;
+        }
+        parts.push(`confluence ${pages} pages`);
+      }
+      if (jiraSync) {
+        const sync = jiraSync;
+        let issues = 0;
+        for (const project of jiraProjects) {
+          const res = await sync.syncProject(project);
+          issues += res.issuesIndexed;
+        }
+        parts.push(`jira ${issues} issues`);
+      }
+      if (parts.length === 0) return "Nothing configured to reindex";
+      return `Reindexed: ${parts.join(", ")}`;
+    } catch (err) {
+      return `Reindex failed: ${(err as Error)?.message ?? "unknown error"}`;
+    }
+  };
+
+  return { stop, ready, syncConfluence, reindexAll };
 }
 
 /**

--- a/tests/index.startup.test.ts
+++ b/tests/index.startup.test.ts
@@ -170,3 +170,45 @@ describe("runMonday — folder watcher attachment (AC-5)", () => {
     errSpy.mockRestore();
   });
 });
+
+describe("recordFeedbackToSink — durable feedback file sink", () => {
+  it("writes a line to MONDAY_FEEDBACK_LOG AND echoes a [feedback] stdout line", () => {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const { recordFeedbackToSink } = require("../src/index") as typeof import("../src/index");
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "monday-feedback-"));
+    const logPath = path.join(dir, "feedback.log");
+    const saved = process.env.MONDAY_FEEDBACK_LOG;
+    process.env.MONDAY_FEEDBACK_LOG = logPath;
+    const logSpy = jest.spyOn(console, "log").mockImplementation(() => undefined);
+    try {
+      recordFeedbackToSink("VPN answer was wrong");
+      const contents = fs.readFileSync(logPath, "utf8");
+      expect(contents).toContain("VPN answer was wrong");
+      const printed = logSpy.mock.calls.map((c) => String(c[0]));
+      expect(printed.some((l) => l.includes("[feedback] VPN answer was wrong"))).toBe(true);
+    } finally {
+      logSpy.mockRestore();
+      if (saved === undefined) delete process.env.MONDAY_FEEDBACK_LOG;
+      else process.env.MONDAY_FEEDBACK_LOG = saved;
+    }
+  });
+
+  it("never throws when the log path is unwritable", () => {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const { recordFeedbackToSink } = require("../src/index") as typeof import("../src/index");
+    const saved = process.env.MONDAY_FEEDBACK_LOG;
+    // A path whose parent is an existing FILE (not a dir) → mkdir/append fail.
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "monday-feedback-bad-"));
+    const fileAsParent = path.join(dir, "afile");
+    fs.writeFileSync(fileAsParent, "x", "utf8");
+    process.env.MONDAY_FEEDBACK_LOG = path.join(fileAsParent, "nested", "feedback.log");
+    const logSpy = jest.spyOn(console, "log").mockImplementation(() => undefined);
+    try {
+      expect(() => recordFeedbackToSink("should not throw")).not.toThrow();
+    } finally {
+      logSpy.mockRestore();
+      if (saved === undefined) delete process.env.MONDAY_FEEDBACK_LOG;
+      else process.env.MONDAY_FEEDBACK_LOG = saved;
+    }
+  });
+});

--- a/tests/knowledge-sources.startup.test.ts
+++ b/tests/knowledge-sources.startup.test.ts
@@ -206,6 +206,122 @@ describe("runMonday — knowledge sources wiring (Confluence + Jira)", () => {
     errSpy.mockRestore();
   });
 
+  it("handle.sources.syncConfluence() + reindexAll() re-sync configured sources", async () => {
+    process.env.SLACK_BOT_TOKEN = BOT_TOKEN;
+    process.env.SLACK_APP_TOKEN = APP_TOKEN;
+    process.env.CONFLUENCE_URL = "https://example.atlassian.net/wiki";
+    process.env.CONFLUENCE_EMAIL = "a@b.c";
+    process.env.CONFLUENCE_API_TOKEN = "tok";
+    process.env.CONFLUENCE_SPACES = "DEMO";
+    process.env.JIRA_PROJECTS = "PROJ";
+
+    const confluenceFetcher: ConfluenceFetcher = {
+      async fetchPages(spaceKey: string) {
+        return [
+          { id: "c1", title: "Onboarding", body: "Welcome", source: "confluence:c1", spaceKey },
+        ];
+      },
+    };
+    const jiraFetcher: JiraFetcher = {
+      async fetchIssues(projectKey: string) {
+        return [{ key: `${projectKey}-1`, summary: "Bug", descriptionText: "broken", commentTexts: [] }];
+      },
+    };
+
+    const fake = makeFakeScheduler();
+    const cfg = makeTempConfigYaml("watchedFolders: []\n");
+    const logSpy = jest.spyOn(console, "log").mockImplementation(() => undefined);
+
+    const handle = await runMonday({
+      configPath: cfg,
+      exitOnError: false,
+      confluenceFetcher,
+      jiraFetcher,
+      scheduler: fake.scheduler,
+    });
+
+    await handle.sources.ready;
+
+    const syncMsg = await handle.sources.syncConfluence();
+    expect(syncMsg).toMatch(/Re-synced confluence/);
+    expect(syncMsg).toMatch(/DEMO \(1 pages\)/);
+
+    const reindexMsg = await handle.sources.reindexAll();
+    expect(reindexMsg).toMatch(/Reindexed: confluence \d+ pages, jira \d+ issues/);
+
+    // Single-space arg path also works.
+    const oneSpace = await handle.sources.syncConfluence("DEMO");
+    expect(oneSpace).toMatch(/DEMO \(1 pages\)/);
+
+    await handle.shutdown();
+    logSpy.mockRestore();
+  });
+
+  it("NO creds → syncConfluence() not configured; reindexAll() nothing to reindex", async () => {
+    process.env.SLACK_BOT_TOKEN = BOT_TOKEN;
+    process.env.SLACK_APP_TOKEN = APP_TOKEN;
+
+    const fake = makeFakeScheduler();
+    const cfg = makeTempConfigYaml("watchedFolders: []\n");
+
+    const handle = await runMonday({
+      configPath: cfg,
+      exitOnError: false,
+      scheduler: fake.scheduler,
+    });
+
+    await handle.sources.ready;
+
+    expect(await handle.sources.syncConfluence()).toMatch(/not configured/i);
+    expect(await handle.sources.reindexAll()).toMatch(/Nothing configured to reindex/i);
+
+    await handle.shutdown();
+  });
+
+  it("creds present but CONFLUENCE_SPACES empty → confluence not configured; reindex is jira-only", async () => {
+    process.env.SLACK_BOT_TOKEN = BOT_TOKEN;
+    process.env.SLACK_APP_TOKEN = APP_TOKEN;
+    process.env.CONFLUENCE_URL = "https://example.atlassian.net/wiki";
+    process.env.CONFLUENCE_EMAIL = "a@b.c";
+    process.env.CONFLUENCE_API_TOKEN = "tok";
+    // CONFLUENCE_SPACES intentionally unset.
+    process.env.JIRA_PROJECTS = "PROJ";
+
+    const confluenceFetcher: ConfluenceFetcher = {
+      async fetchPages() {
+        throw new Error("confluence should not be synced");
+      },
+    };
+    const jiraFetcher: JiraFetcher = {
+      async fetchIssues(projectKey: string) {
+        return [{ key: `${projectKey}-1`, summary: "Bug", descriptionText: "broken", commentTexts: [] }];
+      },
+    };
+
+    const fake = makeFakeScheduler();
+    const cfg = makeTempConfigYaml("watchedFolders: []\n");
+    const logSpy = jest.spyOn(console, "log").mockImplementation(() => undefined);
+
+    const handle = await runMonday({
+      configPath: cfg,
+      exitOnError: false,
+      confluenceFetcher,
+      jiraFetcher,
+      scheduler: fake.scheduler,
+    });
+
+    await handle.sources.ready;
+
+    expect(await handle.sources.syncConfluence()).toMatch(/not configured/i);
+
+    const reindexMsg = await handle.sources.reindexAll();
+    expect(reindexMsg).toMatch(/Reindexed: jira \d+ issues/);
+    expect(reindexMsg).not.toContain("confluence");
+
+    await handle.shutdown();
+    logSpy.mockRestore();
+  });
+
   it("empty watchedFolders → watchFolder is never called (AC-5 parity)", async () => {
     process.env.SLACK_BOT_TOKEN = BOT_TOKEN;
     process.env.SLACK_APP_TOKEN = APP_TOKEN;

--- a/tests/slack-adapter.test.ts
+++ b/tests/slack-adapter.test.ts
@@ -194,6 +194,81 @@ describe("slack/adapter — handler registration & dispatch", () => {
   });
 });
 
+describe("slack/adapter — admin commands wired through adminService", () => {
+  it("/sync-confluence + /reindex route to the adminService and surface its summary", async () => {
+    const syncArgs: Array<string | undefined> = [];
+    const adminService = {
+      syncConfluence: async (spaceKey?: string) => {
+        syncArgs.push(spaceKey);
+        return "Re-synced confluence: DEMO (2 pages)";
+      },
+      reindex: async () => "Reindexed: confluence 2 pages",
+    };
+    const adapter = new SlackAdapter({
+      botToken: "xoxb-test",
+      appToken: "xapp-test",
+      knowledgeService: fakeKnowledge(),
+      adminService,
+    });
+    const fakeApp = adapter._getApp() as unknown as {
+      _triggerCommand(name: string, cmd: unknown): Promise<void>;
+      _ackCalls: number;
+      _respondMessages: Array<{ response_type: string; text: string }>;
+    };
+
+    await fakeApp._triggerCommand("/sync-confluence", { text: "" });
+    expect(fakeApp._ackCalls).toBe(1);
+    expect(fakeApp._respondMessages[0].text).toContain("Re-synced confluence: DEMO (2 pages)");
+    expect(fakeApp._respondMessages[0].text.toLowerCase()).not.toContain("not configured");
+
+    await fakeApp._triggerCommand("/reindex", {});
+    expect(fakeApp._ackCalls).toBe(2);
+    expect(fakeApp._respondMessages[1].text).toContain("Reindexed: confluence 2 pages");
+    expect(fakeApp._respondMessages[1].text.toLowerCase()).not.toContain("not configured");
+  });
+
+  it("/sync-confluence forwards the space argument to adminService.syncConfluence", async () => {
+    const syncArgs: Array<string | undefined> = [];
+    const adminService = {
+      syncConfluence: async (spaceKey?: string) => {
+        syncArgs.push(spaceKey);
+        return `Re-synced confluence: ${spaceKey} (1 pages)`;
+      },
+    };
+    const adapter = new SlackAdapter({
+      botToken: "xoxb-test",
+      appToken: "xapp-test",
+      knowledgeService: fakeKnowledge(),
+      adminService,
+    });
+    const fakeApp = adapter._getApp() as unknown as {
+      _triggerCommand(name: string, cmd: unknown): Promise<void>;
+      _respondMessages: Array<{ text: string }>;
+    };
+
+    await fakeApp._triggerCommand("/sync-confluence", { text: "DEMO" });
+    expect(syncArgs).toEqual(["DEMO"]);
+    expect(fakeApp._respondMessages[0].text).toContain("DEMO");
+  });
+
+  it("back-compat: NO adminService → /reindex hits the default 'not configured' guard", async () => {
+    const adapter = new SlackAdapter({
+      botToken: "xoxb-test",
+      appToken: "xapp-test",
+      // knowledgeService has only query() — no admin methods, so the default
+      // adminService (= knowledgeService) exposes no reindex().
+      knowledgeService: fakeKnowledge(),
+    });
+    const fakeApp = adapter._getApp() as unknown as {
+      _triggerCommand(name: string, cmd: unknown): Promise<void>;
+      _respondMessages: Array<{ text: string }>;
+    };
+
+    await fakeApp._triggerCommand("/reindex", {});
+    expect(fakeApp._respondMessages[0].text.toLowerCase()).toContain("not configured");
+  });
+});
+
 describe("slack/adapter — start/stop", () => {
   it("start() and stop() delegate to the underlying app", async () => {
     const adapter = new SlackAdapter({


### PR DESCRIPTION
## What

The `/sync-confluence` and `/reindex` Slack admin commands returned *"… is not configured on this bot."* The `SlackAdapter` defaults its admin surface to the `KnowledgeService`, which has `getStatus()` (so `/status-monday` works) but no `syncConfluence()`/`reindex()`, so those two commands hit their not-configured guard. The boot-time Confluence+Jira auto-sync (6h scheduler) was unaffected — only the on-demand admin commands were unwired.

## Fix

- **src/knowledge/startup.ts** — hoist the constructed `ConfluenceSync`/`JiraSync` instances + their spaces/projects lists to function scope and expose two non-throwing methods on `KnowledgeSourcesHandle`:
  - `syncConfluence(spaceKey?)` — re-sync one space (if given) or all configured spaces; returns `Re-synced confluence: <space> (N pages)`; returns `Confluence is not configured` when no creds OR no spaces.
  - `reindexAll()` — re-run every Confluence space + every Jira project; returns `Reindexed: confluence N pages, jira M issues` (partial-config aware). Watched folders are kept live continuously by the folder watchers (no on-demand rescan method), so they are intentionally out of scope (documented inline).
- **src/index.ts** — build an `adminService` (`getStatus`→`knowledge.getStatus()` unchanged; `syncConfluence`/`reindex`→the new handle methods; `recordFeedback`→durable file sink) and pass it to `SlackAdapter`.
- **src/slack/adapter.ts** — no change; it already accepts an optional `adminService` and defaults to the knowledge service for back-compat.
- **recordFeedback durable sink** — `recordFeedbackToSink` appends feedback to `MONDAY_FEEDBACK_LOG` (default `~/Library/Logs/monday-bot-feedback.log`), best-effort + never throws, and keeps the existing stdout `[feedback] ` line.

## Tests

- New handle-method tests (mock fetchers): summaries for configured / no-creds / creds-but-no-spaces (confluence not-configured + jira-only reindex) paths.
- New adapter tests: `/sync-confluence` + `/reindex` route through `adminService` and surface its summary (not the guard); space-arg forwarding; back-compat (no adminService → guard still fires).
- New feedback-sink tests (pinned to a tmp `MONDAY_FEEDBACK_LOG`; asserts never-throws on an unwritable path).
- `tsc` clean; `jest` 22 suites / 191 tests green. `/status-monday` behavior unchanged.

Disjoint from #1066 (does not touch generate.ts/formatter.ts).

https://claude.ai/code/session_01FV7REFAxxyRbgvfQm1fJr9