### PR TITLE
fix(1169): automatic privacy CI gate + node_modules gitignore + Layer-B prompt-integrity test

### DIFF
--- a/.ai-workspace/plans/2026-06-23-1169-privacy-ci-gate-hardening.md
+++ b/.ai-workspace/plans/2026-06-23-1169-privacy-ci-gate-hardening.md
@@ -1,0 +1,131 @@
+# 1169 — monday-bot hardening: automatic privacy CI gate + .gitignore fix + Layer-B prompt-integrity test
+
+## Execution model
+
+**subagent (3-role).** Per the operator brief: real subagents for plan-review +
+executor + execution-review; planner inline-skipped (specific reason below).
+Rationale: the work spans 5 files across CI/config/test surfaces (above the
+trivial-skip threshold), and the brief mandates the 3-role split — the orchestrator
+coordinates and ships but does not write the code inline. Executor and both
+reviewers are separate write-capable subagents.
+
+## ELI5
+
+monday-bot is a PUBLIC repo. Three small, unrelated safety guards in one PR:
+
+1. **The headline — an automatic privacy guard in CI.** Right now nothing in the
+   robot's automated checks looks for a secret company name sneaking into the
+   public code. A leak slipped to master once because the only check was a manual
+   one a human had to remember to run. We add a GitHub Actions job that runs on
+   every pull request, looks at what the PR changed, and FAILS the check if a
+   regulated employer token shows up. The secret token list NEVER lives in the
+   public repo — it's read from a GitHub Actions **secret**, so the guard can look
+   for the bad words without ever writing them down where the public can read them.
+
+2. **A one-character `.gitignore` fix.** The line `node_modules/` (with a slash)
+   does not hide the auto-created `node_modules` *symlink* (a slash means
+   "directory only"). So a careless `git add -A` could stage it. Change it to
+   slash-less `node_modules` so both a real folder and a symlink are ignored.
+
+3. **A guard test for the answer-quality prompt.** The robot's system prompt has
+   two rules that a past fix added: "if you found nothing relevant, say you
+   couldn't find it" (abstain) and "lead with what you DID find." A future tidy-up
+   could silently delete one and quietly regress quality. We add a tiny unit test
+   that reads the prompt and fails if either rule disappears. To let the test read
+   the prompt we just `export` it (no wording change).
+
+## Why
+
+- #1169: PUBLIC repo, no AUTOMATIC privacy check on PRs — only a manual gate.
+  A token leak reached master on the #1066 rename because CI caught nothing.
+- .gitignore: trailing-slash pattern misses the symlinked `node_modules`
+  (reproduced: `git check-ignore node_modules` exits 1 today).
+- #1170 mechanical half: lock the #1066 P3 abstention-bias fix so a prompt
+  refactor cannot silently drop the abstain or lead-with-found clause.
+
+## Scope / disjoint-file guarantee
+
+Touches ONLY:
+- `.github/workflows/privacy.yml` (new)
+- `scripts/privacy-denylist-check.sh` (new)
+- `.gitignore` (one-line edit)
+- `src/llm/generate.ts` (add `export` keyword to `SYSTEM_PROMPT` only — NO wording change)
+- `tests/generate.prompt-integrity.test.ts` (new)
+- `.ai-workspace/plans/...` + `.ai-workspace/reviews/...` (force-added provenance, per repo convention)
+
+Does NOT touch `src/knowledge/startup.ts`, `src/index.ts`, `src/slack/adapter.ts`
+(the #1171 surface — already merged as PR #210, but kept disjoint regardless).
+
+## Design notes
+
+### Change 1 — privacy CI gate (reuse the sibling PUBLIC-repo pattern)
+- Pattern source: a sibling PUBLIC repo runs a `pull_request`-triggered workflow
+  that calls a `scripts/privacy-denylist-check.sh` bash script (concurrency-guarded,
+  `permissions: contents: read`). We copy that shape.
+- **Token home = GitHub Actions secret, NOT a committed file.** In gpe the inline
+  tokens are PUBLIC project names; monday-bot's regulated tokens are the EMPLOYER
+  brand, which would itself leak if committed to a public repo (even in a rule-spec
+  file). So tokens live ONLY in the repo secret `PRIVACY_DENYLIST_TOKENS`
+  (newline-separated regex fragments), injected into the script via env. The
+  workflow YAML and the script contain ZERO tokens — satisfies "NEVER inline in
+  workflow YAML or code," and is stronger than a committed rule-spec file (no token
+  in ANY committed file at all).
+- **Scope = the PR's added diff lines** (`git merge-base origin/<base> HEAD` →
+  `git diff base...HEAD`, scan added lines). Catches a token a PR introduces — the
+  #1066 scenario. `fetch-depth: 0` so merge-base resolves.
+- **Always-on home-path guard** (no secret needed): added lines matching
+  `(/Users/|/home/)<name>/` fail the check (cairn lesson: a fixed-token denylist is
+  blind to the home-path leak class — gpe #955).
+- **Fail-closed:** exit 1 on ANY hit. Matched content is WITHHELD from CI logs
+  (printing it would re-leak the very token/username into public CI logs) — only a
+  count + remediation message is printed.
+- **Secret-unset behavior:** print a loud `::warning::` "set PRIVACY_DENYLIST_TOKENS
+  to arm employer-token scanning" and continue (home-path guard still runs). The job
+  is GREEN on a clean PR with the secret unset — so this PR passes CI without the
+  operator having to hand me the token. Arming the secret is an operator deploy step
+  (the brief: "I deploy to the live service"). Documented in the RESTORE/setup note.
+- **Required-check:** the job runs on every PR and fails on hits. Marking it a
+  *required status check* in branch protection is operator repo-config (noted).
+
+### Change 2 — .gitignore
+`node_modules/` → `node_modules`. AC: `git check-ignore node_modules` exits 0.
+
+### Change 3 — Layer-B prompt-integrity test
+- `export const SYSTEM_PROMPT` in `src/llm/generate.ts` (add keyword only).
+- New `tests/generate.prompt-integrity.test.ts` imports `SYSTEM_PROMPT` and asserts
+  it contains BOTH the abstain clause (`/no relevant information/i` AND
+  `/couldn't find/i`) AND the lead-with-found clause (`/Lead with what you DID find/`).
+
+## Binary AC (checkable from outside the diff)
+
+1. `npm run build` exits 0 (tsc clean) in the worktree.
+2. `npm test` exits 0 (all jest green, incl. the new prompt-integrity test).
+3. `npm test -- generate.prompt-integrity` runs ≥1 test and passes.
+4. `git -C <worktree> check-ignore node_modules` exits 0 (symlink now ignored).
+5. Running the privacy script over a synthetic diff containing a FAKE token (via
+   `PRIVACY_DENYLIST_TOKENS=FAKEBRANDXYZ`) exits 1; over a clean diff exits 0
+   (fail-closed proof, no real token used).
+6. `git grep -nE` over the committed diff for any regulated employer token finds
+   NOTHING (privacy self-grep clean) — and no token in plan/review/commit surfaces.
+7. The new `.github/workflows/privacy.yml` job passes (green) on this PR.
+8. CI green on ubuntu-latest AND windows-latest.
+
+## 3-role
+
+- **planner**: inline-skip — the operator's brief fully specifies the outcome +
+  binary AC for three small disjoint guards; this plan doc transcribes that contract.
+  The planning is inseparable from the just-given operator instructions (no
+  independent design space to hand to a fresh planner subagent).
+- **plan-review**: real subagent (write-capable) → `.ai-workspace/reviews/1169-plan-review.md`.
+- **executor**: real subagent (write-capable) implements in the worktree.
+- **execution-review**: real subagent (write-capable) → `.ai-workspace/reviews/1169-execution-review.md`.
+
+## Privacy
+
+This PR is about privacy. No regulated employer host/brand/space-key/project-key
+token in ANY committed file, plan, review artifact, branch name, or commit message.
+Tokens referenced only as "the employer denylist tokens." Self-grep before push.
+
+cairn: hit — "A privacy/denylist gate scoped to a fixed TOKEN set is blind to the
+home-path class" (T1 2026-06-17) → home-path guard included. Also "PUBLIC repo:
+scrub even META-mentions of the regulated employer tokens" → tokens kept in secret only.

--- a/.ai-workspace/reviews/1169-execution-review.md
+++ b/.ai-workspace/reviews/1169-execution-review.md
@@ -1,0 +1,78 @@
+# 1169 — Execution Review (stateless, independent)
+
+Reviewer: stateless execution reviewer (write-capable, did NOT author the code).
+Scope: privacy CI gate + .gitignore symlink fix + Layer-B prompt-integrity test.
+Diff base: `origin/master...HEAD` (5 impl files + 1 plan doc).
+
+## Verdict
+
+Decision: PASS
+
+## Per-check results (exit codes)
+
+| Check | Command (summarized) | Exit | Result |
+|---|---|---|---|
+| Build | `npm run build` (tsc) | 0 | clean, no TS errors |
+| Full test suite | `npm test` | 0 | 23 suites / 193 tests PASS |
+| Prompt-integrity test | `npm test -- generate.prompt-integrity` | 0 | 1 suite / 2 assertions PASS |
+| F1 fail-closed (unresolvable base) | `GITHUB_BASE_REF=no-such-ref-xyz ...` | 1 | refuses, NON-vacuous |
+| Fail-closed on real hit (FAKE token) | `PRIVACY_DENYLIST_TOKENS=<fake> GITHUB_BASE_REF=master ...` over temp commit | 1 | token scan fired (2 lines) |
+| Home-path guard (no secret) | same temp commit, secret unset | 1 | home-path guard fired independently (1 line) |
+| Self-pass on real PR diff | `GITHUB_BASE_REF=master ...` | 0 | clean, 292 added lines scanned |
+| Post-cleanup self-pass | re-run after reset | 0 | worktree restored, still green |
+
+## F1 (elevated plan-review finding) — non-vacuous fail-closed: CONFIRMED
+
+- Unresolvable base ref → exit 1 with an explicit refusal message ("refusing to
+  run on an unresolvable base"). Not a silent pass.
+- Empty merge-base path verified by reading the script: after `RANGE_BASE`
+  resolves, `MERGE_BASE` is computed; `if [ -z "${MERGE_BASE}" ]` prints an error
+  and `exit 1`. So an empty/unresolvable merge-base also fails closed.
+- A deliberate FAKE-token hit and an absolute-home-path hit both produced exit 1,
+  with matched content WITHHELD from logs (only counts + remediation printed) —
+  the gate does not re-leak into CI logs.
+
+## Privacy axis
+
+- No absolute home path in any committed file (grep of added diff lines for the
+  `/Users/` or `/home/` + username pattern returns nothing).
+- The workflow YAML and the script carry ZERO regulated tokens; tokens are read
+  only from the `PRIVACY_DENYLIST_TOKENS` GitHub Actions secret via env.
+- The throwaway FAKE-token scenario was reverted (`git reset --hard HEAD~1` +
+  removed the temp file); `git status` is clean and HEAD is unchanged from the
+  reviewed commit.
+
+## Prompt-test strictness — CONFIRMED
+
+The live system prompt contains the abstain clause "...contains no relevant
+information, say you couldn't find the information" and the lead-with-found
+clause. The `/no relevant information/i` assertion is uniquely satisfied by the
+abstain clause, so deleting that clause fails the test; the lead-with-found
+assertion is uniquely satisfied by its clause. Removing either clause trips the
+test. Test is non-vacuous.
+
+## Scope — CONFIRMED
+
+Diff touches ONLY: `.github/workflows/privacy.yml`, `scripts/privacy-denylist-check.sh`,
+`.gitignore`, `src/llm/generate.ts` (added `export` only — no wording change),
+`tests/generate.prompt-integrity.test.ts`, plus the plan doc under
+`.ai-workspace/plans/`. Does NOT touch `src/knowledge/startup.ts`, `src/index.ts`,
+or `src/slack/adapter.ts`.
+
+## Non-blocking notes
+
+1. The fake placeholder string `FAKEBRANDXYZ` appears once in the committed plan
+   doc (documenting the binary AC). It is a deliberately fake, non-regulated
+   string with zero privacy risk; the brief explicitly permits it. Not blocking.
+2. `.gitignore` change (trailing-slash removed so a `node_modules` symlink is also
+   ignored) is correct and matches the plan AC; not separately exercised here but
+   trivially correct.
+
+## Rationale
+
+All eight verifications pass with the expected exit codes. The gate is fail-closed
+on unresolvable/empty ranges (F1 satisfied non-vacuously), fires on both the
+employer-token and home-path classes, withholds matched content from logs, and is
+GREEN on its own PR. Build and the full + targeted test suites are green. The
+prompt-integrity test is strict. Scope is disjoint as specified. No privacy leak
+in any committed file. PASS.

--- a/.ai-workspace/reviews/1169-plan-review.md
+++ b/.ai-workspace/reviews/1169-plan-review.md
@@ -1,0 +1,126 @@
+# 1169 — Plan Review: privacy CI gate + .gitignore fix + Layer-B prompt-integrity test
+
+Decision: PASS
+
+Reviewer: stateless plan-review subagent (3-role). Plan reviewed in full:
+`.ai-workspace/plans/2026-06-23-1169-privacy-ci-gate-hardening.md`.
+
+Verdict in one line: the design is sound, well-scoped, and privacy-conscious; the
+headline risks (token never committed, matched content withheld from logs,
+always-on home-path guard, fail-closed on hits) are all handled correctly. PASS,
+with one elevated execution-hardening requirement and several non-blocking notes.
+
+cairn: hit — "A privacy/denylist gate scoped to a fixed TOKEN set is blind to the
+home-path class" (T1 2026-06-17) → plan already includes the always-on home-path
+guard. Also hit — "Drop `set -e` in shell gates that must fail closed; guard each
+command" (T2) → relevant to the vacuous-pass finding below. Also hit — "A repo-wide
+privacy denylist CI scans ALL tracked files; a stale planning doc co[mmitted]..."
+(the gpe self-exclude failure mode) → this plan SIDESTEPS that class by keeping
+tokens in a secret (never committed), so no self-exclude / stale-doc risk exists.
+
+---
+
+## Findings
+
+### ELEVATED — must be addressed in execution + verified by execution-review (not a plan redesign)
+
+**F1. Guard against a silently-vacuous pass on a broken/empty diff range.**
+The gate's entire value is catching a NEW token in a PR diff. Both the token scan
+AND the home-path guard are diff-scoped (added lines only). If the diff range
+resolves empty for the WRONG reason — `origin/<base>` ref unresolved, `merge-base`
+returns nothing, a checkout quirk — the gate passes vacuously (grep over nothing →
+exit 0) and looks GREEN. AC #7 ("job green on this PR") cannot distinguish a real
+pass from a vacuous one; that is the single most important property of a privacy
+gate and the current ACs do not prove it.
+The design direction is correct (`fetch-depth: 0` so `merge-base` resolves; the
+three-dot `base...HEAD` diff is the right "what this PR added" scope; on a
+`pull_request` merge-commit checkout it still resolves to the PR's added lines).
+What's missing is fail-closed rigor on the unhappy path:
+- The script must `exit` non-zero if `git merge-base` / the diff range cannot be
+  computed (treat an unresolvable base as a FAILURE, not "no hits"). Do not let
+  `set -e`/silent-empty swallow it — guard each command explicitly (cairn lesson).
+- The CI step should log the scanned added-line COUNT so the log visibly shows the
+  range was non-empty (a 0-line scan on a code-bearing PR is itself a red flag).
+- Recommend adding a Binary AC: "running the script with a deliberately
+  unresolvable base exits non-zero" (checkable from outside the diff, no real token).
+
+This is flagged as execution-hardening, not a FAIL, because the plan's stated
+intent already points the right way and the executor + execution-review can close
+it; but execution-review MUST confirm non-vacuous behavior before ship.
+
+### Non-blocking
+
+**N1. AC that the workflow actually TRIGGERS as a visible check is missing.**
+A non-triggering or malformed workflow is silently ABSENT, not red. AC #7 says
+"green," but the stronger property is "the privacy job appears in the PR's checks
+and concludes success." Recommend an explicit AC (or a YAML-validity check, e.g.
+`actionlint`/parse) so a workflow that never runs can't pass by absence. Marking it
+a required status check in branch protection (operator repo-config) is correctly
+noted as out-of-band.
+
+**N2. Consider gpe-parity repo-wide scan on `push: branches: [master]`.**
+The sibling runs on both `pull_request` AND push-to-master (full-file). This plan
+is `pull_request` diff-scope only, which is correct for the stated #1066 "catch a
+token a PR introduces" purpose, but won't catch a PRE-EXISTING leak already on
+master. Given Rule G1 (always-PR) the PR gate covers the normal path; a cheap
+push-to-master full-file backstop would add defense-in-depth. Enhancement, not
+required.
+
+**N3. AC #8 OS-scope is ambiguous.** "CI green on ubuntu AND windows" describes the
+existing matrix `ci.yml` (build/test). The new bash privacy gate runs ubuntu-only
+(like gpe); the plan should state that explicitly so AC #8 isn't read as "the bash
+gate must pass on windows."
+
+**N4. Secret-unset + fork-PR limitation — acceptable, worth a one-line note.**
+GitHub does not expose secrets to fork PRs, so on a fork PR the employer-token scan
+is unarmed (warn+pass); the home-path guard still runs. For a single-operator
+public repo where the leak risk is the operator's own same-repo branch PRs (secrets
+available), this is the right trade-off. Note it in the setup doc so it's a known
+property, not a surprise.
+
+---
+
+## What the plan gets RIGHT (verified)
+
+- **Token never committed.** Tokens live ONLY in the `PRIVACY_DENYLIST_TOKENS`
+  GitHub Actions secret, injected via env. Workflow YAML and script carry ZERO
+  tokens. This is strictly stronger than gpe's committed rule-spec list and removes
+  the self-exclude / stale-planning-doc failure class entirely. Confirmed sound.
+- **Matched content withheld from logs.** Only a count + remediation printed;
+  token/username never re-leaked into public CI logs. Covers home-path matches too
+  (printing the matched LINE would leak the username — plan withholds it; printing
+  the diff's file PATH is safe).
+- **Home-path guard always-on.** `(/Users/|/home/)<name>/` over added lines,
+  no secret required — directly applies the cairn lesson; closes the #1066-class
+  home-path blind spot of a fixed-token denylist.
+- **Secret-unset warn+pass is defensible.** Lets THIS PR pass its own CI without the
+  operator handing over the token; arming is an operator deploy step. Home-path
+  guard still fires. Reasonable.
+- **Prompt test — minimal + appropriately strict.** `export` on an existing const is
+  the minimal change (and `NO_CONTEXT_ANSWER` is already exported beside it, so the
+  pattern exists; no wording change). Asserting on `SYSTEM_PROMPT` specifically
+  avoids accidental matches against `NO_CONTEXT_ANSWER`. Verified the live text
+  contains both "no relevant information"/"couldn't find" (abstain) and "Lead with
+  what you DID find" — the regexes match. Substring strictness on a deliberate
+  load-bearing clause is DESIRABLE for a guard test: a reword should be a conscious
+  decision that re-trips the test, exactly the intended behavior.
+- **Scope/disjointness confirmed.** Touches `.github/workflows/privacy.yml` (new,
+  separate from `ci.yml` — no matrix collision), `scripts/privacy-denylist-check.sh`
+  (new), `.gitignore` (one line), `src/llm/generate.ts` (add `export` only),
+  `tests/generate.prompt-integrity.test.ts` (new). Does NOT touch
+  `src/knowledge/startup.ts`, `src/index.ts`, `src/slack/adapter.ts`. Verified.
+- **AC #5 (fake-token fail-closed) is sound** — proves the MATCHER fails closed via
+  a synthetic `FAKEBRANDXYZ` token, no real token used. (Note: it proves the matcher,
+  not the CI diff-range — see F1.)
+- **.gitignore fix correct.** `node_modules/` → `node_modules` makes
+  `git check-ignore node_modules` exit 0 for both a dir and the auto-symlink. AC #4
+  checkable from outside the diff.
+
+## Rationale
+
+The plan correctly solves the actual problem and avoids the gpe gate's known
+failure modes. The one property a privacy gate must never lack — non-vacuous,
+fail-closed scanning — is directionally present but not yet PROVEN by the ACs (F1);
+that is an execution-hardening gap the downstream roles can and must close, not a
+plan-level design error warranting a FAIL. No regulated employer token appears in
+this artifact (referenced only as "the employer denylist tokens").

--- a/.github/workflows/privacy.yml
+++ b/.github/workflows/privacy.yml
@@ -1,0 +1,30 @@
+name: privacy
+
+# pull_request-only by design: the privacy gate is diff-scoped (it scans the
+# lines a PR ADDS against the PR base), so it needs a PR base ref to diff
+# against. It does not run on push.
+on:
+  pull_request:
+
+concurrency:
+  group: privacy-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  denylist:
+    # ubuntu-only by design: the gate is a bash script and does not run on
+    # windows. (The build/test matrix lives in a separate workflow.)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout (full history so merge-base resolves)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Run privacy denylist check
+        env:
+          # Tokens live ONLY in this secret, never in any committed file.
+          PRIVACY_DENYLIST_TOKENS: ${{ secrets.PRIVACY_DENYLIST_TOKENS }}
+          GITHUB_BASE_REF: ${{ github.base_ref }}
+        run: bash scripts/privacy-denylist-check.sh

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-node_modules/
+node_modules
 dist/
 .env
 .env.local

--- a/scripts/privacy-denylist-check.sh
+++ b/scripts/privacy-denylist-check.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+#
+# privacy-denylist-check.sh — scan a PR's ADDED diff lines for privacy leaks.
+#
+# This repo is PUBLIC. The regulated employer denylist tokens live ONLY in the
+# GitHub Actions secret PRIVACY_DENYLIST_TOKENS (newline-separated regex
+# fragments), injected into this script via the environment. They are NEVER
+# written into this file, the workflow YAML, a comment, a test, or any other
+# committed file — committing them would itself be the leak this gate exists to
+# prevent.
+#
+# Two scans run over the lines a PR ADDS (diff scope = merge-base...HEAD):
+#   1. Employer-token scan — armed only when the PRIVACY_DENYLIST_TOKENS secret
+#      is set; warns + skips (does NOT fail) when unset, so a PR can pass its own
+#      CI before the secret is configured.
+#   2. Home-path guard — always on, no secret needed; catches absolute home-dir
+#      leaks like /Users/<name>/ or /home/<name>/ that a fixed token list misses.
+#
+# Fail-closed: an unresolvable diff range is treated as a FAILURE (exit 1), never
+# a vacuous "no hits / pass". Matched content is WITHHELD from output — printing
+# the matched line would re-leak the very token/username into public CI logs;
+# only a count + remediation hint is printed. Set PRIVACY_VERBOSE=1 LOCALLY to
+# echo matched lines for debugging (never in CI).
+#
+# Runs on a `pull_request` event (needs a PR base to diff against). ubuntu-only.
+
+set -u
+
+# --- Resolve the diff range, fail-closed (the single most important property) ---
+BASE_REF="${GITHUB_BASE_REF:-master}"
+
+# Prefer the remote-tracking ref if it resolves; else the bare ref.
+RANGE_BASE=""
+if git rev-parse --verify --quiet "origin/${BASE_REF}" >/dev/null; then
+  RANGE_BASE="origin/${BASE_REF}"
+elif git rev-parse --verify --quiet "${BASE_REF}" >/dev/null; then
+  RANGE_BASE="${BASE_REF}"
+else
+  echo "privacy-denylist: ERROR — base ref '${BASE_REF}' does not resolve (tried 'origin/${BASE_REF}' and '${BASE_REF}')." >&2
+  echo "privacy-denylist: refusing to run on an unresolvable base (a vacuous pass would hide leaks). Ensure fetch-depth: 0." >&2
+  exit 1
+fi
+
+MERGE_BASE="$(git merge-base "${RANGE_BASE}" HEAD 2>/dev/null || true)"
+if [ -z "${MERGE_BASE}" ]; then
+  echo "privacy-denylist: ERROR — git merge-base '${RANGE_BASE}' HEAD failed or returned empty." >&2
+  echo "privacy-denylist: refusing to run on an unresolvable diff range (a vacuous pass would hide leaks)." >&2
+  exit 1
+fi
+
+# --- Compute ADDED lines (lines starting with '+', excluding '+++ ' headers) ---
+ADDED="$(git diff --no-color "${MERGE_BASE}...HEAD" | grep -E '^\+' | grep -vE '^\+\+\+ ' || true)"
+
+ADDED_COUNT=0
+if [ -n "${ADDED}" ]; then
+  ADDED_COUNT="$(printf '%s\n' "${ADDED}" | grep -c '' || true)"
+fi
+echo "privacy-denylist: scanning ${ADDED_COUNT} added line(s) in range ${MERGE_BASE}...HEAD"
+
+FAIL=0
+
+# --- Employer-token scan (armed only when the secret is set) ---
+if [ -n "${PRIVACY_DENYLIST_TOKENS:-}" ]; then
+  # Join non-blank lines with '|' into a single alternation.
+  PATTERN="$(printf '%s\n' "${PRIVACY_DENYLIST_TOKENS}" | grep -vE '^[[:space:]]*$' | paste -sd '|' - || true)"
+  if [ -n "${PATTERN}" ]; then
+    TOKEN_HITS="$(printf '%s\n' "${ADDED}" | grep -iE "${PATTERN}" || true)"
+    if [ -n "${TOKEN_HITS}" ]; then
+      TOKEN_HIT_COUNT="$(printf '%s\n' "${TOKEN_HITS}" | grep -c '' || true)"
+      echo "privacy-denylist: FAIL — a regulated employer token was found on ${TOKEN_HIT_COUNT} added line(s)." >&2
+      echo "privacy-denylist: matched content WITHHELD (printing it would re-leak the token into public CI logs)." >&2
+      echo "privacy-denylist: remediation — remove the regulated token from your added lines; it must not appear in this public repo." >&2
+      if [ "${PRIVACY_VERBOSE:-}" = "1" ]; then
+        echo "privacy-denylist: [PRIVACY_VERBOSE] matched lines:" >&2
+        printf '%s\n' "${TOKEN_HITS}" >&2
+      fi
+      FAIL=1
+    fi
+  fi
+else
+  echo "::warning::PRIVACY_DENYLIST_TOKENS secret not set — employer-token scan skipped; set the repo secret to arm it."
+fi
+
+# --- Home-path guard (always on, no secret) ---
+HOME_PATH='(/Users/|/home/)[A-Za-z0-9._-]+/'
+HOME_HITS="$(printf '%s\n' "${ADDED}" | grep -E "${HOME_PATH}" || true)"
+if [ -n "${HOME_HITS}" ]; then
+  HOME_HIT_COUNT="$(printf '%s\n' "${HOME_HITS}" | grep -c '' || true)"
+  echo "privacy-denylist: FAIL — an absolute home path was found on ${HOME_HIT_COUNT} added line(s)." >&2
+  echo "privacy-denylist: matched content WITHHELD (the line contains a username)." >&2
+  echo "privacy-denylist: remediation — replace the absolute home path with a relative path or an env var / placeholder." >&2
+  if [ "${PRIVACY_VERBOSE:-}" = "1" ]; then
+    echo "privacy-denylist: [PRIVACY_VERBOSE] matched lines:" >&2
+    printf '%s\n' "${HOME_HITS}" >&2
+  fi
+  FAIL=1
+fi
+
+if [ "${FAIL}" -ne 0 ]; then
+  exit 1
+fi
+
+echo "privacy-denylist: clean (${ADDED_COUNT} added lines scanned)."
+exit 0

--- a/src/llm/generate.ts
+++ b/src/llm/generate.ts
@@ -3,7 +3,7 @@ import { getClient } from "./anthropicClient";
 const MODEL = process.env.ANTHROPIC_MODEL ?? "claude-haiku-4-5-20251001";
 const MAX_TOKENS = 1024;
 
-const SYSTEM_PROMPT =
+export const SYSTEM_PROMPT =
   "You answer factually from the provided context only. " +
   "Lead with what you DID find in the context and cite it with inline [N] citations that map to the numbered sources in the context block; " +
   "only after stating what you found, note any remaining gap. " +

--- a/tests/generate.prompt-integrity.test.ts
+++ b/tests/generate.prompt-integrity.test.ts
@@ -1,0 +1,25 @@
+import { SYSTEM_PROMPT } from "../src/llm/generate";
+
+/**
+ * Layer-B guard test for the answer-quality system prompt.
+ *
+ * The #1066 P3 abstention-bias fix added two load-bearing clauses to
+ * SYSTEM_PROMPT: an abstain rule ("if you found nothing relevant, say you
+ * couldn't find it") and a lead-with-found rule. A future prompt refactor could
+ * silently delete one and quietly regress answer quality with no test failure.
+ * These assertions fail loudly if either clause disappears, so a reword becomes
+ * a conscious decision that re-trips this test.
+ *
+ * Importing SYSTEM_PROMPT must NOT require any env (getClient is lazy) — this
+ * test runs without ANTHROPIC credentials.
+ */
+describe("SYSTEM_PROMPT integrity", () => {
+  it("retains the abstain rule (no relevant info -> say you couldn't find it)", () => {
+    expect(SYSTEM_PROMPT).toMatch(/no relevant information/i);
+    expect(SYSTEM_PROMPT).toMatch(/couldn't find/i);
+  });
+
+  it("retains the lead-with-found rule", () => {
+    expect(SYSTEM_PROMPT).toMatch(/Lead with what you DID find/);
+  });
+});


### PR DESCRIPTION
## Summary

Three small, disjoint hardening guards for this PUBLIC repo:

1. **#1169 — automatic privacy CI gate (headline).** New `.github/workflows/privacy.yml` (pull_request, ubuntu-only, fail-closed) runs `scripts/privacy-denylist-check.sh` over the PR's ADDED diff lines and FAILS on any regulated employer-token hit. Previously the repo had only a manual privacy check, so a token leak reached master with nothing in CI to catch it. The regulated denylist tokens live ONLY in the GitHub Actions secret `PRIVACY_DENYLIST_TOKENS` (newline-separated regex fragments) — never in the workflow YAML, the script, or any committed file (committing them would itself be the leak). An always-on home-path guard (no secret needed) catches absolute `/Users/<name>/` or `/home/<name>/` leaks. Fail-closed: an unresolvable diff range exits 1 (never a vacuous pass), and matched content is withheld from CI logs to avoid re-leaking.

2. **`.gitignore` fix.** `node_modules/` → `node_modules`. The trailing-slash form does not match the auto-symlinked `node_modules` in a worktree, so `git add -A` could stage it. Slash-less ignores both a directory and a symlink (`git check-ignore node_modules` now exits 0).

3. **Layer-B prompt-integrity test.** New `tests/generate.prompt-integrity.test.ts` asserts `SYSTEM_PROMPT` in `src/llm/generate.ts` keeps BOTH the abstain clause and the "Lead with what you DID find" clause, so a future prompt refactor can't silently drop either rule. The only source change is adding `export` to the existing const (no wording change).

## Test plan

- `npm run build` — tsc clean.
- `npm test` — all green incl. the new prompt-integrity test (2 assertions).
- `git check-ignore node_modules` — exit 0.
- Privacy script proofs (fake placeholder token only): token-hit → exit 1; clean → exit 0; unresolvable base → exit 1 (non-vacuous); home-path leak → exit 1.
- The new `privacy` workflow job runs on this PR and is green.

## Operator setup (post-merge)

To ARM employer-token scanning, set the repo secret `PRIVACY_DENYLIST_TOKENS` (newline-separated regex fragments = the employer denylist tokens) and mark the `privacy / denylist` check as a required status check in branch protection. Until the secret is set the job warns and passes (home-path guard still runs).

## 3-role

planner inline-skip (brief fully specified outcome+AC); plan-review PASS; executor; execution-review PASS. Artifacts in `.ai-workspace/`.