### PR TITLE
fix(retrieval): #1189 passage-chunk Confluence pages so long how-to pages are findable

### DIFF
--- a/src/confluence/sync.ts
+++ b/src/confluence/sync.ts
@@ -43,6 +43,17 @@ export interface ConfluenceClientConfig {
   baseUrl: string;
   email: string;
   apiToken: string;
+  /**
+   * Page-fetch size for the `&limit=` query param. Default 100.
+   *
+   * NOTE (#1189): this only makes the per-request page size CONFIGURABLE — it is
+   * NOT a full large-space fix. The Atlassian content REST API caps `limit`
+   * (commonly 100) and paginates further results via `_links.next` cursors,
+   * which this fetcher does NOT follow. A space with more results than one page
+   * is therefore still truncated regardless of the `limit` value. Cursor
+   * pagination is a deferred follow-up (see the plan's Deferred section).
+   */
+  pageLimit?: number;
 }
 
 /**
@@ -63,9 +74,12 @@ export function buildConfluenceFetcher(
     );
   }
   const auth = Buffer.from(`${config.email}:${config.apiToken}`).toString("base64");
+  // Configurable page size (default 100). Does NOT follow `_links.next` cursors,
+  // so large spaces are still truncated at one page — see ConfluenceClientConfig.
+  const limit = typeof config.pageLimit === "number" && config.pageLimit > 0 ? config.pageLimit : 100;
   return {
     async fetchPages(spaceKey: string): Promise<ConfluencePage[]> {
-      const url = `${config.baseUrl.replace(/\/$/, "")}/wiki/rest/api/content?spaceKey=${encodeURIComponent(spaceKey)}&expand=body.storage&limit=100`;
+      const url = `${config.baseUrl.replace(/\/$/, "")}/wiki/rest/api/content?spaceKey=${encodeURIComponent(spaceKey)}&expand=body.storage&limit=${limit}`;
       const res = await fetchImpl(url, {
         headers: {
           Authorization: `Basic ${auth}`,

--- a/src/ingestion/chunkText.ts
+++ b/src/ingestion/chunkText.ts
@@ -1,0 +1,165 @@
+/**
+ * Passage chunking for retrieval (#1189).
+ *
+ * WHY: Confluence pages are embedded for vector search. Embedding a whole long
+ * page as ONE averaged vector dilutes the relevant sentence into the page mean,
+ * so a 13.5K-char how-to page scores far below short keyword-dense docs and
+ * never lands in top-K. (Two compounding effects: averaging-dilution AND silent
+ * truncation — the MiniLM embedder TRUNCATES input past its 512-token window
+ * rather than throwing, so a whole-page vector literally never "sees" anything
+ * past ~the first ~512 tokens / ~2000 chars.) Splitting a page into bounded
+ * passages and embedding each as its own vector fixes both: the relevant passage
+ * embeds undiluted and untruncated, and ranks high.
+ *
+ * `stripHtml` (confluence/sync.ts) collapses ALL whitespace to single spaces, so
+ * the page body arrives as one long line with NO paragraph breaks. This splitter
+ * is therefore SENTENCE/window-based, not blank-line-based.
+ *
+ * Pure, deterministic, no I/O.
+ */
+
+export interface SplitOptions {
+  /**
+   * Soft upper bound on passage length in characters. Default 900 (~225 tokens
+   * — comfortably under MiniLM's 512-token window, so each passage embeds
+   * without truncation). A passage never exceeds this EXCEPT an unavoidable
+   * single sentence longer than `maxChars`, which is itself hard-window-split
+   * into pieces each `<= maxChars`.
+   */
+  maxChars?: number;
+  /**
+   * Characters of trailing context carried from the end of one passage into the
+   * start of the next, for continuity across the cut. Default 150. Only applied
+   * when it still fits within `maxChars` alongside the next sentence.
+   */
+  overlapChars?: number;
+  /**
+   * Drop passages shorter than this — but ONLY as a cleanup of EXTRA tail/interior
+   * fragments when there are >= 2 passages. A non-empty body ALWAYS yields >= 1
+   * passage; minChars never zeroes out the sole passage (correction #1, #1189).
+   * Default 20.
+   */
+  minChars?: number;
+}
+
+const DEFAULT_MAX_CHARS = 900;
+const DEFAULT_OVERLAP_CHARS = 150;
+const DEFAULT_MIN_CHARS = 20;
+
+/**
+ * Take up to `overlapChars` characters from the END of `text`, aligned to a word
+ * boundary (so we don't carry a half-word). Returns "" when overlap is disabled
+ * or `text` is empty.
+ */
+function overlapTail(text: string, overlapChars: number): string {
+  if (overlapChars <= 0 || text.length === 0) return "";
+  if (text.length <= overlapChars) return text.trim();
+  let tail = text.slice(text.length - overlapChars);
+  // Drop the leading partial word (everything up to and including the first space).
+  const firstSpace = tail.indexOf(" ");
+  if (firstSpace >= 0) tail = tail.slice(firstSpace + 1);
+  return tail.trim();
+}
+
+/**
+ * Hard char-window split for a single sentence that alone exceeds `maxChars`
+ * (no sentence boundary to pack against — e.g. a code block or a run-on with no
+ * `. ! ?`). Windows step by `maxChars - overlapChars` so consecutive windows
+ * overlap; each window is `<= maxChars`.
+ */
+function hardWindowSplit(sentence: string, maxChars: number, overlapChars: number): string[] {
+  const out: string[] = [];
+  const step = Math.max(1, maxChars - Math.max(0, overlapChars));
+  for (let start = 0; start < sentence.length; start += step) {
+    const piece = sentence.slice(start, start + maxChars).trim();
+    if (piece.length > 0) out.push(piece);
+    if (start + maxChars >= sentence.length) break;
+  }
+  return out;
+}
+
+/**
+ * Split `text` into overlapping passages, each `<= maxChars` (modulo a single
+ * over-long sentence, which is hard-window-split). Sentence-aware: greedily packs
+ * whole sentences until the next would overflow, then emits and starts a fresh
+ * passage carrying an `overlapChars` tail for continuity.
+ *
+ * Guarantees:
+ *  - empty / whitespace-only input -> `[]`
+ *  - any non-empty trimmed input -> >= 1 passage (minChars NEVER drops the sole
+ *    passage — correction #1, #1189)
+ *  - deterministic; no I/O
+ *
+ * Overlap is dedup-safe at the index layer: VectorIndex auto-ids each chunk by
+ * sha1(source + text), so distinct passage texts get distinct ids; two
+ * byte-identical passages (a degenerate repeated-sentence doc) collide on id and
+ * VectorIndex.add already skips-with-warn (it does NOT throw) — they collapse to
+ * one chunk. No custom dedup is needed here (correction #4, #1189).
+ */
+export function splitIntoPassages(text: string, opts: SplitOptions = {}): string[] {
+  const maxChars = opts.maxChars ?? DEFAULT_MAX_CHARS;
+  const overlapChars = opts.overlapChars ?? DEFAULT_OVERLAP_CHARS;
+  const minChars = opts.minChars ?? DEFAULT_MIN_CHARS;
+
+  if (typeof text !== "string") return [];
+  const trimmed = text.trim();
+  if (trimmed.length === 0) return [];
+
+  // The body is single-spaced collapsed text; sentence-split on terminal
+  // punctuation followed by whitespace. (stripHtml keeps . ! ? — see module doc.)
+  const sentences = trimmed.split(/(?<=[.!?])\s+/);
+
+  const passages: string[] = [];
+  let current = "";
+
+  const flush = (): void => {
+    const t = current.trim();
+    if (t.length > 0) passages.push(t);
+  };
+
+  for (const raw of sentences) {
+    const sentence = raw.trim();
+    if (sentence.length === 0) continue;
+
+    // A single sentence longer than maxChars can't be packed — emit what we have,
+    // then hard-window-split the over-long sentence on its own.
+    if (sentence.length > maxChars) {
+      flush();
+      current = "";
+      for (const piece of hardWindowSplit(sentence, maxChars, overlapChars)) {
+        passages.push(piece);
+      }
+      continue;
+    }
+
+    const candidate = current.length === 0 ? sentence : `${current} ${sentence}`;
+    if (candidate.length <= maxChars) {
+      current = candidate;
+      continue;
+    }
+
+    // Adding this sentence would overflow: emit current, start fresh. Carry an
+    // overlap tail only if it still leaves the new passage within maxChars.
+    flush();
+    const tail = overlapTail(current, overlapChars);
+    if (tail.length > 0 && tail.length + 1 + sentence.length <= maxChars) {
+      current = `${tail} ${sentence}`;
+    } else {
+      current = sentence;
+    }
+  }
+  flush();
+
+  // minChars cleanup: only drop short EXTRA fragments, and only when >= 2
+  // passages exist — never zero out a non-empty body (correction #1).
+  let result = passages;
+  if (result.length >= 2) {
+    const filtered = result.filter((p) => p.length >= minChars);
+    if (filtered.length > 0) result = filtered;
+  }
+
+  // Belt-and-suspenders: a non-empty trimmed body must ALWAYS yield >= 1 passage.
+  if (result.length === 0) result = [trimmed];
+
+  return result;
+}

