### PR TITLE
fix(confluence): follow _links.next cursor to end 100-page truncation (#1189)

### DIFF
--- a/src/confluence/sync.ts
+++ b/src/confluence/sync.ts
@@ -46,15 +46,23 @@ export interface ConfluenceClientConfig {
   /**
    * Page-fetch size for the `&limit=` query param. Default 100.
    *
-   * NOTE (#1189): this only makes the per-request page size CONFIGURABLE — it is
-   * NOT a full large-space fix. The Atlassian content REST API caps `limit`
-   * (commonly 100) and paginates further results via `_links.next` cursors,
-   * which this fetcher does NOT follow. A space with more results than one page
-   * is therefore still truncated regardless of the `limit` value. Cursor
-   * pagination is a deferred follow-up (see the plan's Deferred section).
+   * NOTE (#1189): this controls only the per-request page SIZE. The Atlassian
+   * content REST API caps `limit` (commonly 100) and paginates further results
+   * via `_links.next` cursors. The fetcher now FOLLOWS those cursors to
+   * exhaustion (see `fetchPages`), so a space with more results than one page is
+   * fully retrieved regardless of the `limit` value — `pageLimit` just tunes how
+   * many pages the walk takes, not whether large spaces are truncated.
    */
   pageLimit?: number;
 }
+
+/**
+ * Hard cap on the number of result pages walked while following `_links.next`.
+ * Defends against a server that never drops the next link and keeps echoing a
+ * cursor (1000 pages * 100 = 100k pages). Mirrors `src/jira/sync.ts`'s
+ * `MAX_PAGES`. Exported so the pagination guard is assertable from tests.
+ */
+export const MAX_PAGES = 1000;
 
 /**
  * Build a `ConfluenceFetcher` backed by real Atlassian REST API. Hits
@@ -74,26 +82,54 @@ export function buildConfluenceFetcher(
     );
   }
   const auth = Buffer.from(`${config.email}:${config.apiToken}`).toString("base64");
-  // Configurable page size (default 100). Does NOT follow `_links.next` cursors,
-  // so large spaces are still truncated at one page — see ConfluenceClientConfig.
+  // Configurable page size (default 100). Follows `_links.next` cursors to walk
+  // every page of a large space — see `fetchPages` below and ConfluenceClientConfig.
   const limit = typeof config.pageLimit === "number" && config.pageLimit > 0 ? config.pageLimit : 100;
+  const base = config.baseUrl.replace(/\/$/, "");
   return {
     async fetchPages(spaceKey: string): Promise<ConfluencePage[]> {
-      const url = `${config.baseUrl.replace(/\/$/, "")}/wiki/rest/api/content?spaceKey=${encodeURIComponent(spaceKey)}&expand=body.storage&limit=${limit}`;
-      const res = await fetchImpl(url, {
-        headers: {
-          Authorization: `Basic ${auth}`,
-          Accept: "application/json",
-        },
-      });
-      if (!res.ok) {
-        throw new Error(
-          `Confluence REST API returned ${res.status} ${res.statusText} for spaceKey=${spaceKey}`,
-        );
+      const out: ConfluencePage[] = [];
+      // Cursor pagination: the first request is the well-known content URL; each
+      // response carries `_links.next` (a path) pointing at the following page.
+      // We follow it to exhaustion, mirroring the Jira `nextPageToken` loop.
+      let url: string | undefined =
+        `${base}/wiki/rest/api/content?spaceKey=${encodeURIComponent(spaceKey)}&expand=body.storage&limit=${limit}`;
+      let pages = 0;
+      while (url) {
+        const res = await fetchImpl(url, {
+          headers: {
+            Authorization: `Basic ${auth}`,
+            Accept: "application/json",
+          },
+        });
+        if (!res.ok) {
+          throw new Error(
+            `Confluence REST API returned ${res.status} ${res.statusText} for spaceKey=${spaceKey}`,
+          );
+        }
+        const data = (await res.json()) as { results?: unknown; _links?: { next?: unknown } };
+        const results = Array.isArray(data.results) ? data.results : [];
+        for (const raw of results) {
+          const page = toConfluencePage(raw);
+          if (page) out.push(page);
+        }
+        pages++;
+        const next = typeof data._links?.next === "string" ? data._links.next : undefined;
+        // Primary stop: no next link → this was the last page (Confluence has no
+        // `isLast` flag; absence of the cursor IS the terminal signal).
+        if (!next) break;
+        // Loop guards (server misbehaving): bail after a sane page cap, and on a
+        // 0-result page that still hands back a cursor (would otherwise spin).
+        if (pages >= MAX_PAGES) break;
+        if (results.length === 0) break;
+        // `_links.next` omits the `/wiki` context prefix (e.g.
+        // `/rest/api/content?...&start=100`); restore it so the next GET does not
+        // 404. Reuse the trailing-slash-trimmed base so a trailing slash on
+        // `baseUrl` does not produce a double slash.
+        const nextPath = next.startsWith("/wiki") ? next : `/wiki${next.startsWith("/") ? "" : "/"}${next}`;
+        url = `${base}${nextPath}`;
       }
-      const data = (await res.json()) as { results?: unknown };
-      const results = Array.isArray(data.results) ? data.results : [];
-      return results.map(toConfluencePage).filter((p): p is ConfluencePage => p !== null);
+      return out;
     },
   };
 }

--- a/tests/confluence.test.ts
+++ b/tests/confluence.test.ts
@@ -6,6 +6,7 @@ import {
   ConfluenceFetcher,
   ConfluencePage,
   buildConfluenceFetcher,
+  MAX_PAGES,
 } from "../src/confluence/sync";
 import { KnowledgeService } from "../src/knowledge/service";
 import { Chunk as LlmChunk, Citation } from "../src/llm/generate";
@@ -334,6 +335,146 @@ describe("buildConfluenceFetcher (HTTP wiring)", () => {
       fetchImpl,
     );
     await expect(fetcher.fetchPages("DEMO")).rejects.toThrow(/401/);
+  });
+});
+
+describe("buildConfluenceFetcher pagination cursor (#1189)", () => {
+  // Build a fake fetch Response whose json() yields the given results + optional
+  // `_links.next` cursor. `results` are minimal synthetic Confluence page shapes.
+  function makeResponse(results: Array<{ id: string }>, next?: string) {
+    return {
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      async json() {
+        const body: { results: unknown[]; _links?: { next: string } } = {
+          results: results.map((r) => ({
+            id: r.id,
+            title: `Title ${r.id}`,
+            body: { storage: { value: `<p>Body for ${r.id}</p>` } },
+            space: { key: "DEMO" },
+          })),
+        };
+        if (next !== undefined) body._links = { next };
+        return body;
+      },
+    };
+  }
+
+  it("AC-3: follows _links.next across N=3 pages, restores /wiki prefix, stops on terminal page", async () => {
+    // 3 chained pages. Pages 1 and 2 carry `_links.next` (page 1's omits the
+    // `/wiki` context prefix — the exact real-API shape); the final page has no
+    // next link (clean terminal). baseUrl WITHOUT a trailing slash.
+    const responses = [
+      // page 1 → next omits /wiki (must be restored)
+      makeResponse([{ id: "p1" }], "/rest/api/content?spaceKey=DEMO&expand=body.storage&limit=100&start=100"),
+      // page 2 → next already carries /wiki (must NOT be double-prefixed)
+      makeResponse([{ id: "p2" }], "/wiki/rest/api/content?spaceKey=DEMO&expand=body.storage&limit=100&start=200"),
+      // page 3 → no next link (terminal)
+      makeResponse([{ id: "p3" }]),
+    ];
+    let call = 0;
+    const fetchImpl = jest.fn(async () => responses[call++]) as unknown as typeof fetch;
+
+    const fetcher = buildConfluenceFetcher(
+      { baseUrl: "https://example.atlassian.net", email: "a@b.c", apiToken: "tok" },
+      fetchImpl,
+    );
+    const pages = await fetcher.fetchPages("DEMO");
+
+    // (a) all pages accumulated — one from every page in the chain
+    expect(pages).toHaveLength(3);
+    const ids = pages.map((p) => p.id).sort();
+    expect(ids).toEqual(["p1", "p2", "p3"]);
+
+    // (b) fetchImpl called EXACTLY N=3 times — walks every page, stops on the
+    // terminal page (no over-/under-fetch).
+    const mock = fetchImpl as unknown as jest.Mock;
+    expect(mock).toHaveBeenCalledTimes(3);
+
+    // (c) /wiki prefix restored on the cursor that omitted it. Call index 1 is
+    // the follow-up driven by page 1's `_links.next` (which lacked /wiki).
+    const followUpUrl = mock.mock.calls[1][0] as string;
+    expect(followUpUrl).toContain("/wiki/rest/api/content");
+    expect(followUpUrl).toContain("start=100");
+    // Exactly ONE slash between host and /wiki (trailing-slash-trim join).
+    expect(followUpUrl).toBe(
+      "https://example.atlassian.net/wiki/rest/api/content?spaceKey=DEMO&expand=body.storage&limit=100&start=100",
+    );
+    // Page 2's cursor already had /wiki — confirm it was NOT double-prefixed.
+    const thirdUrl = mock.mock.calls[2][0] as string;
+    expect(thirdUrl).not.toContain("/wiki/wiki");
+    expect(thirdUrl).toContain("/wiki/rest/api/content");
+  });
+
+  it("AC-3b: trailing-slash baseUrl does not double-slash the first or followed URL", async () => {
+    const responses = [
+      makeResponse([{ id: "p1" }], "/rest/api/content?spaceKey=DEMO&expand=body.storage&limit=100&start=100"),
+      makeResponse([{ id: "p2" }]),
+    ];
+    let call = 0;
+    const fetchImpl = jest.fn(async () => responses[call++]) as unknown as typeof fetch;
+    const fetcher = buildConfluenceFetcher(
+      { baseUrl: "https://example.atlassian.net/", email: "a@b.c", apiToken: "tok" },
+      fetchImpl,
+    );
+    await fetcher.fetchPages("DEMO");
+    const mock = fetchImpl as unknown as jest.Mock;
+    const firstUrl = mock.mock.calls[0][0] as string;
+    const followUpUrl = mock.mock.calls[1][0] as string;
+    expect(firstUrl).toBe(
+      "https://example.atlassian.net/wiki/rest/api/content?spaceKey=DEMO&expand=body.storage&limit=100",
+    );
+    expect(followUpUrl).toBe(
+      "https://example.atlassian.net/wiki/rest/api/content?spaceKey=DEMO&expand=body.storage&limit=100&start=100",
+    );
+  });
+
+  it("AC-4: MAX_PAGES guard terminates a perpetual non-empty cursor at exactly MAX_PAGES", async () => {
+    // Every response has NON-EMPTY results (so the empty-page guard cannot fire)
+    // and ALWAYS carries a next link (cursor never terminates). Only MAX_PAGES
+    // can stop the loop.
+    let n = 0;
+    const fetchImpl = jest.fn(async () => {
+      n++;
+      return makeResponse(
+        [{ id: `page-${n}` }],
+        `/rest/api/content?spaceKey=DEMO&expand=body.storage&limit=100&start=${n * 100}`,
+      );
+    }) as unknown as typeof fetch;
+
+    const fetcher = buildConfluenceFetcher(
+      { baseUrl: "https://example.atlassian.net", email: "a@b.c", apiToken: "tok" },
+      fetchImpl,
+    );
+    const pages = await fetcher.fetchPages("DEMO");
+
+    const mock = fetchImpl as unknown as jest.Mock;
+    // Loops far past the single first fetch, and stops at EXACTLY the cap.
+    expect(mock.mock.calls.length).toBeGreaterThan(1);
+    expect(mock).toHaveBeenCalledTimes(MAX_PAGES);
+    expect(MAX_PAGES).toBe(1000);
+    // Completed (returned) rather than hung; accumulated one page per fetch.
+    expect(pages).toHaveLength(MAX_PAGES);
+  });
+
+  it("AC-5: regression guard — empty page with a dangling cursor stops (does not spin)", async () => {
+    // A page returns ZERO results but STILL hands back a `_links.next`. The loop
+    // must stop on the empty-results guard rather than follow the dangling
+    // cursor forever. (Regression guard — NOT counted as proof of the #1189 fix.)
+    const fetchImpl = jest.fn(async () =>
+      makeResponse([], "/rest/api/content?spaceKey=DEMO&expand=body.storage&limit=100&start=100"),
+    ) as unknown as typeof fetch;
+
+    const fetcher = buildConfluenceFetcher(
+      { baseUrl: "https://example.atlassian.net", email: "a@b.c", apiToken: "tok" },
+      fetchImpl,
+    );
+    const pages = await fetcher.fetchPages("DEMO");
+
+    const mock = fetchImpl as unknown as jest.Mock;
+    expect(mock).toHaveBeenCalledTimes(1);
+    expect(pages).toHaveLength(0);
   });
 });
 


### PR DESCRIPTION
## What
`buildConfluenceFetcher` fetched only the first page and ignored the `_links.next` cursor, so any Confluence space larger than the page limit (~100 pages) was **silently truncated** — the downstream knowledge ingest saw ~1/3 of a large space (#1189).

## Fix
- Walk `_links.next` to exhaustion inside the existing `fetchPages` closure (injected `fetchImpl` seam preserved).
- Restore the `/wiki` context prefix when the cursor path omits it (the v1 content API returns a `/wiki`-less next path); never double-prefix.
- `MAX_PAGES = 1000` guard (exported) mirroring `src/jira/sync.ts`, with three stop conditions: no next link, page cap, empty-page-with-cursor.
- Corrected the stale `#1189` doc-comments that claimed cursors were unfollowed.

## Tests (synthetic fake `fetchImpl`, no network)
- **AC-3** — N=3 pages chained via `_links.next` (one omitting `/wiki`): all accumulated, exact call count, prefix restored, single trailing-slash join.
- **AC-4** — perpetual non-empty cursor stops at exactly `MAX_PAGES`, no hang.
- **AC-5** — empty-page-with-cursor regression guard.

Each proof-of-fix test was confirmed RED against the original single-fetch code and GREEN after the fix (baseline-red reproduced independently in execution-review).

`npm run typecheck` exit 0 · `npm test` 34 suites / 293 tests green.

Built via the 4-role chain (planner → plan-review → executor → execution-review, all PASS).

https://claude.ai/code/session_018TnaPsVNYG78F7y2YipqWL