### PR TITLE
fix(slack): #1190 markdownToMrkdwn edge cases (***bold italic***, # **Title**, __init__)

### DIFF
--- a/src/slack/formatter.ts
+++ b/src/slack/formatter.ts
@@ -88,8 +88,20 @@ function sanitizeTitle(s: string): string {
  * converter handles the common cases an LLM answer produces.
  *
  * Conversions:
- *   - bold:     `**x**` and `__x__` -> `*x*` (NON-GREEDY, per-span — so
- *               `**a** and **b**` convert independently). The ONLY emphasis rule.
+ *   - bold+italic: `***x***` -> `*x*` (Slack has no combined bold+italic; bold is
+ *               the closest single-mark rendering). Runs BEFORE the `**x**` rule so
+ *               the 2-star pass cannot grab the inner pair. This ALSO fixes a
+ *               heading whose text is bold — `# **Title**` heading-wraps to
+ *               `***Title***`, which this 3-star rule then collapses to `*Title*`.
+ *   - bold:     `**x**` -> `*x*` (NON-GREEDY, per-span — so `**a** and **b**`
+ *               convert independently).
+ *   - bold:     `__x__` -> `*x*`, EXCEPT when the inner span is a single bare
+ *               identifier token (`/^\w+$/`): then it is left literal so Python
+ *               dunders / intraword underscores survive — `__init__`, `__name__`,
+ *               `obj.__init__()`, `snake__case`, `__123__`, `__GDP__` all stay as
+ *               written. Multi-word spans (`__very important__`, anything with a
+ *               space) still convert. The `**x**` rule is UNCHANGED (asterisk-bold
+ *               has no identifier collision).
  *   - headings: a line `^#{1,6}\s+(.*)$` -> `*$1*` (per line; Slack has no headings).
  *   - links:    `[text](url)` -> `<url|text>`.
  *   - bullets:  a line starting `- ` or `* ` -> `• ` + the item text.
@@ -99,6 +111,10 @@ function sanitizeTitle(s: string): string {
  *     italic; a stray Markdown `*italic*` renders as Slack bold — a far smaller
  *     miss than bold vanishing, and adding a single-`*`->`_` rule would clobber
  *     the `*x*` the bold pass just produced.
+ *   - a single-word `__bold__` / `__123__` / `__GDP__` now stays LITERAL (the
+ *     identifier-skip above can't tell a legit single-word bold from a dunder).
+ *     Accepted v1 cosmetic miss — the LLM emits `**bold**` for that, which still
+ *     converts correctly.
  *   - `~strike~`, citation tokens like `[2]` (no parens -> not a link), plain text.
  *
  * Known v1 LIMITATION: inline/fenced code spans are NOT masked, so a `**` inside
@@ -120,9 +136,16 @@ export function markdownToMrkdwn(s: string): string {
     .join("\n")
     // links: [text](url) -> <url|text> (a bare `[2]` citation has no `(...)`).
     .replace(/\[([^\]]+)\]\(([^)]+)\)/g, "<$2|$1>")
-    // bold: **x** and __x__ -> *x* (non-greedy / per-span). The ONLY emphasis rule.
+    // bold+italic: ***x*** -> *x* (Slack has no combined mark). MUST run before the
+    // **x** rule so the 2-star pass doesn't grab the inner pair. Also collapses a
+    // heading-wrapped bold title (`# **Title**` -> `***Title***` -> `*Title*`).
+    .replace(/\*\*\*(.+?)\*\*\*/g, "*$1*")
+    // bold: **x** -> *x* (non-greedy / per-span).
     .replace(/\*\*(.+?)\*\*/g, "*$1*")
-    .replace(/__(.+?)__/g, "*$1*");
+    // bold: __x__ -> *x*, but SKIP a single bare identifier token (`/^\w+$/`) so
+    // Python dunders / intraword underscores (`__init__`, `obj.__init__()`,
+    // `snake__case`, `__123__`) are left literal. Multi-word spans still convert.
+    .replace(/__(.+?)__/g, (m, inner) => (/^\w+$/.test(inner) ? m : `*${inner}*`));
 
   return out;
 }

--- a/tests/slack-formatter.test.ts
+++ b/tests/slack-formatter.test.ts
@@ -124,8 +124,8 @@ describe("markdownToMrkdwn", () => {
     expect(markdownToMrkdwn("**a** and **b**")).toBe("*a* and *b*");
   });
 
-  it("converts `__bold__` to single-asterisk bold", () => {
-    expect(markdownToMrkdwn("__bold__")).toBe("*bold*");
+  it("leaves single-word `__bold__` literal (accepted v1 miss — #1190 identifier-skip can't tell a dunder from a 1-word bold; the LLM emits `**bold**` for this)", () => {
+    expect(markdownToMrkdwn("__bold__")).toBe("__bold__");
   });
 
   it("converts an ATX heading line to bold", () => {
@@ -166,6 +166,81 @@ describe("markdownToMrkdwn", () => {
     // The converter has no code-span protection in v1 — this asserts the
     // CURRENT behavior explicitly rather than leaving the gap silent.
     expect(markdownToMrkdwn("`a**b**c`")).toBe("`a*b*c`");
+  });
+
+  // ---- #1190 edge cases ----
+  // NEW-BEHAVIOR (these FAIL on current master, PASS after the 3-star rule +
+  // the __identifier__ skip land).
+  describe("#1190 new-behavior (red on master, green after)", () => {
+    it("collapses `***bold italic***` to single-asterisk bold", () => {
+      expect(markdownToMrkdwn("***bold italic***")).toBe("*bold italic*");
+    });
+
+    it("fixes a bold ATX heading `# **Title**` -> `*Title*`", () => {
+      expect(markdownToMrkdwn("# **Title**")).toBe("*Title*");
+    });
+
+    it("fixes a multi-word bold heading `## **Multi Word**` -> `*Multi Word*`", () => {
+      expect(markdownToMrkdwn("## **Multi Word**")).toBe("*Multi Word*");
+    });
+
+    it("locks 3-star-before-2-star on a shared line: `mix ***bi*** and **b**`", () => {
+      expect(markdownToMrkdwn("mix ***bi*** and **b**")).toBe("mix *bi* and *b*");
+    });
+
+    it("leaves a Python dunder `__init__` literal", () => {
+      expect(markdownToMrkdwn("__init__")).toBe("__init__");
+    });
+
+    it("leaves a method call `obj.__init__()` literal", () => {
+      expect(markdownToMrkdwn("obj.__init__()")).toBe("obj.__init__()");
+    });
+
+    it("leaves `__name__` literal", () => {
+      expect(markdownToMrkdwn("__name__")).toBe("__name__");
+    });
+
+    it("leaves intraword underscores `a__b__c` intact", () => {
+      expect(markdownToMrkdwn("a__b__c")).toBe("a__b__c");
+    });
+
+    it("leaves intraword underscores `snake__case__x` intact", () => {
+      expect(markdownToMrkdwn("snake__case__x")).toBe("snake__case__x");
+    });
+  });
+
+  // REGRESSION-GUARD: these already PASS on master; keep them green. They do NOT
+  // assert "differs from master" — the multi-word `__` path was never the bug.
+  describe("#1190 regression-guard (already green on master)", () => {
+    it("still converts multi-word `__very important__` -> `*very important*`", () => {
+      expect(markdownToMrkdwn("__very important__")).toBe("*very important*");
+    });
+
+    it("still converts `**bold**` -> `*bold*`", () => {
+      expect(markdownToMrkdwn("**bold**")).toBe("*bold*");
+    });
+
+    it("still converts heading `# Heading` -> `*Heading*`", () => {
+      expect(markdownToMrkdwn("# Heading")).toBe("*Heading*");
+    });
+
+    it("still converts bullet `- item` -> `• item`", () => {
+      expect(markdownToMrkdwn("- item")).toBe("• item");
+    });
+
+    it("still converts link `[text](url)` -> `<url|text>`", () => {
+      expect(markdownToMrkdwn("[text](http://x)")).toBe("<http://x|text>");
+    });
+
+    it("still leaves a `[2]` citation untouched", () => {
+      expect(markdownToMrkdwn("see note [2] for details")).toBe(
+        "see note [2] for details"
+      );
+    });
+
+    it("still converts `**a** and **b**` -> `*a* and *b*` independently", () => {
+      expect(markdownToMrkdwn("**a** and **b**")).toBe("*a* and *b*");
+    });
   });
 
   it("behavioral both-ends: a multi-paragraph `**bold:**` answer's section text contains no `**`", () => {


### PR DESCRIPTION
## Summary
Three LLM-Markdown cases still rendered wrong in Slack after #1188:
- `***bold italic***` → the 2-star rule left `**bold italic**` (literal asterisks)
- `# **Title**` → heading-wrap made `***Title***` → mis-collapsed to `**Title**`
- intraword `__init__` → the `__x__` bold rule turned it into `*init*` (Python dunder mangled)

**Fix:** add a `***x***`→`*x*` rule BEFORE the 2-star pass (fixes bold-italic AND `# **Title**` for free — the heading wrap produces a true 3+3 span), and switch the `__x__` pass to a replacer that skips single-identifier tokens (`/^\w+$/`) so dunders/intraword underscores stay literal while multi-word `__very important__` still converts. Single-word `__bold__` now stays literal (accepted miss — the LLM emits `**bold**`).

## Test plan
- `npm test` **237 passed**; typecheck clean; privacy gate clean.
- 3-role: plan-review PASS-WITH-FIXES (the regexes were re-implemented + traced against master — RED→GREEN confirmed; AC framing corrected), exec-review PASS (re-ran 237, verified the `__bold__`→literal change is the only existing-test delta and is sound).