### PR TITLE
feat(triage): categorize open Jira defects with write-back, dry-run default (#1284)

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "test": "jest",
     "typecheck": "tsc --noEmit && tsc --noEmit -p tsconfig.test.json",
     "eval:recall": "npm run build && node scripts/eval-recall.js",
-    "eval:golden": "npm run build && node scripts/eval-golden.js"
+    "eval:golden": "npm run build && node scripts/eval-golden.js",
+    "triage:categorize": "npm run build && node scripts/categorize-defects.js"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/scripts/categorize-defects.js
+++ b/scripts/categorize-defects.js
@@ -1,0 +1,93 @@
+#!/usr/bin/env node
+/*
+ * categorize-defects.js — thin I/O shell over the injectable CLI core
+ * (`dist/triage/cli.js` -> run(deps)).
+ *
+ * DRY-RUN by DEFAULT: reads the team's OPEN Jira defects, classifies each by
+ * defect-type (deterministic rules engine), prints the per-defect plan + the
+ * grouped-counts tally, and writes NOTHING. The real write-back is reachable
+ * ONLY behind an explicit `--apply` flag (and needs operator go) — that is the
+ * ONLY path that constructs the writer and mutates Jira.
+ *
+ * All creds + target come from env ONLY (gitignored .env; repo is public). The
+ * env-cred construction lives HERE, in the outer shell — `run(deps)` itself is
+ * cred-free + injectable so tests drive it against a fake.
+ *
+ *   Read it:   node scripts/categorize-defects.js            (dry-run preview)
+ *   Apply it:  node scripts/categorize-defects.js --apply    (outward write)
+ *
+ * Env: CONFLUENCE_URL (or CONFLUENCE_BASE_URL), CONFLUENCE_EMAIL,
+ *      CONFLUENCE_API_TOKEN (Jira reuses the Atlassian creds), JIRA_PROJECTS
+ *      (comma-separated; the FIRST entry is categorized). Optional JQL overrides:
+ *      JIRA_OPEN_DEFECTS_STATUS_JQL, JIRA_DEFECT_ISSUETYPE_JQL.
+ */
+"use strict";
+
+const path = require("path");
+
+const DIST = path.resolve(__dirname, "..", "dist");
+const { run } = require(path.join(DIST, "triage", "cli"));
+const { buildOpenDefectsFetcher } = require(path.join(DIST, "jira", "sync"));
+const { buildJiraCategoryWriter } = require(path.join(DIST, "jira", "categoryWriter"));
+
+/** Strip a trailing /wiki (and trailing slash) so the site root feeds Jira REST. */
+function toSiteRoot(url) {
+  return url.replace(/\/wiki\/?$/, "").replace(/\/$/, "");
+}
+
+function splitList(raw) {
+  return (raw || "")
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+async function main() {
+  const apply = process.argv.includes("--apply");
+  const env = process.env;
+
+  const url = env.CONFLUENCE_URL || env.CONFLUENCE_BASE_URL;
+  const email = env.CONFLUENCE_EMAIL;
+  const apiToken = env.CONFLUENCE_API_TOKEN;
+  const projects = splitList(env.JIRA_PROJECTS);
+
+  if (!url || !email || !apiToken || projects.length === 0) {
+    console.error(
+      "categorize-defects: missing config. Need CONFLUENCE_URL (or CONFLUENCE_BASE_URL), " +
+        "CONFLUENCE_EMAIL, CONFLUENCE_API_TOKEN, and a non-empty JIRA_PROJECTS.",
+    );
+    process.exit(1);
+  }
+
+  const config = { baseUrl: toSiteRoot(url), email, apiToken };
+  const scope = {
+    statusJql: env.JIRA_OPEN_DEFECTS_STATUS_JQL,
+    issueTypeJql: env.JIRA_DEFECT_ISSUETYPE_JQL,
+  };
+  const projectKey = projects[0];
+  const fetcher = buildOpenDefectsFetcher(config, scope, globalThis.fetch);
+
+  const deps = {
+    fetchOpenDefects: () => fetcher.fetchOpenDefects(projectKey),
+    apply,
+  };
+  // The writer is constructed ONLY on --apply (dry-run never builds it).
+  if (apply) {
+    deps.writer = buildJiraCategoryWriter(config, globalThis.fetch);
+  }
+
+  const result = await run(deps);
+
+  if (!apply) {
+    console.log(
+      "\n(dry-run: no Jira writes performed. Re-run with --apply to write categories back.)",
+    );
+  } else {
+    console.log(`\napplied ${result.applied} category write(s).`);
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/jira/categoryWriter.ts
+++ b/src/jira/categoryWriter.ts
@@ -1,0 +1,61 @@
+import { JiraClientConfig, basicAuthHeader } from "./sync";
+
+/**
+ * OUTWARD-write seam: stamps a defect's category back onto its Jira issue.
+ *
+ * Dependency-injected (the `fetchImpl` is injectable) so the write path is
+ * covered by a mocked fake in tests with ZERO live mutation. Default write is a
+ * non-destructive, reversible `labels` ADD via `PUT /rest/api/3/issue/{key}`.
+ * Constructed ONLY on the CLI `--apply` path — the dry-run default never builds
+ * a writer, so it can issue no PUT.
+ */
+export interface JiraCategoryWriter {
+  setCategory(issueKey: string, category: string): Promise<void>;
+}
+
+export interface JiraCategoryWriterOptions {
+  /**
+   * Label prefix for the category label (default `defect-category`). The stamped
+   * label is `<prefix>:<category>` — a reversible add, not a replace.
+   */
+  labelPrefix?: string;
+}
+
+export function buildJiraCategoryWriter(
+  config: JiraClientConfig,
+  fetchImpl: typeof fetch = globalThis.fetch,
+  options: JiraCategoryWriterOptions = {},
+): JiraCategoryWriter {
+  if (typeof fetchImpl !== "function") {
+    throw new TypeError(
+      "buildJiraCategoryWriter: no global fetch available; pass an explicit fetchImpl",
+    );
+  }
+  const base = config.baseUrl.replace(/\/$/, "");
+  const prefix = options.labelPrefix ?? "defect-category";
+
+  return {
+    async setCategory(issueKey: string, category: string): Promise<void> {
+      if (typeof issueKey !== "string" || issueKey.length === 0) {
+        throw new TypeError("setCategory: issueKey must be a non-empty string");
+      }
+      const label = `${prefix}:${category}`;
+      const url = `${base}/rest/api/3/issue/${encodeURIComponent(issueKey)}`;
+      const res = await fetchImpl(url, {
+        method: "PUT",
+        headers: {
+          Authorization: basicAuthHeader(config),
+          "Content-Type": "application/json",
+          Accept: "application/json",
+        },
+        // Reversible labels ADD (does NOT replace the issue's other labels).
+        body: JSON.stringify({ update: { labels: [{ add: label }] } }),
+      });
+      if (!res.ok) {
+        throw new Error(
+          `Jira REST API returned ${res.status} ${res.statusText} for PUT issue ${issueKey}`,
+        );
+      }
+    },
+  };
+}

--- a/src/jira/index.ts
+++ b/src/jira/index.ts
@@ -3,8 +3,18 @@ export {
   JiraSyncOptions,
   JiraSyncResult,
   JiraFetcher,
+  OpenDefectsFetcher,
+  OpenDefectsScope,
   JiraIssue,
   JiraClientConfig,
   buildJiraFetcher,
+  buildOpenDefectsFetcher,
+  buildOpenDefectsJql,
+  basicAuthHeader,
   adfToText,
 } from "./sync";
+export {
+  buildJiraCategoryWriter,
+  JiraCategoryWriter,
+  JiraCategoryWriterOptions,
+} from "./categoryWriter";

--- a/src/jira/sync.ts
+++ b/src/jira/sync.ts
@@ -20,6 +20,10 @@ export interface JiraIssue {
   descriptionText: string;
   commentTexts: string[];
   projectKey?: string;
+  /** Issue labels (`fields.labels`); omitted when the issue carries none. */
+  labels?: string[];
+  /** Issue type name (`fields.issuetype.name`); omitted when absent. */
+  issueType?: string;
 }
 
 /**
@@ -31,10 +35,29 @@ export interface JiraFetcher {
   fetchIssues(projectKey: string): Promise<JiraIssue[]>;
 }
 
+/** Fetcher for the OPEN-DEFECTS scope (a different JQL + extra `fields`). */
+export interface OpenDefectsFetcher {
+  fetchOpenDefects(projectKey: string): Promise<JiraIssue[]>;
+}
+
 export interface JiraClientConfig {
   baseUrl: string;
   email: string;
   apiToken: string;
+}
+
+/**
+ * Environment-specific JQL fragments for the open-defects scope. Both default to
+ * generic, universally-valid clauses; override per project when the team's
+ * status/issuetype names differ. Pass an empty string to drop a clause entirely.
+ */
+export interface OpenDefectsScope {
+  /** Open-state JQL clause. Default: `statusCategory != Done`. */
+  statusJql?: string;
+  /** Defect-issuetype JQL clause. Default: `issuetype in (Bug)`. */
+  issueTypeJql?: string;
+  /** Page size. Default 100. */
+  maxResults?: number;
 }
 
 export interface JiraSyncOptions {
@@ -103,14 +126,102 @@ function collapse(text: string): string {
 }
 
 /**
- * Build a `JiraFetcher` backed by the real Atlassian REST API. Hits
- * `GET <baseUrl>/rest/api/3/search/jql?jql=project=<KEY>&fields=summary,description,comment&maxResults=100`
- * with Basic auth (email + API token). Paginates via the `nextPageToken` cursor:
- * the first request omits the token, each response returns
- * `{ issues, nextPageToken, isLast }`, and subsequent requests append
- * `&nextPageToken=<token>`. Stops when `isLast === true` OR no token is returned.
- * Description and comment bodies are ADF objects (or plain strings / null) and
- * are flattened to text.
+ * Single source of truth for the Jira Basic-auth header (email + API token,
+ * Base64-encoded). EVERY authenticated Jira call — the knowledge-sync fetch, the
+ * open-defects fetch, and the category writer — routes through here, so there is
+ * exactly ONE Base64-auth site in `src/jira` (AC-9, anti-fork).
+ */
+export function basicAuthHeader(config: JiraClientConfig): string {
+  return `Basic ${Buffer.from(`${config.email}:${config.apiToken}`).toString("base64")}`;
+}
+
+/** Parameters for the single shared paginated-GET helper. */
+interface PaginatedSearchParams {
+  /** Raw (un-encoded) JQL — encoded once inside the helper. */
+  jql: string;
+  /** Comma-separated `fields` list, passed through verbatim. */
+  fields: string;
+  /** Page size; default 100. */
+  maxResults?: number;
+}
+
+/**
+ * The ONE shared paginated-GET + Basic-auth implementation for Jira reads.
+ *
+ * Hits `GET <baseUrl>/rest/api/3/search/jql?jql=<JQL>&fields=<FIELDS>&maxResults=<N>`
+ * with Basic auth. Paginates via the `nextPageToken` cursor: the first request
+ * omits the token, each response returns `{ issues, nextPageToken, isLast }`, and
+ * subsequent requests append `&nextPageToken=<token>`. Stops when `isLast === true`
+ * OR no token is returned. Description / comment bodies (ADF or plain) are
+ * flattened to text by `toJiraIssue`.
+ *
+ * BOTH `buildJiraFetcher` (knowledge scope) and `buildOpenDefectsFetcher` (defect
+ * scope) construct their reads from THIS helper — the JQL + `fields` are the only
+ * things they parameterize. The auth line and cursor loop live here and nowhere
+ * else (AC-9, anti-fork): no module may copy them.
+ */
+async function fetchPaginatedIssues(
+  config: JiraClientConfig,
+  fetchImpl: typeof fetch,
+  params: PaginatedSearchParams,
+): Promise<JiraIssue[]> {
+  const auth = basicAuthHeader(config);
+  const base = config.baseUrl.replace(/\/$/, "");
+  const maxResults = params.maxResults ?? 100;
+  // Hard cap on pages walked — defends against a server that never sets
+  // `isLast` and keeps echoing a cursor (1000 pages * 100 = 100k issues).
+  const MAX_PAGES = 1000;
+
+  const out: JiraIssue[] = [];
+  let token: string | undefined;
+  let pages = 0;
+  // Cursor pagination: the first request omits the token; each response returns
+  // the next page's cursor. Stop on `isLast === true` OR no token.
+  for (;;) {
+    let url =
+      `${base}/rest/api/3/search/jql?jql=${encodeURIComponent(params.jql)}` +
+      `&fields=${params.fields}&maxResults=${maxResults}`;
+    if (token) url += `&nextPageToken=${encodeURIComponent(token)}`;
+    const res = await fetchImpl(url, {
+      headers: {
+        Authorization: auth,
+        Accept: "application/json",
+      },
+    });
+    if (!res.ok) {
+      throw new Error(
+        `Jira REST API returned ${res.status} ${res.statusText} for jql=${params.jql}`,
+      );
+    }
+    const data = (await res.json()) as {
+      issues?: unknown;
+      nextPageToken?: unknown;
+      isLast?: unknown;
+    };
+    const issues = Array.isArray(data.issues) ? data.issues : [];
+    for (const raw of issues) {
+      const mapped = toJiraIssue(raw);
+      if (mapped) out.push(mapped);
+    }
+    token = typeof data.nextPageToken === "string" ? data.nextPageToken : undefined;
+    pages++;
+    // Primary stop: the server says this was the last page, or no cursor.
+    if (data.isLast === true || !token) break;
+    // Loop guards (server misbehaving): bail after a sane page cap, and on a
+    // 0-issue page that still hands back a token (would otherwise spin).
+    if (pages >= MAX_PAGES) break;
+    if (issues.length === 0) break;
+  }
+  return out;
+}
+
+/**
+ * Build a `JiraFetcher` for the KNOWLEDGE scope (all issues in a project) backed
+ * by the real Atlassian REST API. Constructed FROM the shared
+ * `fetchPaginatedIssues` helper — it only parameterizes the JQL (`project=<KEY>`)
+ * and `fields` (`summary,description,comment`); the auth + cursor loop are NOT
+ * re-implemented here. The knowledge-sync URL contract (locked by
+ * `tests/jira.test.ts`) is byte-identical to the pre-extraction behavior.
  *
  * Not used by tests — tests inject a stub fetcher OR a fake `fetchImpl`. Exposed
  * so the scheduler / CLI can wire production usage in one line.
@@ -124,56 +235,53 @@ export function buildJiraFetcher(
       "buildJiraFetcher: no global fetch available; pass an explicit fetchImpl",
     );
   }
-  const auth = Buffer.from(`${config.email}:${config.apiToken}`).toString("base64");
-  const base = config.baseUrl.replace(/\/$/, "");
-  const MAX_RESULTS = 100;
-  // Hard cap on pages walked — defends against a server that never sets
-  // `isLast` and keeps echoing a cursor (1000 pages * 100 = 100k issues).
-  const MAX_PAGES = 1000;
-
   return {
     async fetchIssues(projectKey: string): Promise<JiraIssue[]> {
-      const out: JiraIssue[] = [];
-      let token: string | undefined;
-      let pages = 0;
-      // Cursor pagination: the first request omits the token; each response
-      // returns the next page's cursor. Stop on `isLast === true` OR no token.
-      for (;;) {
-        let url =
-          `${base}/rest/api/3/search/jql?jql=${encodeURIComponent(`project=${projectKey}`)}` +
-          `&fields=summary,description,comment&maxResults=${MAX_RESULTS}`;
-        if (token) url += `&nextPageToken=${encodeURIComponent(token)}`;
-        const res = await fetchImpl(url, {
-          headers: {
-            Authorization: `Basic ${auth}`,
-            Accept: "application/json",
-          },
-        });
-        if (!res.ok) {
-          throw new Error(
-            `Jira REST API returned ${res.status} ${res.statusText} for project=${projectKey}`,
-          );
-        }
-        const data = (await res.json()) as {
-          issues?: unknown;
-          nextPageToken?: unknown;
-          isLast?: unknown;
-        };
-        const issues = Array.isArray(data.issues) ? data.issues : [];
-        for (const raw of issues) {
-          const mapped = toJiraIssue(raw);
-          if (mapped) out.push(mapped);
-        }
-        token = typeof data.nextPageToken === "string" ? data.nextPageToken : undefined;
-        pages++;
-        // Primary stop: the server says this was the last page, or no cursor.
-        if (data.isLast === true || !token) break;
-        // Loop guards (server misbehaving): bail after a sane page cap, and on a
-        // 0-issue page that still hands back a token (would otherwise spin).
-        if (pages >= MAX_PAGES) break;
-        if (issues.length === 0) break;
-      }
-      return out;
+      return fetchPaginatedIssues(config, fetchImpl, {
+        jql: `project=${projectKey}`,
+        fields: "summary,description,comment",
+        maxResults: 100,
+      });
+    },
+  };
+}
+
+/**
+ * Compose the open-defects JQL from a project key + the (configurable) scope.
+ * Defaults are generic and universally valid (`statusCategory != Done`,
+ * `issuetype in (Bug)`); an empty-string clause is dropped.
+ */
+export function buildOpenDefectsJql(projectKey: string, scope: OpenDefectsScope = {}): string {
+  const status = scope.statusJql ?? "statusCategory != Done";
+  const issueType = scope.issueTypeJql ?? "issuetype in (Bug)";
+  return [`project=${projectKey}`, status, issueType]
+    .filter((clause) => clause.trim().length > 0)
+    .join(" AND ");
+}
+
+/**
+ * Build an `OpenDefectsFetcher` for the DEFECT scope. Constructed FROM the same
+ * shared `fetchPaginatedIssues` helper as `buildJiraFetcher` — it only swaps the
+ * JQL (open-defects scope) and the `fields` (adds `labels,issuetype` so the
+ * categorizer's input fields are surfaced). No copied auth / pagination loop.
+ */
+export function buildOpenDefectsFetcher(
+  config: JiraClientConfig,
+  scope: OpenDefectsScope = {},
+  fetchImpl: typeof fetch = globalThis.fetch,
+): OpenDefectsFetcher {
+  if (typeof fetchImpl !== "function") {
+    throw new TypeError(
+      "buildOpenDefectsFetcher: no global fetch available; pass an explicit fetchImpl",
+    );
+  }
+  return {
+    async fetchOpenDefects(projectKey: string): Promise<JiraIssue[]> {
+      return fetchPaginatedIssues(config, fetchImpl, {
+        jql: buildOpenDefectsJql(projectKey, scope),
+        fields: "summary,description,comment,labels,issuetype",
+        maxResults: scope.maxResults ?? 100,
+      });
     },
   };
 }
@@ -187,6 +295,8 @@ function toJiraIssue(raw: unknown): JiraIssue | null {
       description?: unknown;
       comment?: { comments?: unknown };
       project?: { key?: unknown };
+      labels?: unknown;
+      issuetype?: { name?: unknown };
     };
   };
   if (typeof r.key !== "string" || r.key.length === 0) return null;
@@ -199,6 +309,14 @@ function toJiraIssue(raw: unknown): JiraIssue | null {
   );
   const issue: JiraIssue = { key: r.key, summary, descriptionText, commentTexts };
   if (typeof fields.project?.key === "string") issue.projectKey = fields.project.key;
+  // Extended mapping (AC-11): surface labels + issuetype for the categorizer.
+  if (Array.isArray(fields.labels)) {
+    const labels = (fields.labels as unknown[]).filter(
+      (l): l is string => typeof l === "string",
+    );
+    if (labels.length > 0) issue.labels = labels;
+  }
+  if (typeof fields.issuetype?.name === "string") issue.issueType = fields.issuetype.name;
   return issue;
 }
 

--- a/src/triage/categorizeDefect.ts
+++ b/src/triage/categorizeDefect.ts
@@ -1,0 +1,162 @@
+/**
+ * Pure, deterministic defect categorizer — no I/O, no network, no LLM.
+ *
+ * Given a defect's structural signals (summary + description text + labels +
+ * issuetype), an ordered rule table assigns exactly ONE `DefectCategory`. The
+ * table is evaluated in PRECEDENCE order (first match wins); anything that
+ * matches no rule lands in `other` via the fallback. The categorizer is the
+ * reusable core EPIC #1280 calls directly (no CLI / env coupling).
+ *
+ * Rules key ONLY on generic structural tokens (defect-type words, public
+ * Atlassian field/label/issuetype names) — never on internal hostnames,
+ * project/space keys, codenames, or colleague identifiers.
+ */
+
+/**
+ * The defect taxonomy.
+ *
+ * IMPORTANT: the DECLARATION order below is an arbitrary, readable order and is
+ * INTENTIONALLY NOT the precedence order. Tie-breaking uses a SEPARATE precedence
+ * defined by `RULES` below (`correctness-bug > type-safety > test-infra >
+ * code-quality > documentation > enhancement > other`). Do NOT "align" the two —
+ * they are deliberately distinct, and AC-5 asserts the precedence directly.
+ */
+export type DefectCategory =
+  | "correctness-bug"
+  | "code-quality"
+  | "documentation"
+  | "test-infra"
+  | "type-safety"
+  | "enhancement"
+  | "other";
+
+/** Every category value, in declaration order — used to seed a complete tally. */
+export const DEFECT_CATEGORIES: readonly DefectCategory[] = [
+  "correctness-bug",
+  "code-quality",
+  "documentation",
+  "test-infra",
+  "type-safety",
+  "enhancement",
+  "other",
+];
+
+/** Categorizer input — maps trivially from a `JiraIssue`. */
+export interface DefectInput {
+  key?: string;
+  summary: string;
+  descriptionText?: string;
+  labels?: string[];
+  issueType?: string;
+}
+
+/** A single categorized defect. */
+export interface DefectResult {
+  key?: string;
+  category: DefectCategory;
+  matchedRule: string;
+}
+
+interface DefectRule {
+  category: Exclude<DefectCategory, "other">;
+  name: string;
+  /** Keyword/regex over the combined text (summary + description). */
+  text?: RegExp;
+  /** Label values (lowercased) that trigger this rule. */
+  labels?: string[];
+  /** Issuetype names (lowercased) that trigger this rule. */
+  issueTypes?: string[];
+}
+
+/**
+ * Ordered rule table — evaluated top-to-bottom, FIRST MATCH WINS. The order here
+ * IS the precedence: correctness-bug > type-safety > test-infra > code-quality >
+ * documentation > enhancement. A defect matching multiple rules resolves to the
+ * highest one (AC-5). Nothing here keys on `issueType: "Bug"` alone, so a
+ * type-safety task tagged Bug is not swallowed by correctness-bug.
+ */
+const RULES: readonly DefectRule[] = [
+  {
+    category: "correctness-bug",
+    name: "correctness-bug:keyword",
+    text: /\b(crash(?:es|ed)?|broken|incorrect|wrong|regress(?:ion|es|ed)?|exception|throws?|swallow(?:s|ed)?|hang(?:s|ed)?|deadlock|race condition|memory leak|null pointer|npe|returns? empty|infinite loop|off-by-one|corrupt(?:s|ed|ion)?|fails?|failing|errors?)\b/i,
+    labels: ["bug"],
+  },
+  {
+    category: "type-safety",
+    name: "type-safety:keyword",
+    text: /\b(type|types|typing|typed|typecheck|type-safety|typesafe|cast|casting|generic|generics|nullable|non-null|narrow(?:ing)?)\b/i,
+    labels: ["type-safety", "typing"],
+  },
+  {
+    category: "test-infra",
+    name: "test-infra:keyword",
+    text: /\b(test|tests|testing|spec|specs|mock(?:s|ed)?|fixture|fixtures|ci|flaky|hoist|test-runner|jest|snapshot|e2e|coverage|stub|stubs)\b/i,
+    labels: ["test", "test-infra", "ci"],
+  },
+  {
+    category: "code-quality",
+    name: "code-quality:keyword",
+    text: /\b(refactor(?:ing)?|dedupe|deduplicate|duplicat(?:e|ed|ion)|cleanup|clean up|rename|extract|simplify|lint|tidy|consolidate|readability|dead code)\b/i,
+    labels: ["refactor", "chore", "tech-debt"],
+  },
+  {
+    category: "documentation",
+    name: "documentation:keyword",
+    text: /\b(doc|docs|document|documentation|readme|changelog|comment|comments|typo|wording|link|links|guide|tutorial|docstring|javadoc)\b/i,
+    labels: ["docs", "documentation"],
+  },
+  {
+    category: "enhancement",
+    name: "enhancement:keyword",
+    text: /\b(add|adds|added|feature|features|support|enhance(?:ment)?|improve(?:ment)?|introduce|new|option|optional|knob|configurable|extend)\b/i,
+    labels: ["enhancement", "feature"],
+    issueTypes: ["story", "epic", "new feature", "feature"],
+  },
+];
+
+function ruleMatches(rule: DefectRule, text: string, labels: string[], issueType: string): boolean {
+  if (rule.text && rule.text.test(text)) return true;
+  if (rule.labels && rule.labels.some((l) => labels.includes(l))) return true;
+  if (rule.issueTypes && issueType.length > 0 && rule.issueTypes.includes(issueType)) return true;
+  return false;
+}
+
+/**
+ * Categorize a single defect. Deterministic + pure: the same input always yields
+ * the same `{ category, matchedRule }` (AC-4). First matching rule in precedence
+ * order wins (AC-5); no match → `{ category: "other", matchedRule: "fallback" }`.
+ */
+export function categorizeDefect(input: DefectInput): { category: DefectCategory; matchedRule: string } {
+  const text = `${input.summary ?? ""} ${input.descriptionText ?? ""}`;
+  const labels = (input.labels ?? []).map((l) => l.toLowerCase());
+  const issueType = (input.issueType ?? "").toLowerCase();
+
+  for (const rule of RULES) {
+    if (ruleMatches(rule, text, labels, issueType)) {
+      return { category: rule.category, matchedRule: rule.name };
+    }
+  }
+  return { category: "other", matchedRule: "fallback" };
+}
+
+/**
+ * Categorize a list of defects and aggregate the grouped counts. `counts` is
+ * seeded with EVERY category at 0 (so the shape is stable + no category is
+ * silently absent), then incremented per result (AC-6).
+ */
+export function categorizeAll(inputs: DefectInput[]): {
+  results: DefectResult[];
+  counts: Record<DefectCategory, number>;
+} {
+  const counts = Object.fromEntries(DEFECT_CATEGORIES.map((c) => [c, 0])) as Record<
+    DefectCategory,
+    number
+  >;
+  const results: DefectResult[] = inputs.map((input) => {
+    const { category, matchedRule } = categorizeDefect(input);
+    counts[category] += 1;
+    return { key: input.key, category, matchedRule };
+  });
+  return { results, counts };
+}

--- a/src/triage/cli.ts
+++ b/src/triage/cli.ts
@@ -1,0 +1,79 @@
+import {
+  categorizeAll,
+  DEFECT_CATEGORIES,
+  DefectCategory,
+  DefectInput,
+  DefectResult,
+} from "./categorizeDefect";
+import type { JiraIssue } from "../jira/sync";
+import type { JiraCategoryWriter } from "../jira/categoryWriter";
+
+/**
+ * Injectable core of the categorize-defects CLI. Accepts an injected open-defects
+ * fetcher + (optional) writer so a test can drive the FULL path — including the
+ * `--apply`-positive write path — against a FAKE, never touching real creds. The
+ * env-cred construction lives in the thin outer shell (`scripts/categorize-defects.js`),
+ * NEVER in here.
+ *
+ * Dry-run is the DEFAULT: when `apply` is false (or no writer is supplied), the
+ * core computes + previews categories and issues ZERO writes. The writer is
+ * exercised ONLY when `apply === true` AND a writer is injected (AC-7).
+ */
+export interface CategorizeRunDeps {
+  /** Injected open-defects read — returns the issues to categorize. */
+  fetchOpenDefects: () => Promise<JiraIssue[]>;
+  /** Injected writer — constructed by the shell ONLY on `--apply`. */
+  writer?: JiraCategoryWriter;
+  /** Real-write flag. Default false (dry-run). */
+  apply?: boolean;
+  /** Logger sink; defaults to `console.log`. */
+  log?: (msg: string) => void;
+}
+
+export interface CategorizeRunResult {
+  results: DefectResult[];
+  counts: Record<DefectCategory, number>;
+  /** Number of category writes performed (always 0 in dry-run). */
+  applied: number;
+}
+
+function toDefectInput(issue: JiraIssue): DefectInput {
+  return {
+    key: issue.key,
+    summary: issue.summary,
+    descriptionText: issue.descriptionText,
+    labels: issue.labels,
+    issueType: issue.issueType,
+  };
+}
+
+export async function run(deps: CategorizeRunDeps): Promise<CategorizeRunResult> {
+  const log = deps.log ?? ((msg: string) => console.log(msg));
+  const apply = deps.apply === true;
+
+  const issues = await deps.fetchOpenDefects();
+  const inputs = issues.map(toDefectInput);
+  const { results, counts } = categorizeAll(inputs);
+
+  // Per-defect planned category (preview).
+  log(`Categorized ${results.length} open defect(s) (${apply ? "APPLY" : "dry-run"}):`);
+  for (const r of results) {
+    log(`  ${r.key ?? "(no key)"} -> ${r.category} [${r.matchedRule}]`);
+  }
+  // Grouped-counts tally.
+  log("Category tally:");
+  for (const category of DEFECT_CATEGORIES) {
+    log(`  ${category}: ${counts[category]}`);
+  }
+
+  let applied = 0;
+  if (apply && deps.writer) {
+    for (const r of results) {
+      if (!r.key) continue;
+      await deps.writer.setCategory(r.key, r.category);
+      applied++;
+    }
+  }
+
+  return { results, counts, applied };
+}

--- a/src/triage/index.ts
+++ b/src/triage/index.ts
@@ -1,0 +1,8 @@
+export {
+  categorizeDefect,
+  categorizeAll,
+  DEFECT_CATEGORIES,
+} from "./categorizeDefect";
+export type { DefectCategory, DefectInput, DefectResult } from "./categorizeDefect";
+export { run } from "./cli";
+export type { CategorizeRunDeps, CategorizeRunResult } from "./cli";

--- a/tests/jira.categoryWriter.test.ts
+++ b/tests/jira.categoryWriter.test.ts
@@ -1,0 +1,69 @@
+import { buildJiraCategoryWriter } from "../src/jira/categoryWriter";
+
+describe("buildJiraCategoryWriter — outward write (mocked, never live)", () => {
+  it("AC-8: setCategory issues PUT /rest/api/3/issue/{key} with a labels-add body", async () => {
+    const fakeResponse = {
+      ok: true,
+      status: 204,
+      statusText: "No Content",
+      async json() {
+        return {};
+      },
+    };
+    const fetchImpl = jest.fn(async () => fakeResponse) as unknown as typeof fetch;
+    const writer = buildJiraCategoryWriter(
+      { baseUrl: "https://example.atlassian.net", email: "a@b.c", apiToken: "tok" },
+      fetchImpl,
+    );
+
+    await writer.setCategory("PROJ-42", "correctness-bug");
+
+    expect((fetchImpl as unknown as jest.Mock)).toHaveBeenCalledTimes(1);
+    const [url, init] = (fetchImpl as unknown as jest.Mock).mock.calls[0] as [
+      string,
+      { method: string; headers: Record<string, string>; body: string },
+    ];
+    expect(url).toBe("https://example.atlassian.net/rest/api/3/issue/PROJ-42");
+    expect(init.method).toBe("PUT");
+    expect(init.headers.Authorization).toMatch(/^Basic /);
+    expect(init.headers["Content-Type"]).toBe("application/json");
+    const body = JSON.parse(init.body);
+    expect(body).toEqual({ update: { labels: [{ add: "defect-category:correctness-bug" }] } });
+  });
+
+  it("honors a configurable label prefix", async () => {
+    const fetchImpl = jest.fn(async () => ({
+      ok: true,
+      status: 204,
+      statusText: "No Content",
+      async json() {
+        return {};
+      },
+    })) as unknown as typeof fetch;
+    const writer = buildJiraCategoryWriter(
+      { baseUrl: "https://example.atlassian.net", email: "a@b.c", apiToken: "tok" },
+      fetchImpl,
+      { labelPrefix: "kind" },
+    );
+    await writer.setCategory("PROJ-9", "documentation");
+    const init = (fetchImpl as unknown as jest.Mock).mock.calls[0][1] as { body: string };
+    expect(JSON.parse(init.body)).toEqual({ update: { labels: [{ add: "kind:documentation" }] } });
+  });
+
+  it("throws on a non-2xx response and on an empty issueKey", async () => {
+    const fetchImpl = jest.fn(async () => ({
+      ok: false,
+      status: 403,
+      statusText: "Forbidden",
+      async json() {
+        return {};
+      },
+    })) as unknown as typeof fetch;
+    const writer = buildJiraCategoryWriter(
+      { baseUrl: "https://example.atlassian.net", email: "a@b.c", apiToken: "tok" },
+      fetchImpl,
+    );
+    await expect(writer.setCategory("PROJ-1", "other")).rejects.toThrow(/403/);
+    await expect(writer.setCategory("", "other")).rejects.toThrow(TypeError);
+  });
+});

--- a/tests/jira.openDefects.test.ts
+++ b/tests/jira.openDefects.test.ts
@@ -1,0 +1,134 @@
+import {
+  buildOpenDefectsFetcher,
+  buildOpenDefectsJql,
+  JiraIssue,
+} from "../src/jira/sync";
+
+/** Minimal ADF paragraph node wrapping the given text. */
+function adfParagraph(text: string): unknown {
+  return {
+    type: "doc",
+    version: 1,
+    content: [{ type: "paragraph", content: [{ type: "text", text }] }],
+  };
+}
+
+describe("buildOpenDefectsJql (open-defects scope, configurable)", () => {
+  it("defaults to a generic open + defect scope", () => {
+    expect(buildOpenDefectsJql("PROJ")).toBe(
+      "project=PROJ AND statusCategory != Done AND issuetype in (Bug)",
+    );
+  });
+
+  it("honors overrides and drops an empty-string clause", () => {
+    expect(
+      buildOpenDefectsJql("PROJ", { statusJql: "status = Open", issueTypeJql: "" }),
+    ).toBe("project=PROJ AND status = Open");
+  });
+});
+
+describe("buildOpenDefectsFetcher (constructed from the shared helper)", () => {
+  it("AC-11: extended mapping surfaces labels + issueType from a fixture issue", async () => {
+    const rawIssue = {
+      key: "PROJ-7",
+      fields: {
+        summary: "defect with labels and a type",
+        description: adfParagraph("a body"),
+        comment: { comments: [] },
+        labels: ["x", "y"],
+        issuetype: { name: "Bug" },
+        project: { key: "PROJ" },
+      },
+    };
+    const fakeResponse = {
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      async json() {
+        return { issues: [rawIssue], isLast: true };
+      },
+    };
+    const fetchImpl = jest.fn(async () => fakeResponse) as unknown as typeof fetch;
+    const fetcher = buildOpenDefectsFetcher(
+      { baseUrl: "https://example.atlassian.net", email: "a@b.c", apiToken: "tok" },
+      {},
+      fetchImpl,
+    );
+
+    const issues = await fetcher.fetchOpenDefects("PROJ");
+    expect(issues).toHaveLength(1);
+    expect(issues[0].labels).toEqual(["x", "y"]);
+    expect(issues[0].issueType).toBe("Bug");
+
+    // The fetch URL carries the open-defects JQL + the extra fields.
+    const url = (fetchImpl as unknown as jest.Mock).mock.calls[0][0] as string;
+    expect(url).toContain("/rest/api/3/search/jql");
+    expect(decodeURIComponent(url)).toContain("statusCategory != Done");
+    expect(decodeURIComponent(url)).toContain("issuetype in (Bug)");
+    expect(url).toContain("fields=summary,description,comment,labels,issuetype");
+  });
+
+  it("AC-11 (backward-compat): an issue lacking labels/issuetype yields undefined", async () => {
+    const rawIssue = {
+      key: "PROJ-8",
+      fields: {
+        summary: "defect without labels or type",
+        description: null,
+        comment: { comments: [] },
+      },
+    };
+    const fakeResponse = {
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      async json() {
+        return { issues: [rawIssue], isLast: true };
+      },
+    };
+    const fetchImpl = jest.fn(async () => fakeResponse) as unknown as typeof fetch;
+    const fetcher = buildOpenDefectsFetcher(
+      { baseUrl: "https://example.atlassian.net", email: "a@b.c", apiToken: "tok" },
+      {},
+      fetchImpl,
+    );
+    const issues = await fetcher.fetchOpenDefects("PROJ");
+    expect(issues[0].labels).toBeUndefined();
+    expect(issues[0].issueType).toBeUndefined();
+  });
+
+  it("paginates via the SAME shared cursor loop (nextPageToken, stops on isLast)", async () => {
+    const page = (
+      start: number,
+      count: number,
+      nextPageToken: string | undefined,
+      isLast: boolean,
+    ) => ({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      async json() {
+        return {
+          nextPageToken,
+          isLast,
+          issues: Array.from({ length: count }, (_, i) => ({
+            key: `PROJ-${start + i}`,
+            fields: { summary: `Defect ${start + i}`, description: null, comment: { comments: [] } },
+          })) as unknown[],
+        };
+      },
+    });
+    const responses = [page(0, 100, "t1", false), page(100, 50, undefined, true)];
+    let call = 0;
+    const fetchImpl = jest.fn(async () => responses[call++]) as unknown as typeof fetch;
+    const fetcher = buildOpenDefectsFetcher(
+      { baseUrl: "https://example.atlassian.net", email: "a@b.c", apiToken: "tok" },
+      {},
+      fetchImpl,
+    );
+    const issues: JiraIssue[] = await fetcher.fetchOpenDefects("PROJ");
+    expect(issues).toHaveLength(150);
+    const urls = (fetchImpl as unknown as jest.Mock).mock.calls.map((c) => c[0] as string);
+    expect(urls[0]).not.toContain("nextPageToken");
+    expect(urls[1]).toContain("nextPageToken=t1");
+  });
+});

--- a/tests/triage.categorizeDefect.test.ts
+++ b/tests/triage.categorizeDefect.test.ts
@@ -1,0 +1,114 @@
+import {
+  categorizeDefect,
+  categorizeAll,
+  DEFECT_CATEGORIES,
+  DefectCategory,
+  DefectInput,
+} from "../src/triage/categorizeDefect";
+
+/**
+ * Synthetic fixtures — ALL invented placeholder text shaped like real entries.
+ * No internal hostname, project/space key, colleague name, or codename (PS-1/PS-2).
+ * One fixture per category, including the `other` fallback.
+ */
+const SYNTHETIC: Array<{ input: DefectInput; expected: DefectCategory }> = [
+  {
+    input: { key: "X-1", summary: "handler silently swallows errors and returns empty", issueType: "Bug" },
+    expected: "correctness-bug",
+  },
+  {
+    input: { key: "X-2", summary: "rename mockFoo for test-runner hoist compatibility", labels: ["chore"] },
+    expected: "test-infra",
+  },
+  {
+    input: { key: "X-3", summary: "doc page: link the changelog instead of an inline date", issueType: "Task" },
+    expected: "documentation",
+  },
+  {
+    input: { key: "X-4", summary: "tighten the Foo type to forbid the empty case", issueType: "Bug" },
+    expected: "type-safety",
+  },
+  {
+    input: { key: "X-5", summary: "extract duplicated factory into one helper", labels: ["refactor"] },
+    expected: "code-quality",
+  },
+  {
+    input: { key: "X-6", summary: "add an optional pagination knob to the fetcher", issueType: "Story" },
+    expected: "enhancement",
+  },
+  {
+    input: { key: "X-7", summary: "miscellaneous unclassifiable note", labels: [] },
+    expected: "other",
+  },
+];
+
+describe("categorizeDefect — taxonomy + rules", () => {
+  it("AC-3: at least one synthetic input lands in EACH category (incl. other) — no dead category", () => {
+    const landed = new Set<DefectCategory>();
+    for (const { input, expected } of SYNTHETIC) {
+      const { category } = categorizeDefect(input);
+      expect(category).toBe(expected);
+      landed.add(category);
+    }
+    // Enum-completeness loop: every declared category is reachable by a fixture.
+    for (const category of DEFECT_CATEGORIES) {
+      expect(landed.has(category)).toBe(true);
+    }
+  });
+
+  it("AC-4: determinism — same input twice yields an identical result", () => {
+    for (const { input } of SYNTHETIC) {
+      const a = categorizeDefect(input);
+      const b = categorizeDefect(input);
+      expect(a).toEqual(b);
+    }
+    // A representative deep-equality check, not just category.
+    const sample = { summary: "crash: null pointer exception in the cast path" };
+    expect(categorizeDefect(sample)).toEqual(categorizeDefect(sample));
+  });
+
+  it("AC-5: precedence — an input matching two type-rules resolves to the higher one", () => {
+    // Matches BOTH correctness-bug (crash/throws/null pointer/exception) AND
+    // type-safety (cast/type). Precedence: correctness-bug > type-safety.
+    const multi: DefectInput = {
+      summary: "crash: the cast to the Foo type throws a null pointer exception",
+    };
+    const { category } = categorizeDefect(multi);
+    expect(category).toBe("correctness-bug");
+
+    // And a test-infra vs code-quality collision: "rename" (code-quality) +
+    // "test-runner"/"mock" (test-infra). Precedence: test-infra > code-quality.
+    const collide: DefectInput = { summary: "rename the mock in the test-runner setup" };
+    expect(categorizeDefect(collide).category).toBe("test-infra");
+  });
+
+  it("fallback — an unmatched input is `other` / matchedRule: fallback", () => {
+    const r = categorizeDefect({ summary: "miscellaneous unclassifiable note" });
+    expect(r.category).toBe("other");
+    expect(r.matchedRule).toBe("fallback");
+  });
+});
+
+describe("categorizeAll — grouped counts", () => {
+  it("AC-6: per-category counts equal the per-result tally", () => {
+    const inputs = SYNTHETIC.map((s) => s.input);
+    const { results, counts } = categorizeAll(inputs);
+
+    // Every category key is present (seeded at 0).
+    for (const category of DEFECT_CATEGORIES) {
+      expect(counts).toHaveProperty(category);
+    }
+
+    // counts == manual tally over results.
+    const tally = Object.fromEntries(DEFECT_CATEGORIES.map((c) => [c, 0])) as Record<
+      DefectCategory,
+      number
+    >;
+    for (const r of results) tally[r.category] += 1;
+    expect(counts).toEqual(tally);
+
+    // Sum of counts == number of inputs (every defect lands in exactly one bucket).
+    const total = Object.values(counts).reduce((a, b) => a + b, 0);
+    expect(total).toBe(inputs.length);
+  });
+});

--- a/tests/triage.cli.test.ts
+++ b/tests/triage.cli.test.ts
@@ -1,0 +1,86 @@
+import { run } from "../src/triage/cli";
+import { buildOpenDefectsFetcher } from "../src/jira/sync";
+import type { JiraCategoryWriter } from "../src/jira/categoryWriter";
+import type { JiraIssue } from "../src/jira/sync";
+
+/** Two synthetic open defects, both with keys (so --apply has something to write). */
+const FIXTURE_ISSUES: JiraIssue[] = [
+  { key: "X-1", summary: "handler swallows an error", descriptionText: "", commentTexts: [], issueType: "Bug" },
+  { key: "X-2", summary: "add an optional knob", descriptionText: "", commentTexts: [], issueType: "Story" },
+];
+
+/** A writer spy whose setCategory is bound to a fake — NEVER live Jira. */
+function makeWriterSpy(): { writer: JiraCategoryWriter; calls: Array<[string, string]> } {
+  const calls: Array<[string, string]> = [];
+  const writer: JiraCategoryWriter = {
+    async setCategory(issueKey, category) {
+      calls.push([issueKey, category]);
+    },
+  };
+  return { writer, calls };
+}
+
+describe("run(deps) — dry-run default + flag-gated outward write (AC-7)", () => {
+  it("dry-run (no --apply) makes ZERO writes", async () => {
+    const { writer, calls } = makeWriterSpy();
+    const logs: string[] = [];
+    const result = await run({
+      fetchOpenDefects: async () => FIXTURE_ISSUES,
+      writer,
+      apply: false,
+      log: (m) => logs.push(m),
+    });
+    expect(calls).toHaveLength(0);
+    expect(result.applied).toBe(0);
+    // The tally is still printed in dry-run.
+    expect(logs.some((l) => l.startsWith("Category tally:"))).toBe(true);
+  });
+
+  it("--apply (same injected fake) makes a NON-ZERO number of writes", async () => {
+    const { writer, calls } = makeWriterSpy();
+    const result = await run({
+      fetchOpenDefects: async () => FIXTURE_ISSUES,
+      writer,
+      apply: true,
+      log: () => undefined,
+    });
+    expect(calls.length).toBeGreaterThan(0);
+    expect(result.applied).toBe(FIXTURE_ISSUES.length);
+    // Each write stamps the computed category for that key.
+    expect(calls).toEqual([
+      ["X-1", "correctness-bug"],
+      ["X-2", "enhancement"],
+    ]);
+  });
+
+  it("dry-run with the read seam bound to a FAKE fetchImpl still issues no write", async () => {
+    // Read seam driven by an injected fake fetchImpl (no live network); writer
+    // is a spy. Proves both ends bind to fakes.
+    const rawIssue = {
+      key: "X-9",
+      fields: { summary: "doc: link the changelog", description: null, comment: { comments: [] } },
+    };
+    const fetchImpl = jest.fn(async () => ({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      async json() {
+        return { issues: [rawIssue], isLast: true };
+      },
+    })) as unknown as typeof fetch;
+    const fetcher = buildOpenDefectsFetcher(
+      { baseUrl: "https://example.atlassian.net", email: "a@b.c", apiToken: "tok" },
+      {},
+      fetchImpl,
+    );
+    const { writer, calls } = makeWriterSpy();
+    const result = await run({
+      fetchOpenDefects: () => fetcher.fetchOpenDefects("PROJ"),
+      writer,
+      apply: false,
+      log: () => undefined,
+    });
+    expect(calls).toHaveLength(0);
+    expect(result.counts.documentation).toBe(1);
+  });
+});

--- a/tests/triage.seam.test.ts
+++ b/tests/triage.seam.test.ts
@@ -1,0 +1,53 @@
+/**
+ * AC-12 — the #1280 reuse seam is importable with NO CLI/env coupling.
+ *
+ * Imports `categorizeAll` from `src/triage/` AND `buildJiraCategoryWriter` from
+ * `src/jira/` directly, exercises `setCategory` against an injected fake, and
+ * NEVER imports the CLI module (`src/triage/cli`) nor reads any env var. This
+ * proves EPIC #1280 can wire the two core gears without the CLI shell.
+ */
+import { categorizeAll } from "../src/triage/categorizeDefect";
+import { buildJiraCategoryWriter } from "../src/jira/categoryWriter";
+
+describe("AC-12 — #1280 reuse seam (importable, no CLI/env coupling)", () => {
+  it("classifies via categorizeAll and writes via buildJiraCategoryWriter against a fake", async () => {
+    // Snapshot env to PROVE no env var is read by these gears.
+    const envBefore = JSON.stringify(process.env);
+
+    const { results, counts } = categorizeAll([
+      { key: "S-1", summary: "crash on null pointer", issueType: "Bug" },
+      { key: "S-2", summary: "update the readme doc", issueType: "Task" },
+    ]);
+    expect(results).toHaveLength(2);
+    expect(counts["correctness-bug"]).toBe(1);
+    expect(counts.documentation).toBe(1);
+
+    const writes: Array<[string, string]> = [];
+    const fetchImpl = jest.fn(async (_url: unknown, init: unknown) => {
+      const body = JSON.parse((init as { body: string }).body);
+      writes.push([(_url as string), body.update.labels[0].add]);
+      return { ok: true, status: 204, statusText: "No Content", async json() { return {}; } };
+    }) as unknown as typeof fetch;
+
+    const writer = buildJiraCategoryWriter(
+      { baseUrl: "https://example.atlassian.net", email: "a@b.c", apiToken: "tok" },
+      fetchImpl,
+    );
+    for (const r of results) {
+      if (r.key) await writer.setCategory(r.key, r.category);
+    }
+    expect(writes).toHaveLength(2);
+    expect(writes[0][0]).toContain("/rest/api/3/issue/S-1");
+
+    // Env was untouched by either gear.
+    expect(JSON.stringify(process.env)).toBe(envBefore);
+  });
+
+  it("the CLI module is NOT a transitive import of the seam gears", () => {
+    // If importing these two gears pulled in the CLI, it would appear in the
+    // module cache. Assert it does not.
+    const cliResolved = require.resolve("../src/triage/cli");
+    const inCache = Object.keys(require.cache).some((p) => p === cliResolved);
+    expect(inCache).toBe(false);
+  });
+});


### PR DESCRIPTION
## What
Slice 1 of EPIC #1280. monday-bot reads **OPEN Jira defects**, categorizes each via a deterministic **rules engine** (no LLM) by defect-type — defined precedence on multi-match, an `other` fallback so every defect lands in exactly one category — prints a per-category tally, and **writes the category back to Jira** behind an explicit `--apply` flag.

**Safety: DRY-RUN by default.** The writer is constructed only inside the `--apply` branch, so the default path physically cannot mutate Jira. Every test binds an injected fake fetchImpl/writer — zero live network calls.

## Reuse, not fork
Extracted ONE shared `basicAuthHeader` + `fetchPaginatedIssues` helper in `src/jira/sync.ts`; both `buildJiraFetcher` (knowledge-sync — URL contract unchanged) and the new `buildOpenDefectsFetcher` route through it. Extended `JiraIssue`/`toJiraIssue` with `labels`/`issueType`. New DI'd `buildJiraCategoryWriter().setCategory()` (PUT seam) + injectable `run(deps)` CLI core. #1280 seam: `categorizeAll` + the writer importable with no CLI/env coupling.

## Evidence
- 4-role chain PASS (planner / plan-review R2 / executor / execution-review)
- **289/289 tests** (34 suites); `npm run build` + `typecheck` exit 0
- knowledge-sync URL assertions (`tests/jira.test.ts`) unchanged + green
- single-impl reuse: `grep -rc 'toString("base64")' src/jira/` = 1
- privacy clean (only `example.atlassian.net`/`PROJ` placeholders)

> Note: the live `--apply` write against real Jira is operator-gated and has NOT been run.

https://claude.ai/code/session_018TnaPsVNYG78F7y2YipqWL