### PR TITLE
chore: release 0.12.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to monday-bot will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.12.12](https://github.com/ziyilam3999/monday-bot/compare/v0.12.11...v0.12.12) (2026-06-23)
+
+### Bug Fixes
+
+* wire the `/sync-confluence` and `/reindex` admin slash commands to real on-demand re-sync — they previously returned "… is not configured on this bot." because the adapter's admin surface (the knowledge service) exposed `getStatus()` but no sync/reindex methods. Expose `syncConfluence()`/`reindexAll()` on the knowledge-sources handle and forward the commands to them via an `adminService` in `index.ts`; `/status-monday` is unchanged. Also adds a durable feedback file sink (`MONDAY_FEEDBACK_LOG`) (#1171) (#210)
+
 ## [0.12.11](https://github.com/ziyilam3999/monday-bot/compare/v0.12.10...v0.12.11) (2026-06-23)
 
 ### Bug Fixes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "monday-bot",
-  "version": "0.12.11",
+  "version": "0.12.12",
   "description": "Team Slack knowledge assistant — answers from internal documents with cited, fact-based summaries.",
   "private": true,
   "type": "commonjs",


### PR DESCRIPTION
Release 0.12.12.

- bump package.json 0.12.11 -> 0.12.12
- prepend CHANGELOG entry for #1171 (admin slash command wiring) merged in #210

release-pr: true

https://claude.ai/code/session_01FV7REFAxxyRbgvfQm1fJr9