### PR TITLE
chore: release 0.12.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [0.12.18](https://github.com/ziyilam3999/monday-bot/compare/v0.12.17...v0.12.18) (2026-06-24)
+
+### Features
+
+* **recall:** #1191 recall v2 — query-expansion (geo/availability intent) + per-source-type diversity cap + cross-encoder rerank, config-gated (expansion+cap default ON, rerank measure-first OFF) ([#222](https://github.com/ziyilam3999/monday-bot/pull/222))
+* **eval:** #1170 two-tier golden recall eval — committed synthetic Tier-A (real embedder + discrimination self-check) + skip-safe private Tier-B pinning ground-truth source ids ([#222](https://github.com/ziyilam3999/monday-bot/pull/222))
+
 ## [0.12.17](https://github.com/ziyilam3999/monday-bot/compare/v0.12.16...v0.12.17) (2026-06-24)
 
 ### Bug Fixes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "monday-bot",
-  "version": "0.12.17",
+  "version": "0.12.18",
   "description": "Team Slack knowledge assistant — answers from internal documents with cited, fact-based summaries.",
   "private": true,
   "type": "commonjs",


### PR DESCRIPTION
Release 0.12.18 — recall v2 ranking levers (#1191) + two-tier golden eval (#1170).

release-pr: true