### PR TITLE
fix(answer): strip stray [N] markers on abstain replies (#1203)

### DIFF
--- a/src/llm/generate.ts
+++ b/src/llm/generate.ts
@@ -48,6 +48,38 @@ export function selectCitedCitations(
 }
 
 /**
+ * Deterministic post-processor for abstention replies.
+ *
+ * If `answer` OPENS with an abstain phrase ("I couldn't find ...", anchored at
+ * start, leading whitespace tolerated, case-insensitive, optional/typographic
+ * apostrophe), then: (a) remove every inline `[N]` marker and tidy the leftover
+ * spacing, and (b) force `citations` to `[]`. Otherwise return both unchanged.
+ *
+ * The opener guard is the control: a grounded reply that LEADS with content and
+ * only later notes a gap does NOT open with the phrase, so it is untouched.
+ *
+ * Defensive: a non-string `answer` cannot match the opener -> returned unchanged
+ * (no throw, citations normalized to `[]` only when non-array); the type guard
+ * runs BEFORE any regex/`.replace` so `undefined` answers never throw.
+ */
+export function stripStrayAbstainCitations(
+  answer: string,
+  citations: Citation[],
+): AnswerResult {
+  if (typeof answer !== "string") {
+    return { answer, citations: Array.isArray(citations) ? citations : [] };
+  }
+  if (!/^\s*I couldn['’]?t find/i.test(answer)) {
+    return { answer, citations };
+  }
+  const cleaned = answer
+    .replace(/\s*\[\d+\]/g, "")
+    .replace(/ {2,}/g, " ")
+    .trim();
+  return { answer: cleaned, citations: [] };
+}
+
+/**
  * Offline / test-mode flag. When set (or when no Anthropic credentials are
  * available at runtime), `generateAnswer` returns a deterministic fallback
  * answer assembled from the top retrieved chunks instead of calling the LLM.
@@ -182,8 +214,8 @@ export async function generateAnswer(
     return { answer: NO_CONTEXT_ANSWER, citations: [] };
   }
 
-  return {
-    answer: text,
-    citations: selectCitedCitations(text, buildCitations(chunks)),
-  };
+  return stripStrayAbstainCitations(
+    text,
+    selectCitedCitations(text, buildCitations(chunks)),
+  );
 }

--- a/tests/generate.test.ts
+++ b/tests/generate.test.ts
@@ -15,6 +15,7 @@ jest.mock("node:os", () => {
 import {
   generateAnswer,
   selectCitedCitations,
+  stripStrayAbstainCitations,
   NO_CONTEXT_ANSWER,
   Chunk,
   Citation,
@@ -177,5 +178,76 @@ describe("selectCitedCitations", () => {
     expect(
       selectCitedCitations("Foo [1].", undefined as unknown as Citation[]),
     ).toEqual([]);
+  });
+});
+
+describe("stripStrayAbstainCitations", () => {
+  const cites: Citation[] = [
+    { number: 1, source: "doc-a" },
+    { number: 2, source: "doc-b" },
+  ];
+
+  test("A: abstain opener with a stray [1] -> marker stripped, citations emptied", () => {
+    const result = stripStrayAbstainCitations(
+      "I couldn't find a separate guide for the asked topic [1].",
+      [cites[0]],
+    );
+    expect(result.answer).toBe(
+      "I couldn't find a separate guide for the asked topic.",
+    );
+    expect(result.answer).not.toContain("[1]");
+    expect(result.citations).toEqual([]);
+  });
+
+  test("A2: typographic-apostrophe opener with a stray [2] is also stripped", () => {
+    const result = stripStrayAbstainCitations(
+      "I couldn’t find anything on the asked topic [2].",
+      [cites[1]],
+    );
+    expect(result.answer).not.toContain("[2]");
+    expect(result.citations).toEqual([]);
+  });
+
+  test("B: grounded answer that leads with content and notes a gap later is UNCHANGED", () => {
+    const answer =
+      "The setup doc [1] covers the asked topic; I couldn't find a separate deep-dive [2].";
+    const result = stripStrayAbstainCitations(answer, cites);
+    expect(result.answer).toBe(answer);
+    expect(result.answer).toContain("[1]");
+    expect(result.answer).toContain("[2]");
+    expect(result.citations).toBe(cites);
+  });
+
+  test("C: canonical NO_CONTEXT_ANSWER is returned unchanged and clean", () => {
+    const result = stripStrayAbstainCitations(NO_CONTEXT_ANSWER, []);
+    expect(result.answer).toBe(NO_CONTEXT_ANSWER);
+    expect(result.citations).toEqual([]);
+  });
+
+  test("D(i): non-string answer does not throw and is returned as-is", () => {
+    const result = stripStrayAbstainCitations(
+      undefined as unknown as string,
+      cites,
+    );
+    expect(result.answer).toBeUndefined();
+    expect(result.citations).toBe(cites);
+  });
+
+  test("D(ii): non-array citations on the abstain branch -> stripped + []", () => {
+    const result = stripStrayAbstainCitations(
+      "I couldn't find it [1].",
+      undefined as unknown as Citation[],
+    );
+    expect(result.answer).not.toContain("[1]");
+    expect(result.citations).toEqual([]);
+  });
+
+  test("E: spacing tidy contract -> no double spaces, no space before period", () => {
+    const result = stripStrayAbstainCitations(
+      "I couldn't find  [1]  the asked topic [2] here.",
+      cites,
+    );
+    expect(result.answer).toBe("I couldn't find the asked topic here.");
+    expect(result.citations).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary
Closes the pre-existing temp-0 cosmetic flake noted by #1201 exec-review: an abstention reply ("I couldn't find ...") occasionally carries a stray `[N]` marker, violating the SYSTEM_PROMPT's own no-cite-on-abstain rule and leaking a dangling citation to the user.

Adds a deterministic pure helper `stripStrayAbstainCitations(answer, citations)`:
- On an anchored abstain-opener match (`/^\s*I couldn['’]?t find/i`): strips inline `[N]` markers, tidies leftover spacing, and forces `citations: []`.
- Otherwise returns answer + citations unchanged.
- Type-guarded (non-string answer / non-array citations → safe shape, no throw).
- Applied to the **live-LLM return path only**. Grounded answers (which lead with content, never open with the abstain phrase) are untouched; the `NO_CONTEXT_ANSWER` early returns and the offline/test-mode path are unaffected.

## Test plan
- `tests/generate.test.ts` +7 both-ends cases: abstain+stray `[1]` → stripped + `citations: []` (discriminator); typographic-apostrophe variant; CONTROL grounded gap-later answer → unchanged (keeps both markers + citations); CONTROL canonical `NO_CONTEXT_ANSWER` → unchanged/clean; DEFENSIVE non-string answer + non-array citations; `" [1]." → "."` spacing-tidy contract.
- Both-ends integrity independently proven in review by stubbing the abstain branch to a no-op (discriminator cases went red), then reverting.
- `npm run build` clean; `npm test` → 30 suites / 289 tests passing (12→19 in the generate suite).

3-role: planner + plan-review (PASS) + executor + execution-review (PASS) ledger complete.