### PR TITLE
chore: release 0.12.21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [0.12.21](https://github.com/ziyilam3999/monday-bot/compare/v0.12.20...v0.12.21) (2026-06-24)
+
+### Features
+
+* **answer:** #1201 single-product grounding clause + docPrior 0.15 — the bot now grounds on a how-to question whose answer doc does not name the product verbatim (closes the find-parking grounding gap, 0/5 -> 5/5 Tier-B; abstain controls + no-regression preserved) ([#228](https://github.com/ziyilam3999/monday-bot/pull/228))
+
 ## [0.12.20](https://github.com/ziyilam3999/monday-bot/compare/v0.12.19...v0.12.20) (2026-06-24)
 
 ### Features

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "monday-bot",
-  "version": "0.12.20",
+  "version": "0.12.21",
   "description": "Team Slack knowledge assistant — answers from internal documents with cited, fact-based summaries.",
   "private": true,
   "type": "commonjs",


### PR DESCRIPTION
Release 0.12.21 — #1201 single-product grounding clause + docPrior 0.15 (closes the find-parking grounding gap).

release-pr: true