--- a/src/knowledge/service.ts
+++ b/src/knowledge/service.ts
@@ -1,4 +1,5 @@
 import { ingestFile, Chunk as IngestChunk } from "../ingestion/ingest";
+import { splitIntoPassages } from "../ingestion/chunkText";
 import { VectorIndex, SearchResult, Chunk as IndexChunk } from "../index/vectorIndex";
 import { generateAnswer, Chunk as LlmChunk, Citation } from "../llm/generate";
 import {
@@ -6,7 +7,10 @@ import {
   FolderWatcherOptions,
 } from "../watcher/folderWatcher";
 
-const DEFAULT_TOP_K = 5;
+// Raised 5 -> 12 (#1189): passage-chunking can fill several top slots with
+// passages from the same doc, so a wider window leaves room for the relevant
+// passage AND cross-doc coverage. `opts.topK` still overrides per-service.
+const DEFAULT_TOP_K = 12;
 const NO_DOCUMENTS_ANSWER =
   "I couldn't find any relevant information in the indexed documents to answer this question.";
 
@@ -169,16 +173,33 @@ export class KnowledgeService {
     await this.vectorIndex.removeBySource(source);
 
     const text = page.body.trim();
-    if (text.length === 0) {
+
+    // Passage-chunk the page (#1189): embed each bounded passage as its own
+    // vector so the relevant passage ranks high, instead of one diluted +
+    // truncated whole-page vector. removeBySource above already cleared all prior
+    // passages (they share this `source`), so re-sync replaces rather than
+    // accumulates. A non-empty body ALWAYS yields >= 1 passage, so
+    // `passages.length === 0` is reached ONLY for an empty/whitespace body —
+    // which we treat as a delete (mirrors the prior empty-body guard).
+    const passages = splitIntoPassages(text);
+    if (passages.length === 0) {
       this.indexedSources.delete(source);
       return;
     }
 
-    const chunk: IngestChunk = { text, source };
-    if (typeof page.title === "string" && page.title.length > 0) chunk.heading = page.title;
-    if (typeof page.spaceKey === "string" && page.spaceKey.length > 0) chunk.section = page.spaceKey;
+    const heading =
+      typeof page.title === "string" && page.title.length > 0 ? page.title : undefined;
+    const section =
+      typeof page.spaceKey === "string" && page.spaceKey.length > 0 ? page.spaceKey : undefined;
 
-    await this.vectorIndex.add([chunk]);
+    const passageChunks: IngestChunk[] = passages.map((passage) => {
+      const chunk: IngestChunk = { text: passage, source };
+      if (heading !== undefined) chunk.heading = heading;
+      if (section !== undefined) chunk.section = section;
+      return chunk;
+    });
+
+    await this.vectorIndex.add(passageChunks);
     this.indexedSources.add(source);
   }
 

--- a/src/knowledge/startup.ts
+++ b/src/knowledge/startup.ts
@@ -131,7 +131,14 @@ export function startKnowledgeSources(deps: KnowledgeSourcesDeps): KnowledgeSour
     } else {
       const fetcher =
         deps.confluenceFetcher ??
-        buildConfluenceFetcher({ baseUrl: siteRoot, email: email!, apiToken: apiToken! });
+        buildConfluenceFetcher({
+          baseUrl: siteRoot,
+          email: email!,
+          apiToken: apiToken!,
+          // Configurable page size (default 100 inside buildConfluenceFetcher).
+          // Not a full large-space fix — cursor pagination is deferred (#1189).
+          pageLimit: config.confluence?.pageLimit,
+        });
       const sync = new ConfluenceSync({ knowledge: deps.knowledge, fetcher, logger });
       confluenceSync = sync;
       confluenceSpaces.push(...spaces);

--- a/tests/chunkText.test.ts
+++ b/tests/chunkText.test.ts
@@ -1,0 +1,90 @@
+import { splitIntoPassages } from "../src/ingestion/chunkText";
+
+const MAX = 900; // DEFAULT_MAX_CHARS
+
+describe("splitIntoPassages (AC2 — pure chunker)", () => {
+  it("empty / whitespace-only input -> []", () => {
+    expect(splitIntoPassages("")).toEqual([]);
+    expect(splitIntoPassages("   \n\t  ")).toEqual([]);
+    expect(splitIntoPassages(undefined as unknown as string)).toEqual([]);
+  });
+
+  it("a 7-char non-empty body -> exactly 1 passage (correction #1: minChars never zeroes a non-empty body)", () => {
+    const out = splitIntoPassages("v1 body");
+    expect(out).toEqual(["v1 body"]);
+    expect(out).toHaveLength(1);
+  });
+
+  it("a 12-char non-empty body -> exactly 1 passage (the other short-fixture used in confluence tests)", () => {
+    expect(splitIntoPassages("real content")).toEqual(["real content"]);
+  });
+
+  it("a 5000-char single-line input -> multiple passages, each <= maxChars", () => {
+    // Build ~120 short sentences on a single line (no newlines). ~5000 chars.
+    const sentences: string[] = [];
+    for (let i = 0; i < 120; i++) {
+      sentences.push(`Sentence number ${i} carries some filler words for packing.`);
+    }
+    const text = sentences.join(" ");
+    expect(text.length).toBeGreaterThan(5000);
+    expect(text.includes("\n")).toBe(false);
+
+    const passages = splitIntoPassages(text);
+    expect(passages.length).toBeGreaterThan(1);
+    for (const p of passages) {
+      expect(p.length).toBeLessThanOrEqual(MAX);
+      expect(p.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("overlap is present between consecutive passages (the next passage starts with a tail of the prior)", () => {
+    const sentences: string[] = [];
+    for (let i = 0; i < 120; i++) {
+      sentences.push(`Sentence number ${i} carries some filler words for packing.`);
+    }
+    const passages = splitIntoPassages(sentences.join(" "));
+    expect(passages.length).toBeGreaterThan(1);
+
+    // Each passage (after the first) begins with an overlap tail taken from the
+    // END of the previous passage, so its first 30 chars are a substring of the
+    // previous passage.
+    for (let i = 1; i < passages.length; i++) {
+      const head = passages[i].slice(0, 30);
+      expect(head.length).toBe(30);
+      expect(passages[i - 1].includes(head)).toBe(true);
+    }
+  });
+
+  it("a sub-minChars trailing fragment is dropped when >= 2 passages exist", () => {
+    // First sentence near maxChars, then a tiny 'Zz.' sentence. Disable overlap so
+    // the tiny final sentence stands alone as a < minChars passage and is dropped.
+    const longSentence = "x".repeat(898) + ".";
+    const text = `${longSentence} Zz.`;
+    const passages = splitIntoPassages(text, { overlapChars: 0, minChars: 20 });
+    expect(passages).toHaveLength(1); // the tiny 'Zz.' tail was dropped
+    expect(passages.some((p) => p.includes("Zz"))).toBe(false);
+    expect(passages[0].length).toBeLessThanOrEqual(MAX);
+  });
+
+  it("a single sentence longer than maxChars -> hard-split into bounded passages with overlap", () => {
+    // 2500-char run-on with NO sentence terminator -> hard char-window split.
+    const longSentence = "abcdefghij".repeat(250); // 2500 chars, no . ! ?
+    expect(longSentence.length).toBe(2500);
+    const passages = splitIntoPassages(longSentence);
+
+    expect(passages.length).toBeGreaterThan(1);
+    for (const p of passages) {
+      expect(p.length).toBeLessThanOrEqual(MAX);
+    }
+    // Overlap present: consecutive windows share a boundary region.
+    for (let i = 1; i < passages.length; i++) {
+      const head = passages[i].slice(0, 30);
+      expect(passages[i - 1].includes(head)).toBe(true);
+    }
+  });
+
+  it("never zeroes out a non-empty body even when every fragment is below minChars", () => {
+    // A short single sentence below a large minChars must still survive.
+    expect(splitIntoPassages("tiny.", { minChars: 1000 })).toEqual(["tiny."]);
+  });
+});

--- a/tests/confluence.test.ts
+++ b/tests/confluence.test.ts
@@ -194,6 +194,79 @@ describe("KnowledgeService.indexConfluencePage replace-on-resync", () => {
   });
 });
 
+describe("KnowledgeService.indexConfluencePage passage-chunking (AC4, #1189)", () => {
+  function longBody(): string {
+    // ~3500 chars of sentences on a single collapsed line (mirrors stripHtml
+    // output) so the chunker produces several passages.
+    const sentences: string[] = [];
+    for (let i = 0; i < 80; i++) {
+      sentences.push(`Step ${i} explains a part of the onboarding workflow in detail.`);
+    }
+    return sentences.join(" ");
+  }
+
+  it("a long page produces > 1 chunk under the same source", async () => {
+    const knowledge = new KnowledgeService();
+    await knowledge.indexConfluencePage({
+      id: "long-1",
+      title: "Big How-To",
+      body: longBody(),
+      source: "confluence:long-1",
+      spaceKey: "ENG",
+    });
+    expect(knowledge.getChunkCountForSource("confluence:long-1")).toBeGreaterThan(1);
+    // The page still counts as exactly ONE document (source), not N.
+    expect(knowledge.getStatus().documentCount).toBe(1);
+  });
+
+  it("re-syncing a long page replaces (not duplicates) its chunks", async () => {
+    const knowledge = new KnowledgeService();
+    await knowledge.indexConfluencePage({
+      id: "long-2",
+      title: "Big How-To",
+      body: longBody(),
+      source: "confluence:long-2",
+    });
+    const first = knowledge.getChunkCountForSource("confluence:long-2");
+    expect(first).toBeGreaterThan(1);
+
+    // Re-sync the SAME source with a different long body.
+    const sentences: string[] = [];
+    for (let i = 0; i < 80; i++) {
+      sentences.push(`Revised step ${i} of the workflow now reads differently here.`);
+    }
+    await knowledge.indexConfluencePage({
+      id: "long-2",
+      title: "Big How-To",
+      body: sentences.join(" "),
+      source: "confluence:long-2",
+    });
+    const second = knowledge.getChunkCountForSource("confluence:long-2");
+    // Replaced, not accumulated — count reflects only the new body's passages.
+    expect(second).toBeGreaterThan(1);
+    expect(second).toBe(splitForCount(sentences.join(" ")));
+    expect(knowledge.getStatus().documentCount).toBe(1);
+  });
+
+  it("a short page still produces >= 1 chunk", async () => {
+    const knowledge = new KnowledgeService();
+    await knowledge.indexConfluencePage({
+      id: "short-1",
+      title: "Tiny",
+      body: "Short note.",
+      source: "confluence:short-1",
+    });
+    expect(knowledge.getChunkCountForSource("confluence:short-1")).toBeGreaterThanOrEqual(1);
+  });
+});
+
+// Local helper mirroring the chunker so the resync test asserts exact replacement.
+function splitForCount(body: string): number {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { splitIntoPassages } = require("../src/ingestion/chunkText");
+  return splitIntoPassages(body).length;
+}
+
 describe("config.yaml has a Confluence sync schedule", () => {
   it("contains a confluence section with a schedule/cron/interval field", () => {
     const configPath = path.join(__dirname, "..", "config.yaml");

--- a/tests/recall.test.ts
+++ b/tests/recall.test.ts
@@ -1,0 +1,108 @@
+import { embed } from "../src/embeddings/embed";
+import { VectorIndex } from "../src/index/vectorIndex";
+import { splitIntoPassages } from "../src/ingestion/chunkText";
+
+/**
+ * AC3 — recall both-ends proof (#1189), dilution mechanism.
+ *
+ * IMPORTANT — which embedder runs here: jest remaps `@xenova/transformers` to a
+ * deterministic bag-of-words stub (tests/__stubs__/xenova-transformers.js — a
+ * normalized token histogram). That stub reproduces the PRIMARY #1189 failure,
+ * AVERAGING-DILUTION: a whole-doc vector spreads the answer's keywords across
+ * thousands of tokens so its query-similarity collapses toward zero. Splitting
+ * into passages embeds the answer's region with far less filler around it, so the
+ * best answer-bearing chunk's similarity is many times higher than the whole-doc
+ * vector's — that lift is exactly what lets the relevant passage climb into
+ * top-K in production.
+ *
+ * What the stub canNOT host: the absolute "chunk ranks within topK against
+ * keyword decoys" claim. In pure bag-of-words a 900-char production chunk is
+ * still mostly filler, so it can't out-score an ultra-dense keyword decoy the way
+ * the REAL semantic MiniLM model does (the real model embeds the answer region's
+ * MEANING, not its token frequencies). The real-embedder topK both-ends
+ * (RED: buried past topK=12 / GREEN: within topK=12, answer pinned past 2000
+ * chars) is proven by the standalone script run outside jest + the live
+ * re-measure — see the executor report. This spec proves the deterministic
+ * mechanism the production fix rests on.
+ *
+ * RED end: the whole-doc vector is buried below keyword decoys (low similarity).
+ * GREEN end: chunking lifts the answer region's similarity far above the diluted
+ * whole-doc vector — dilution removed.
+ */
+
+const QUERY = "alpha beta gamma delta epsilon rotation procedure";
+const ANSWER_SENTENCE =
+  "The alpha beta gamma delta epsilon rotation procedure must be run from the admin console.";
+const ANSWER_SOURCE = "confluence:answer-doc";
+
+function filler(i: number): string {
+  return `Background note ${i} about meetings schedules lunches parking and weather updates.`;
+}
+
+/** Long prose doc with the answer sentence pinned in the MIDDLE, past ~2000 chars. */
+function buildLongDoc(): string {
+  const parts: string[] = [];
+  for (let i = 0; i < 60; i++) parts.push(filler(i));
+  parts.push(ANSWER_SENTENCE);
+  for (let i = 60; i < 120; i++) parts.push(filler(i));
+  return parts.join(" ");
+}
+
+function cosine(a: number[], b: number[]): number {
+  let dot = 0;
+  let na = 0;
+  let nb = 0;
+  for (let i = 0; i < a.length; i++) {
+    dot += a[i] * b[i];
+    na += a[i] * a[i];
+    nb += b[i] * b[i];
+  }
+  const denom = Math.sqrt(na) * Math.sqrt(nb);
+  return denom === 0 ? 0 : dot / denom;
+}
+
+describe("AC3 recall both-ends — dilution mechanism (#1189)", () => {
+  jest.setTimeout(30_000);
+
+  const longDoc = buildLongDoc();
+
+  it("fixture: the answer sits past the first ~2000 chars (correction #3)", () => {
+    expect(longDoc.indexOf(ANSWER_SENTENCE)).toBeGreaterThan(2000);
+  });
+
+  it("RED: the whole-doc vector is buried below keyword decoys for the answer query", async () => {
+    const index = new VectorIndex();
+    // Keyword decoys that share query tokens — these out-rank the diluted whole doc.
+    const decoys = [
+      "alpha beta", "gamma delta", "delta epsilon", "alpha gamma", "beta delta",
+      "gamma epsilon", "alpha delta", "beta gamma", "alpha epsilon", "beta epsilon",
+      "gamma alpha", "delta beta", "epsilon gamma", "delta alpha", "epsilon beta",
+    ].map((p, i) => ({ text: `${p} ${p} ${p}`, source: `confluence:decoy-${i}` }));
+
+    await index.add(decoys);
+    await index.add([{ text: longDoc, source: ANSWER_SOURCE }]); // ONE diluted vector
+
+    const results = await index.search(QUERY, decoys.length + 1);
+    const rank = results.findIndex((r) => r.source === ANSWER_SOURCE) + 1;
+    // Buried: the whole-doc vector ranks behind every keyword decoy.
+    expect(rank).toBeGreaterThan(12);
+  });
+
+  it("GREEN: chunking lifts the answer region's similarity far above the diluted whole-doc vector", async () => {
+    const q = await embed(QUERY);
+    const wholeDocSim = cosine(q, await embed(longDoc));
+
+    const passages = splitIntoPassages(longDoc);
+    expect(passages.length).toBeGreaterThan(1);
+
+    let bestChunkSim = -Infinity;
+    for (const p of passages) {
+      bestChunkSim = Math.max(bestChunkSim, cosine(q, await embed(p)));
+    }
+
+    // Dilution removed: the best answer-bearing chunk is many times more similar
+    // to the query than the whole-doc average. This concentration is what carries
+    // the passage into top-K under the real semantic embedder.
+    expect(bestChunkSim).toBeGreaterThan(wholeDocSim * 3);
+  });
+});


### PR DESCRIPTION
## Summary
Monday over-abstained ("I couldn't find any relevant information") on questions the docs DO answer. **Measured root cause:** each whole Confluence page was embedded as ONE averaged vector (no chunking), so a 13.5K-char prose how-to page diluted to ~0.2–0.4 cosine and ranked #64–#398 — far past topK=5 — while short keyword-dense Jira tickets filled the top-5 and the LLM honestly abstained.

**Fix:** a pure `splitIntoPassages()` (sentence-aware ~900-char passages + overlap + hard-split fallback) applied in `indexConfluencePage` so each page becomes multiple passage vectors; `DEFAULT_TOP_K` 5→12; Confluence `pageLimit` configurable (honest: not a full large-space fix — cursor pagination deferred to a follow-up).

## Test plan
- `npm run typecheck` clean; `npm test` = **221 passed / 25 suites** (existing 207 + 14 new: chunker units, an AC3 both-ends recall test proving the dilution mechanism, AC4 multi-passage indexing + resync-replace).
- 3-role: plan-review PASS-WITH-FIXES (caught a confirmed short-page test breakage + the 512-token window + a deterministic RED-end pin — all folded) + exec-review PASS (re-ran all 221).

## Live re-measure (real MiniLM, 859-doc corpus → 1417 passages, topK=12)
Every buried page lifted **52–656 positions**. Real UAT: **4/5 fixed** — Q "how to use" 60→1, "which places" 394→8, "how seeker works" 176→1 (all into top-12); the chit-chat control still correctly abstains. The 5th ("find parking") rises 664→38 but is still crowded out of top-12 by keyword-dense Jira tickets → **hybrid/rerank follow-up (#1191)**.