### PR TITLE
fix(slack): #1188 convert LLM Markdown to Slack mrkdwn (bold renders)

### DIFF
--- a/src/slack/formatter.ts
+++ b/src/slack/formatter.ts
@@ -79,6 +79,55 @@ function sanitizeTitle(s: string): string {
 }
 
 /**
+ * Convert CommonMark-style Markdown (as emitted by the LLM) into Slack mrkdwn.
+ *
+ * Slack mrkdwn is a different dialect from standard Markdown: bold is a single
+ * `*` (not `**`), links are `<url|text>` (not `[text](url)`), and there are no
+ * `#` headings. The LLM emits standard Markdown, so dropping it straight into a
+ * Slack `mrkdwn` block renders literal asterisks. This deterministic, pure v1
+ * converter handles the common cases an LLM answer produces.
+ *
+ * Conversions:
+ *   - bold:     `**x**` and `__x__` -> `*x*` (NON-GREEDY, per-span — so
+ *               `**a** and **b**` convert independently). The ONLY emphasis rule.
+ *   - headings: a line `^#{1,6}\s+(.*)$` -> `*$1*` (per line; Slack has no headings).
+ *   - links:    `[text](url)` -> `<url|text>`.
+ *   - bullets:  a line starting `- ` or `* ` -> `• ` + the item text.
+ *
+ * Intentionally LEFT ALONE (accepted v1 cosmetic misses):
+ *   - single `*x*` / `_x_` emphasis is untouched. `_x_` is already valid Slack
+ *     italic; a stray Markdown `*italic*` renders as Slack bold — a far smaller
+ *     miss than bold vanishing, and adding a single-`*`->`_` rule would clobber
+ *     the `*x*` the bold pass just produced.
+ *   - `~strike~`, citation tokens like `[2]` (no parens -> not a link), plain text.
+ *
+ * Known v1 LIMITATION: inline/fenced code spans are NOT masked, so a `**` inside
+ * a `` `code` `` span IS converted. Acceptable for v1 (rare in answer bodies).
+ */
+export function markdownToMrkdwn(s: string): string {
+  if (typeof s !== "string") return s;
+
+  // Per-line: headings and bullets operate on the raw line markers.
+  const out = s
+    .split("\n")
+    .map((line) => {
+      const heading = line.match(/^#{1,6}\s+(.*)$/);
+      if (heading) return `*${heading[1]}*`;
+      const bullet = line.match(/^[-*] (.*)$/);
+      if (bullet) return `• ${bullet[1]}`;
+      return line;
+    })
+    .join("\n")
+    // links: [text](url) -> <url|text> (a bare `[2]` citation has no `(...)`).
+    .replace(/\[([^\]]+)\]\(([^)]+)\)/g, "<$2|$1>")
+    // bold: **x** and __x__ -> *x* (non-greedy / per-span). The ONLY emphasis rule.
+    .replace(/\*\*(.+?)\*\*/g, "*$1*")
+    .replace(/__(.+?)__/g, "*$1*");
+
+  return out;
+}
+
+/**
  * Format a `{ answer, citations }` payload into a Slack Block Kit message.
  *
  * Layout:
@@ -94,7 +143,9 @@ export function formatAnswer(input: FormatAnswerInput): SlackMessagePayload {
     throw new TypeError("formatAnswer: input.answer must be a string");
   }
 
-  const answer = input.answer.trim();
+  // Convert ONCE here so both the section block and the fallback `text` field
+  // below use the same Slack-mrkdwn string (consistent; no `**` in either).
+  const answer = markdownToMrkdwn(input.answer.trim());
   const citations = Array.isArray(input.citations) ? input.citations : [];
 
   const blocks: SlackBlock[] = [];

--- a/tests/slack-formatter.test.ts
+++ b/tests/slack-formatter.test.ts
@@ -1,4 +1,4 @@
-import { formatAnswer } from "../src/slack/formatter";
+import { formatAnswer, markdownToMrkdwn } from "../src/slack/formatter";
 
 describe("slack/formatter", () => {
   it("produces a section block with the answer text", () => {
@@ -109,5 +109,88 @@ describe("slack/formatter", () => {
   it("throws TypeError on bad input", () => {
     expect(() => formatAnswer(undefined as never)).toThrow(TypeError);
     expect(() => formatAnswer({ answer: 123 as never })).toThrow(TypeError);
+  });
+});
+
+describe("markdownToMrkdwn", () => {
+  it("converts `**bold:**` to a single-asterisk bold and leaves no `**`", () => {
+    const out = markdownToMrkdwn("**Daily Borrowing Limit:**");
+    expect(out).toBe("*Daily Borrowing Limit:*");
+    expect(out).not.toContain("**");
+  });
+
+  it("converts multiple bold spans independently (non-greedy)", () => {
+    // A greedy match would swallow the middle " and " into one span.
+    expect(markdownToMrkdwn("**a** and **b**")).toBe("*a* and *b*");
+  });
+
+  it("converts `__bold__` to single-asterisk bold", () => {
+    expect(markdownToMrkdwn("__bold__")).toBe("*bold*");
+  });
+
+  it("converts an ATX heading line to bold", () => {
+    expect(markdownToMrkdwn("# Title")).toBe("*Title*");
+  });
+
+  it("converts a Markdown link to Slack link syntax", () => {
+    expect(markdownToMrkdwn("[text](http://x)")).toBe("<http://x|text>");
+  });
+
+  it("converts a `- ` bullet line to a `• ` bullet", () => {
+    expect(markdownToMrkdwn("- item")).toBe("• item");
+  });
+
+  it("converts a `* ` bullet line to a `• ` bullet", () => {
+    expect(markdownToMrkdwn("* item")).toBe("• item");
+  });
+
+  it("leaves a bare citation token `[2]` untouched (no parens -> not a link)", () => {
+    expect(markdownToMrkdwn("see note [2] for details")).toBe(
+      "see note [2] for details"
+    );
+  });
+
+  it("leaves single `_italic_` untouched (already valid Slack italic)", () => {
+    expect(markdownToMrkdwn("_italic_")).toBe("_italic_");
+  });
+
+  it("leaves single `*italic*` untouched (accepted v1 cosmetic miss)", () => {
+    expect(markdownToMrkdwn("*italic*")).toBe("*italic*");
+  });
+
+  it("leaves `~strike~` and plain text untouched", () => {
+    expect(markdownToMrkdwn("plain ~strike~ text")).toBe("plain ~strike~ text");
+  });
+
+  it("documented v1 limitation: does NOT mask code spans, so `**` inside a `code` span IS converted", () => {
+    // The converter has no code-span protection in v1 — this asserts the
+    // CURRENT behavior explicitly rather than leaving the gap silent.
+    expect(markdownToMrkdwn("`a**b**c`")).toBe("`a*b*c`");
+  });
+
+  it("behavioral both-ends: a multi-paragraph `**bold:**` answer's section text contains no `**`", () => {
+    const answer = [
+      "**Overview:** This is the summary line.",
+      "",
+      "**Steps:**",
+      "- First do the thing.",
+      "- Then do the **other** thing.",
+      "",
+      "See the [guide](http://example.test/guide) for more. [1]",
+    ].join("\n");
+    const payload = formatAnswer({
+      answer,
+      citations: [{ num: 1, source: "guide.md" }],
+    });
+    const section = payload.blocks.find((b) => b.type === "section");
+    expect(section).toBeDefined();
+    if (section && section.type === "section") {
+      expect(section.text.text).not.toContain("**");
+      expect(section.text.text).toContain("*Overview:*");
+      expect(section.text.text).toContain("• First do the thing.");
+      expect(section.text.text).toContain("<http://example.test/guide|guide>");
+    }
+    // The fallback text uses the same converted string.
+    expect(payload.text).not.toContain("**");
   });
 });


### PR DESCRIPTION
## Summary
Monday's Slack answers showed literal `**Daily Borrowing Limit:**` instead of bold. The LLM emits CommonMark (`**bold**`), but `src/slack/formatter.ts` put that into a Slack `section` block of `type:"mrkdwn"`, where bold is a *single* `*` — so the double-asterisks render literally. Adds an exported pure `markdownToMrkdwn()` applied once at the answer assignment (so section block + fallback `text` are consistent): `**x**`/`__x__` → `*x*` (non-greedy per-span), `# heading` → `*heading*`, `[t](u)` → `<u|t>`, `- `/`* ` bullets → `• `. Single `*`/`_` and bare `[N]` citations left intact. Citation/sanitize path unchanged.

## Test plan
- `npm run typecheck` clean; `npm test` = 207 passed (23 suites) incl. 12 new `markdownToMrkdwn` cases (non-greedy multi-span, `__bold__`, heading, link emits literal `<url|text>`, both bullet markers, untouched citation/`_italic_`/`*italic*`/`~strike~`, documented inline-code v1 limitation, and a behavioral both-ends multi-paragraph answer asserting no `**` in the section text).
- 3-role: plan-review PASS-WITH-FIXES (caught a bold-deleting ordering bug, folded) + execution-review PASS (re-ran all AC, confirmed link output is literal mrkdwn).