### PR TITLE
feat(recall): how-to-intent doc-over-ticket ranking prior (#1197)

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -67,6 +67,18 @@ recall:
   rerank:
     enabled: false
     candidatePool: 150
+  # Lever 4 (#1197) — how-to-action doc-over-ticket prior. On a genuine "how do
+  # I…" / "how to…" question, narrative DOC passages get a SMALL additive score
+  # bonus so a how-to page rises above the bare ticket stubs the bi-encoder
+  # over-ranked on keyword density. Fires ONLY on how-to-action intent (a tight,
+  # unit-tested classifier that EXCLUDES "how are you" greetings and capacity/
+  # frequency/pricing "how many/often/much" questions); chit-chat / geo /
+  # not-in-corpus queries are untouched, so the abstain controls stay clean.
+  # Cheap + always-on (unlike rerank). bonus is the single tuning knob: 0.10 is
+  # the minimal value that lands the how-to doc inside the top-3 grounding window.
+  docPrior:
+    enabled: true
+    bonus: 0.1
   # Bi-encoder search pool size used when rerank OR diversityCap is enabled (a
   # wider pool than top-K so a lower-ranked-but-relevant passage can be recovered).
   candidatePoolSize: 150

--- a/src/knowledge/docPrior.ts
+++ b/src/knowledge/docPrior.ts
@@ -1,0 +1,83 @@
+/**
+ * Lever 4 — how-to-action doc-over-ticket ranking prior (#1197).
+ *
+ * Problem (the find-parking how-to query class): the bi-encoder hands the LLM a
+ * wall of short, keyword-dense issue-tracker (ticket) stubs first, while the
+ * user-facing how-to DOC passage that actually explains the mechanism sits just
+ * below the window (rank #7 on the real index). The LLM reads only ticket stubs,
+ * sees no usable instructions, and abstains. This is a RANKING problem, not a
+ * framing one (#1195 proved framing cannot move it).
+ *
+ * Fix: when — and ONLY when — the question carries how-to-ACTION intent, add a
+ * SMALL additive score bonus to narrative-DOC source-types so a how-to page
+ * rises above the bare ticket stubs the bi-encoder over-ranked on keyword
+ * density. NON-how-to queries pass through UNCHANGED (control-safety: the boost
+ * code path never runs for chit-chat / geo / not-in-corpus queries).
+ *
+ * MECHANISM CHOICE (plan-review correction #1) — minimal additive bonus, NOT the
+ * plan's max-aggressive 0.20:
+ *   - A pure source-type TIE-BREAK is a no-op here: the bi-encoder scores are
+ *     distinct, and the gt-doc (#7) scores BELOW the six tickets above it, so a
+ *     secondary tie-break by source-type never fires and cannot lift it. Pure
+ *     tie-break rejected on that ground.
+ *   - The least-overfit mechanism that reliably grounds the target is therefore
+ *     a SMALL additive bonus. The read-only probe sweep showed +0.10 lands the
+ *     gt-doc at #3 — INSIDE the #1-3 grounding window — while +0.20 overshoots to
+ *     #1 with doc×5 monopolizing the top-6 (the overfit smell: an additive bonus
+ *     is tuned to clear THIS query's ticket↔doc gap on THIS index, so a larger
+ *     value over-promotes every doc passage by a fixed amount regardless of
+ *     relevance). We ship the SMALLEST bonus that lands inside the grounding
+ *     window, justified by the Tier-B grounding rate, not "it made Q5 #1".
+ *   - The bonus is the single config knob (`bonus`), tunable without code change.
+ *
+ * The prior reorders only; it never mutates the stored `score`, never adds or
+ * removes candidates, and never fires for non-how-to-action intent. Stable
+ * re-sort (ties keep input order). Pure + deterministic — no model, no I/O. Runs
+ * BEFORE the diversity cap so the cap then shapes the already-prioritized order.
+ */
+
+import { sourceType, HasSource } from "./diversity";
+import { hasHowToActionIntent } from "./queryExpansion";
+
+export interface DocPriorConfig {
+  /** When false, applyDocPrior is identity. Default decided by resolveRecall. */
+  enabled?: boolean;
+  /**
+   * Additive score bonus for narrative-DOC source-types on how-to-action intent.
+   * Default 0.10 (the minimal-sufficient value: probe showed it lands the
+   * how-to doc inside the #1-3 grounding window — correction #1).
+   */
+  bonus?: number;
+  /** Source-types treated as narrative DOCs (boosted). Default ["confluence"]. */
+  docSourceTypes?: readonly string[];
+}
+
+/** Minimal-sufficient bonus — lands the how-to doc inside the #1-3 window (#1197). */
+export const DEFAULT_DOC_PRIOR_BONUS = 0.1;
+export const DEFAULT_DOC_SOURCE_TYPES = ["confluence"] as const;
+
+/**
+ * Apply the how-to-action doc-over-ticket prior. When the question carries
+ * how-to-action intent, add `bonus` to narrative-DOC passages and stable-re-sort
+ * by the adjusted score (ties keep input order). Returns the input UNCHANGED
+ * when disabled or when the question is not how-to-action.
+ */
+export function applyDocPrior<T extends HasSource & { score: number }>(
+  question: string,
+  results: T[],
+  cfg?: DocPriorConfig,
+): T[] {
+  if (!Array.isArray(results)) return [];
+  const enabled = cfg?.enabled ?? true;
+  if (!enabled || !hasHowToActionIntent(question)) return results;
+  const bonus = cfg?.bonus ?? DEFAULT_DOC_PRIOR_BONUS;
+  const docTypes = new Set(cfg?.docSourceTypes ?? DEFAULT_DOC_SOURCE_TYPES);
+  return results
+    .map((r, idx) => ({
+      r,
+      idx,
+      s: r.score + (docTypes.has(sourceType(r.source)) ? bonus : 0),
+    }))
+    .sort((a, b) => b.s - a.s || a.idx - b.idx)
+    .map((x) => x.r);
+}

--- a/src/knowledge/queryExpansion.ts
+++ b/src/knowledge/queryExpansion.ts
@@ -116,3 +116,31 @@ export function expandQuery(
   if (additions.length === 0) return question;
   return `${question} ${additions.join(" ")}`;
 }
+
+/**
+ * CLOSED how-to-ACTION intent signal (#1197). Detects a user asking how to DO
+ * something (an action they take), distinct from geo intent and from the
+ * "how are you" greeting. Pure + deterministic. Adds NO query expansion —
+ * classification only (generic how-to-vocab expansion regressed ranking in
+ * #1191; this signal only feeds the doc-over-ticket re-rank prior).
+ *
+ * TIGHTENED (plan-review correction #2): only the two PRECISE clauses are kept.
+ * The plan's loose third clause — `tokens include "how" ANYWHERE + an
+ * action-verb ANYWHERE` — was DROPPED. That anywhere-in-sentence co-occurrence
+ * false-fired on plausible NON-how-to questions ("how many can I add", "how
+ * often do I get billed", "how much does it cost to book") where the answer may
+ * well live in a ticket, which would wrongly trigger the doc boost. The precise
+ * clauses below bind the action to the interrogative ("how to <X>" / "how
+ * do|can|does|could|should <X>"), which is what the genuine how-to-action
+ * targets use; the dropped clause added open-world risk for no target benefit.
+ * These NON-firing cases are locked as negative unit tests.
+ */
+export function hasHowToActionIntent(question: string): boolean {
+  if (typeof question !== "string") return false;
+  const s = question.toLowerCase();
+  // Exclude the greeting / state-of-being "how are/is/was…" (chit-chat control).
+  if (/\bhow\s+(are|is|was|were|'?s)\b/.test(s)) return false;
+  if (/\bhow\s+to\b/.test(s)) return true; //                "how to X"
+  if (/\bhow\s+(do|can|does|could|should)\b/.test(s)) return true; // "how do I X"
+  return false;
+}

--- a/src/knowledge/service.ts
+++ b/src/knowledge/service.ts
@@ -9,6 +9,12 @@ import {
 import { expandQuery, QueryExpansionConfig } from "./queryExpansion";
 import { applyDiversityCap, DiversityCapConfig } from "./diversity";
 import { rerank, RerankConfig } from "./rerank";
+import {
+  applyDocPrior,
+  DocPriorConfig,
+  DEFAULT_DOC_PRIOR_BONUS,
+  DEFAULT_DOC_SOURCE_TYPES,
+} from "./docPrior";
 
 // Raised 5 -> 12 (#1189): passage-chunking can fill several top slots with
 // passages from the same doc, so a wider window leaves room for the relevant
@@ -28,6 +34,12 @@ export interface RecallConfig {
   queryExpansion?: QueryExpansionConfig;
   diversityCap?: DiversityCapConfig;
   rerank?: RerankConfig;
+  /**
+   * Lever 4 (#1197) — how-to-action doc-over-ticket prior. Default ON (see
+   * resolveRecall): the Tier-B controls hold 5/5 and Q3/Q4 do not regress, so an
+   * always-on cheap re-rank is conservative (correction #4).
+   */
+  docPrior?: DocPriorConfig;
   /** Bi-encoder search pool widened when rerank OR diversity cap is enabled. */
   candidatePoolSize?: number;
 }
@@ -37,6 +49,7 @@ interface ResolvedRecall {
   expansion: { enabled: boolean };
   diversityCap: { enabled: boolean; maxPerSourceType: number };
   rerank: RerankConfig & { enabled: boolean; candidatePool: number };
+  docPrior: { enabled: boolean; bonus: number; docSourceTypes: readonly string[] };
   candidatePoolSize: number;
 }
 
@@ -55,6 +68,15 @@ function resolveRecall(cfg?: RecallConfig): ResolvedRecall {
       ...(cfg?.rerank ?? {}),
       enabled: cfg?.rerank?.enabled ?? false,
       candidatePool: cfg?.rerank?.candidatePool ?? DEFAULT_CANDIDATE_POOL,
+    },
+    docPrior: {
+      // Default ON (correction #4): justified by Tier-B — controls 5/5, no
+      // Q3/Q4 regression. The bonus is the single tunable knob; a small additive
+      // value (0.10) lands the how-to doc inside the #1-3 grounding window.
+      enabled: cfg?.docPrior?.enabled ?? true,
+      bonus: cfg?.docPrior?.bonus ?? DEFAULT_DOC_PRIOR_BONUS,
+      docSourceTypes:
+        cfg?.docPrior?.docSourceTypes ?? DEFAULT_DOC_SOURCE_TYPES,
     },
     candidatePoolSize: cfg?.candidatePoolSize ?? DEFAULT_CANDIDATE_POOL,
   };
@@ -183,8 +205,9 @@ export class KnowledgeService {
    *   1. expandQuery   — widen the bi-encoder recall net for geo intent (L1)
    *   2. search(poolK) — widen pool only when rerank/cap need a deeper batch
    *   3. rerank        — cross-encoder scores the ORIGINAL question (L2, OFF by default)
-   *   4. diversity cap — reshuffle so one source-type can't monopolize (L3)
-   *   5. slice topK
+   *   4. docPrior      — how-to-action doc-over-ticket prior (L4, ON by default; no-op off-intent)
+   *   5. diversity cap — reshuffle so one source-type can't monopolize (L3)
+   *   6. slice topK
    *
    * With all levers off this collapses to `search(question, topK)` — byte-identical
    * to the pre-#1191 behavior. SHIPPED defaults are expansion+cap ON, rerank OFF.
@@ -205,6 +228,16 @@ export class KnowledgeService {
         candidatePool: r.rerank.candidatePool,
       });
     }
+
+    // Lever 4 (#1197) — how-to-action doc-over-ticket prior. Cheap, always-on by
+    // default, fires ONLY on how-to-action intent (the ORIGINAL question, like
+    // rerank); controls / geo / already-grounded queries pass through unchanged.
+    // Runs before the diversity cap so the cap shapes the prioritized order.
+    ranked = applyDocPrior(question, ranked, {
+      enabled: r.docPrior.enabled,
+      bonus: r.docPrior.bonus,
+      docSourceTypes: r.docPrior.docSourceTypes,
+    });
 
     const capped = applyDiversityCap(ranked, this.topK, {
       enabled: r.diversityCap.enabled,

--- a/tests/recall-docprior.test.ts
+++ b/tests/recall-docprior.test.ts
@@ -1,0 +1,168 @@
+import { applyDocPrior, DEFAULT_DOC_PRIOR_BONUS } from "../src/knowledge/docPrior";
+import { hasHowToActionIntent } from "../src/knowledge/queryExpansion";
+import { KnowledgeService } from "../src/knowledge/service";
+import { VectorIndex } from "../src/index/vectorIndex";
+
+/**
+ * Tier-A — how-to-action doc-over-ticket prior (#1197). Synthetic, deterministic,
+ * CI-safe. NONE of these queries echo a real fixture question (the real UAT
+ * questions + ids live only in the gitignored private fixture). Both-ends:
+ * every behavioral claim is paired with its WITHOUT case so the test fails if the
+ * prior is a no-op AND if it over-fires.
+ */
+
+interface Scored {
+  id: string;
+  source: string;
+  score: number;
+}
+
+function pool(): Scored[] {
+  // Six ticket stubs the bi-encoder over-ranked on keyword density, plus one
+  // narrative-DOC passage just below them (mirrors the real "#7 doc under a
+  // 6-ticket wall" shape).
+  return [
+    { id: "t1", source: "jira:T-1", score: 0.5 },
+    { id: "t2", source: "jira:T-2", score: 0.47 },
+    { id: "t3", source: "jira:T-3", score: 0.43 },
+    { id: "t4", source: "jira:T-4", score: 0.41 },
+    { id: "t5", source: "jira:T-5", score: 0.39 },
+    { id: "t6", source: "jira:T-6", score: 0.37 },
+    { id: "d1", source: "confluence:C-1", score: 0.35 },
+  ];
+}
+
+describe("hasHowToActionIntent — tightened classifier (correction #2)", () => {
+  it("FIRES on genuine how-to-action phrasings", () => {
+    expect(hasHowToActionIntent("how to reserve a slot")).toBe(true);
+    expect(hasHowToActionIntent("how do I book a desk")).toBe(true);
+    expect(hasHowToActionIntent("how can I cancel a booking")).toBe(true);
+    // Q4-class "how does X work" DOES fire (correction #3 — reconciled below).
+    expect(hasHowToActionIntent("how does the matching feature work")).toBe(true);
+  });
+
+  it("does NOT fire on the greeting control", () => {
+    expect(hasHowToActionIntent("how are you today")).toBe(false);
+  });
+
+  it("does NOT fire on capacity / frequency / pricing 'how' questions (dropped loose clause)", () => {
+    // These false-fired under the plan's anywhere-in-sentence clause 3, which was
+    // DROPPED — their answers may live in a ticket, so the doc boost must NOT run.
+    expect(hasHowToActionIntent("how many people can I add to a team")).toBe(false);
+    expect(hasHowToActionIntent("how often do I get billed")).toBe(false);
+    expect(hasHowToActionIntent("how much does it cost to book")).toBe(false);
+  });
+
+  it("does NOT fire on non-how phrasings", () => {
+    expect(hasHowToActionIntent("what is the weekly schedule")).toBe(false);
+    expect(hasHowToActionIntent("how it works")).toBe(false); // no interrogative+verb bind
+    expect(hasHowToActionIntent("")).toBe(false);
+  });
+});
+
+describe("applyDocPrior — both-ends reorder (correction #1: minimal bonus)", () => {
+  it("lifts the DOC above ALL ticket stubs WITH how-to-action intent (equal scores)", () => {
+    // Equal-score variant: every passage shares the query token, so any positive
+    // bonus must move the doc above every ticket. Proves the boost path runs.
+    const eq: Scored[] = [
+      { id: "t1", source: "jira:T-1", score: 0.5 },
+      { id: "t2", source: "jira:T-2", score: 0.5 },
+      { id: "d1", source: "confluence:C-1", score: 0.5 },
+    ];
+    const out = applyDocPrior("how to reserve a slot", eq);
+    expect(out[0].source).toBe("confluence:C-1");
+  });
+
+  it("DOES NOT reorder WITHOUT how-to-action intent (control-safety, no-op)", () => {
+    const eq: Scored[] = [
+      { id: "t1", source: "jira:T-1", score: 0.5 },
+      { id: "t2", source: "jira:T-2", score: 0.5 },
+      { id: "d1", source: "confluence:C-1", score: 0.5 },
+    ];
+    const out = applyDocPrior("how are you today", eq);
+    // Byte-identical input order — the boost path never ran.
+    expect(out.map((r) => r.id)).toEqual(["t1", "t2", "d1"]);
+  });
+
+  it("is a no-op when disabled (lever off → unchanged order)", () => {
+    const out = applyDocPrior("how to reserve a slot", pool(), { enabled: false });
+    expect(out.map((r) => r.id)).toEqual(pool().map((r) => r.id));
+  });
+
+  it("the minimal default bonus (0.10) lands the buried DOC inside the top-3 window", () => {
+    // The #7 doc (score 0.35) under six tickets. Default 0.10 must lift it into
+    // the #1-3 grounding window WITHOUT overshooting to a doc-monopoly top-6.
+    expect(DEFAULT_DOC_PRIOR_BONUS).toBe(0.1);
+    const out = applyDocPrior("how do I find a spot", pool());
+    const docRank = out.findIndex((r) => r.source === "confluence:C-1") + 1;
+    expect(docRank).toBeGreaterThanOrEqual(1);
+    expect(docRank).toBeLessThanOrEqual(3);
+    // It does NOT clear the entire wall: the top ticket still outranks it.
+    expect(out[0].source).toBe("jira:T-1");
+  });
+
+  it("reorders only — never mutates the stored score", () => {
+    const input = pool();
+    const out = applyDocPrior("how to reserve a slot", input);
+    const doc = out.find((r) => r.source === "confluence:C-1");
+    expect(doc?.score).toBe(0.35); // original score preserved
+  });
+
+  it("Q4-class 'how does X work' FIRES but causes NO regression when the DOC is already #1 (correction #3)", () => {
+    // The prior MAY fire on a "how does X work" phrasing; no harm because the
+    // grounding doc passage is already the top result — a uniform doc bonus
+    // keeps it #1 (this is the Q4 no-regression mechanism: fires-but-no-harm,
+    // NOT byte-identical-by-construction).
+    const docTop: Scored[] = [
+      { id: "d1", source: "confluence:C-1", score: 0.6 }, // already #1
+      { id: "t1", source: "jira:T-1", score: 0.5 },
+      { id: "t2", source: "jira:T-2", score: 0.48 },
+    ];
+    expect(hasHowToActionIntent("how does the matching feature work")).toBe(true);
+    const out = applyDocPrior("how does the matching feature work", docTop);
+    expect(out[0].source).toBe("confluence:C-1"); // still #1 — no regression
+    expect(out.map((r) => r.id)).toEqual(["d1", "t1", "t2"]);
+  });
+});
+
+describe("KnowledgeService wiring — docPrior ON by default (correction #4)", () => {
+  async function buildIndex(
+    docs: Array<{ source: string; text: string }>,
+  ): Promise<VectorIndex> {
+    const index = new VectorIndex();
+    await index.add(docs.map((d) => ({ text: d.text, source: d.source })));
+    return index;
+  }
+
+  // jira stubs added first + one confluence last, all sharing the query token →
+  // equal bi-encoder scores → insertion order puts confluence last by default.
+  const docs = [
+    { source: "jira:T-1", text: "alpha alpha" },
+    { source: "jira:T-2", text: "alpha alpha" },
+    { source: "jira:T-3", text: "alpha alpha" },
+    { source: "confluence:C-1", text: "alpha alpha" },
+  ];
+
+  it("a how-to-action query lifts the confluence passage above the jira stubs via full retrieve()", async () => {
+    // NO recall opts → docPrior ON by default (proves it runs in production defaults).
+    const svc = new KnowledgeService({ index: await buildIndex(docs), topK: 12 });
+    const hits = await svc.retrieve("how to use alpha");
+    expect(hits[0].source).toBe("confluence:C-1");
+  });
+
+  it("a NON-how-to query leaves the jira-first order unchanged (control-safety, live path)", async () => {
+    const svc = new KnowledgeService({ index: await buildIndex(docs), topK: 12 });
+    const hits = await svc.retrieve("what is alpha");
+    expect(hits[0].source.startsWith("jira:")).toBe(true);
+  });
+
+  it("docPrior explicitly OFF → how-to-action query no longer reorders", async () => {
+    const svc = new KnowledgeService({
+      index: await buildIndex(docs),
+      topK: 12,
+      recall: { docPrior: { enabled: false } },
+    });
+    const hits = await svc.retrieve("how to use alpha");
+    expect(hits[0].source.startsWith("jira:")).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
For how-to-action questions, boost narrative **doc-source** passages above bare **issue-tracker ticket** stubs in the candidate pool — so a how-to doc's answerable passage isn't buried under backend implementation tickets. Config-gated (`recall.docPrior`, minimal additive bonus **0.10**, default ON). 3-role: plan-review PASS-WITH-FIXES + execution-review PASS-WITH-FIXES.

- **Tightened how-to-action intent classifier** — precise clauses only; does NOT fire on greetings or "how many / how often / how much" billing/quantity questions (negative tests locked).
- **Lifts the relevant how-to doc's answerable passage #7 → #3.** No-op when the lever is off or intent doesn't fire.
- **Controls preserved by construction** (classifier false on greeting/off-topic → byte-identical ordering): abstain controls 5/5 unchanged, no regression on the questions that already work (5/5).

## Honest scope
This is a **ranking** improvement. It does **not** yet flip the hardest how-to question to grounded. Tier-B measurement showed that once the doc ranks #1, the bot explains the documented mechanism well **but** prepends a hedge opener because the query's proper-noun isn't verbatim in the passages — a content/framing last-mile tracked separately (#1201), not a ranking issue. No overclaim here.

## Test plan
- `npm test` — 275 green (+13 Tier-A: classifier positives/negatives, doc-ranks-above-ticket both-ends, no-op-off, Q4 no-harm, wiring).
- `npm run typecheck` — clean.
- Tier-B N-run rate measurement (real LLM, private fixture) captured RED→GREEN: doc #7→#3, controls 5/5, Q3/Q4 no-regress.
- Privacy: committed diff token-free; real data only in the gitignored fixture.

https://claude.ai/code/session_01MwxEjva8rvcFYrmGefwFEQ