### PR TITLE
refactor(triage): reframe defect taxonomy to a symptom axis (S1, #1284)

### DIFF
--- a/src/triage/categorizeDefect.ts
+++ b/src/triage/categorizeDefect.ts
@@ -1,43 +1,50 @@
 /**
  * Pure, deterministic defect categorizer — no I/O, no network, no LLM.
  *
- * Given a defect's structural signals (summary + description text + labels +
- * issuetype), an ordered rule table assigns exactly ONE `DefectCategory`. The
- * table is evaluated in PRECEDENCE order (first match wins); anything that
- * matches no rule lands in `other` via the fallback. The categorizer is the
- * reusable core EPIC #1280 calls directly (no CLI / env coupling).
+ * Given a defect's text (summary + optional description), an ordered rule table
+ * assigns exactly ONE `DefectCategory` by SYMPTOM — the way a user describes what
+ * went wrong, not the way a developer would tag the underlying task. The table is
+ * evaluated in PRECEDENCE order (first match wins); anything that matches no rule
+ * lands in `other` via the fallback. The categorizer is the reusable core EPIC
+ * #1280 calls directly (no CLI / env coupling).
  *
- * Rules key ONLY on generic structural tokens (defect-type words, public
- * Atlassian field/label/issuetype names) — never on internal hostnames,
- * project/space keys, codenames, or colleague identifiers.
+ * Rules key ONLY on generic English symptom words (crash / cannot / wrong /
+ * missing / button / navigate / slow …) — never on product names, feature names,
+ * codenames, hostnames, project/space keys, or colleague identifiers.
  */
 
 /**
- * The defect taxonomy.
+ * The defect symptom taxonomy.
  *
- * IMPORTANT: the DECLARATION order below is an arbitrary, readable order and is
- * INTENTIONALLY NOT the precedence order. Tie-breaking uses a SEPARATE precedence
- * defined by `RULES` below (`correctness-bug > type-safety > test-infra >
- * code-quality > documentation > enhancement > other`). Do NOT "align" the two —
- * they are deliberately distinct, and AC-5 asserts the precedence directly.
+ * DECLARATION order below IS the precedence order (highest → lowest), with `other`
+ * as the fallback. One ordered set serves as both the readable declaration order
+ * and the first-match-wins precedence:
+ *
+ *   crash-error > cannot-complete > data-incorrect > missing-element >
+ *   display-ui > navigation-flow > performance > other
+ *
+ * The precedence is still asserted directly by the precedence test (via the
+ * behavior of a colliding fixture), independent of this array's order.
  */
 export type DefectCategory =
-  | "correctness-bug"
-  | "code-quality"
-  | "documentation"
-  | "test-infra"
-  | "type-safety"
-  | "enhancement"
+  | "crash-error"
+  | "cannot-complete"
+  | "data-incorrect"
+  | "missing-element"
+  | "display-ui"
+  | "navigation-flow"
+  | "performance"
   | "other";
 
-/** Every category value, in declaration order — used to seed a complete tally. */
+/** Every category value, in precedence/declaration order — seeds a complete tally. */
 export const DEFECT_CATEGORIES: readonly DefectCategory[] = [
-  "correctness-bug",
-  "code-quality",
-  "documentation",
-  "test-infra",
-  "type-safety",
-  "enhancement",
+  "crash-error",
+  "cannot-complete",
+  "data-incorrect",
+  "missing-element",
+  "display-ui",
+  "navigation-flow",
+  "performance",
   "other",
 ];
 
@@ -70,48 +77,47 @@ interface DefectRule {
 
 /**
  * Ordered rule table — evaluated top-to-bottom, FIRST MATCH WINS. The order here
- * IS the precedence: correctness-bug > type-safety > test-infra > code-quality >
- * documentation > enhancement. A defect matching multiple rules resolves to the
- * highest one (AC-5). Nothing here keys on `issueType: "Bug"` alone, so a
- * type-safety task tagged Bug is not swallowed by correctness-bug.
+ * IS the precedence (see `DEFECT_CATEGORIES`). A defect matching multiple rules
+ * resolves to the highest one. Every regex keys ONLY on generic English symptom
+ * words; the `labels`/`issueTypes` fields stay on the interface for
+ * shape-compatibility but the symptom rules do not rely on them (a symptom is a
+ * text phenomenon; corpus labels/issuetypes are product-specific → privacy risk).
  */
 const RULES: readonly DefectRule[] = [
   {
-    category: "correctness-bug",
-    name: "correctness-bug:keyword",
-    text: /\b(crash(?:es|ed)?|broken|incorrect|wrong|regress(?:ion|es|ed)?|exception|throws?|swallow(?:s|ed)?|hang(?:s|ed)?|deadlock|race condition|memory leak|null pointer|npe|returns? empty|infinite loop|off-by-one|corrupt(?:s|ed|ion)?|fails?|failing|errors?)\b/i,
-    labels: ["bug"],
+    category: "crash-error",
+    name: "crash-error:keyword",
+    text: /\b(crash(?:e[sd]|ing)?|freeze|frozen|freezing|hang(?:s|ing)?|stuck|anr|force ?clos(?:e|ed|ing)|exception|fatal|reboot(?:s|ed|ing)?|restart(?:s|ed|ing)?|error(?:s|ed)?|bug(?:s|ged)?|glitch)\b/i,
   },
   {
-    category: "type-safety",
-    name: "type-safety:keyword",
-    text: /\b(type|types|typing|typed|typecheck|type-safety|typesafe|cast|casting|generic|generics|nullable|non-null|narrow(?:ing)?)\b/i,
-    labels: ["type-safety", "typing"],
+    category: "cannot-complete",
+    name: "cannot-complete:keyword",
+    text: /\b(can ?not|cant|can.?t|unable|not able|doesn.?t|does not|won.?t|will not|fail(?:s|ed|ing|ure)?|not work(?:ing)?|no response|unresponsive|block(?:s|ed)?|disabled|greyed|grayed|stop(?:s|ped|ping)? working|unavailable|reject(?:s|ed|ing)?)\b/i,
   },
   {
-    category: "test-infra",
-    name: "test-infra:keyword",
-    text: /\b(test|tests|testing|spec|specs|mock(?:s|ed)?|fixture|fixtures|ci|flaky|hoist|test-runner|jest|snapshot|e2e|coverage|stub|stubs)\b/i,
-    labels: ["test", "test-infra", "ci"],
+    category: "data-incorrect",
+    name: "data-incorrect:keyword",
+    text: /\b(wrong|incorrect|mismatch|not match|inaccurate|miscalc(?:ulat\w*)?|invalid|should be|instead of|not correct|calcul\w*|amount|price|fee|total|count|balance|number|value|duplicat\w*|wrongly|null|reflect(?:s|ed|ing)?|update(?:s|d|ing)?|outdated|sync(?:s|ed|ing|hroni\w*)?|reset(?:s|ting)?)\b/i,
   },
   {
-    category: "code-quality",
-    name: "code-quality:keyword",
-    text: /\b(refactor(?:ing)?|dedupe|deduplicate|duplicat(?:e|ed|ion)|cleanup|clean up|rename|extract|simplify|lint|tidy|consolidate|readability|dead code)\b/i,
-    labels: ["refactor", "chore", "tech-debt"],
+    category: "missing-element",
+    name: "missing-element:keyword",
+    text: /\b(missing|not show(?:n|ing)?|not display(?:ed|ing)?|not appear(?:ing)?|blank|empty|no data|not visible|disappear(?:s|ed|ing)?|absent|without|gone|nothing show)\b/i,
   },
   {
-    category: "documentation",
-    name: "documentation:keyword",
-    text: /\b(doc|docs|document|documentation|readme|changelog|comment|comments|typo|wording|link|links|guide|tutorial|docstring|javadoc)\b/i,
-    labels: ["docs", "documentation"],
+    category: "display-ui",
+    name: "display-ui:keyword",
+    text: /\b(ui|layout|align(?:ment|ed)?|overlap(?:s|ping|ped)?|cut ?off|button|icon|colou?r|font|spacing|display|design|truncat\w*|responsive|scroll(?:s|ing)?|padding|margin|image|photo|text|label|popup|pop-up|modal|banner|grey|gray|black|white|keyboard|swipe|tap|stack(?:s|ed|ing)?|indicator|toggle|theme)\b/i,
   },
   {
-    category: "enhancement",
-    name: "enhancement:keyword",
-    text: /\b(add|adds|added|feature|features|support|enhance(?:ment)?|improve(?:ment)?|introduce|new|option|optional|knob|configurable|extend)\b/i,
-    labels: ["enhancement", "feature"],
-    issueTypes: ["story", "epic", "new feature", "feature"],
+    category: "navigation-flow",
+    name: "navigation-flow:keyword",
+    text: /\b(navigat\w*|redirect(?:s|ed|ing)?|back button|transition(?:s|ed|ing)?|route(?:s|d|ing)?|deep ?link|flow)\b/i,
+  },
+  {
+    category: "performance",
+    name: "performance:keyword",
+    text: /\b(slow(?:ness|ly)?|lag(?:s|ging|gy)?|delay(?:s|ed)?|timed? ?out|timeout|loading|performance|takes? (?:too )?long|laggy|spinner|spinning|stutter\w*)\b/i,
   },
 ];
 
@@ -124,8 +130,8 @@ function ruleMatches(rule: DefectRule, text: string, labels: string[], issueType
 
 /**
  * Categorize a single defect. Deterministic + pure: the same input always yields
- * the same `{ category, matchedRule }` (AC-4). First matching rule in precedence
- * order wins (AC-5); no match → `{ category: "other", matchedRule: "fallback" }`.
+ * the same `{ category, matchedRule }`. First matching rule in precedence order
+ * wins; no match → `{ category: "other", matchedRule: "fallback" }`.
  */
 export function categorizeDefect(input: DefectInput): { category: DefectCategory; matchedRule: string } {
   const text = `${input.summary ?? ""} ${input.descriptionText ?? ""}`;
@@ -143,7 +149,7 @@ export function categorizeDefect(input: DefectInput): { category: DefectCategory
 /**
  * Categorize a list of defects and aggregate the grouped counts. `counts` is
  * seeded with EVERY category at 0 (so the shape is stable + no category is
- * silently absent), then incremented per result (AC-6).
+ * silently absent), then incremented per result.
  */
 export function categorizeAll(inputs: DefectInput[]): {
   results: DefectResult[];

--- a/tests/jira.categoryWriter.test.ts
+++ b/tests/jira.categoryWriter.test.ts
@@ -16,7 +16,7 @@ describe("buildJiraCategoryWriter — outward write (mocked, never live)", () =>
       fetchImpl,
     );
 
-    await writer.setCategory("PROJ-42", "correctness-bug");
+    await writer.setCategory("PROJ-42", "crash-error");
 
     expect((fetchImpl as unknown as jest.Mock)).toHaveBeenCalledTimes(1);
     const [url, init] = (fetchImpl as unknown as jest.Mock).mock.calls[0] as [
@@ -28,7 +28,7 @@ describe("buildJiraCategoryWriter — outward write (mocked, never live)", () =>
     expect(init.headers.Authorization).toMatch(/^Basic /);
     expect(init.headers["Content-Type"]).toBe("application/json");
     const body = JSON.parse(init.body);
-    expect(body).toEqual({ update: { labels: [{ add: "defect-category:correctness-bug" }] } });
+    expect(body).toEqual({ update: { labels: [{ add: "defect-category:crash-error" }] } });
   });
 
   it("honors a configurable label prefix", async () => {
@@ -45,9 +45,9 @@ describe("buildJiraCategoryWriter — outward write (mocked, never live)", () =>
       fetchImpl,
       { labelPrefix: "kind" },
     );
-    await writer.setCategory("PROJ-9", "documentation");
+    await writer.setCategory("PROJ-9", "display-ui");
     const init = (fetchImpl as unknown as jest.Mock).mock.calls[0][1] as { body: string };
-    expect(JSON.parse(init.body)).toEqual({ update: { labels: [{ add: "kind:documentation" }] } });
+    expect(JSON.parse(init.body)).toEqual({ update: { labels: [{ add: "kind:display-ui" }] } });
   });
 
   it("throws on a non-2xx response and on an empty issueKey", async () => {

--- a/tests/triage.categorizeDefect.test.ts
+++ b/tests/triage.categorizeDefect.test.ts
@@ -7,42 +7,52 @@ import {
 } from "../src/triage/categorizeDefect";
 
 /**
- * Synthetic fixtures — ALL invented placeholder text shaped like real entries.
- * No internal hostname, project/space key, colleague name, or codename (PS-1/PS-2).
- * One fixture per category, including the `other` fallback.
+ * Synthetic fixtures — ALL invented, generic-English symptom sentences. No real
+ * defect text, product name, feature name, codename, hostname, or project/space
+ * key. One fixture per symptom category, including the `other` fallback.
+ *
+ * Fixture-isolation: `cannot-complete` and `display-ui` are broad + high in
+ * precedence, so each per-bucket fixture is crafted to trigger on a word UNIQUE to
+ * its intended bucket and to avoid any higher-precedence bucket's vocabulary
+ * (precedence: crash-error > cannot-complete > data-incorrect > missing-element >
+ * display-ui > navigation-flow > performance > other).
  */
 const SYNTHETIC: Array<{ input: DefectInput; expected: DefectCategory }> = [
   {
-    input: { key: "X-1", summary: "handler silently swallows errors and returns empty", issueType: "Bug" },
-    expected: "correctness-bug",
+    input: { key: "X-1", summary: "the application crashed unexpectedly on launch" },
+    expected: "crash-error",
   },
   {
-    input: { key: "X-2", summary: "rename mockFoo for test-runner hoist compatibility", labels: ["chore"] },
-    expected: "test-infra",
+    input: { key: "X-2", summary: "the user is unable to submit the new entry" },
+    expected: "cannot-complete",
   },
   {
-    input: { key: "X-3", summary: "doc page: link the changelog instead of an inline date", issueType: "Task" },
-    expected: "documentation",
+    input: { key: "X-3", summary: "the running total shows the wrong amount" },
+    expected: "data-incorrect",
   },
   {
-    input: { key: "X-4", summary: "tighten the Foo type to forbid the empty case", issueType: "Bug" },
-    expected: "type-safety",
+    input: { key: "X-4", summary: "the avatar is missing after saving" },
+    expected: "missing-element",
   },
   {
-    input: { key: "X-5", summary: "extract duplicated factory into one helper", labels: ["refactor"] },
-    expected: "code-quality",
+    input: { key: "X-5", summary: "the button label overlaps the icon" },
+    expected: "display-ui",
   },
   {
-    input: { key: "X-6", summary: "add an optional pagination knob to the fetcher", issueType: "Story" },
-    expected: "enhancement",
+    input: { key: "X-6", summary: "the navigation transition skips a route" },
+    expected: "navigation-flow",
   },
   {
-    input: { key: "X-7", summary: "miscellaneous unclassifiable note", labels: [] },
+    input: { key: "X-7", summary: "the feed is very slow and takes too long" },
+    expected: "performance",
+  },
+  {
+    input: { key: "X-8", summary: "general miscellaneous note" },
     expected: "other",
   },
 ];
 
-describe("categorizeDefect — taxonomy + rules", () => {
+describe("categorizeDefect — symptom taxonomy + rules", () => {
   it("AC-3: at least one synthetic input lands in EACH category (incl. other) — no dead category", () => {
     const landed = new Set<DefectCategory>();
     for (const { input, expected } of SYNTHETIC) {
@@ -56,34 +66,34 @@ describe("categorizeDefect — taxonomy + rules", () => {
     }
   });
 
-  it("AC-4: determinism — same input twice yields an identical result", () => {
+  it("AC-5: determinism — same input twice yields an identical result", () => {
     for (const { input } of SYNTHETIC) {
       const a = categorizeDefect(input);
       const b = categorizeDefect(input);
       expect(a).toEqual(b);
     }
-    // A representative deep-equality check, not just category.
-    const sample = { summary: "crash: null pointer exception in the cast path" };
+    // A representative deep-equality check, not just category (re-grounded to a
+    // new-taxonomy fixture that lands in crash-error).
+    const sample = { summary: "the application crashed unexpectedly" };
     expect(categorizeDefect(sample)).toEqual(categorizeDefect(sample));
   });
 
-  it("AC-5: precedence — an input matching two type-rules resolves to the higher one", () => {
-    // Matches BOTH correctness-bug (crash/throws/null pointer/exception) AND
-    // type-safety (cast/type). Precedence: correctness-bug > type-safety.
-    const multi: DefectInput = {
-      summary: "crash: the cast to the Foo type throws a null pointer exception",
+  it("AC-4: precedence — an input matching two rules resolves to the HIGHER one", () => {
+    // Collision near the TOP: matches crash-error (crashed) AND data-incorrect
+    // (wrong/total). Precedence: crash-error > data-incorrect.
+    const high: DefectInput = {
+      summary: "the app crashed and then showed the wrong total",
     };
-    const { category } = categorizeDefect(multi);
-    expect(category).toBe("correctness-bug");
+    expect(categorizeDefect(high).category).toBe("crash-error");
 
-    // And a test-infra vs code-quality collision: "rename" (code-quality) +
-    // "test-runner"/"mock" (test-infra). Precedence: test-infra > code-quality.
-    const collide: DefectInput = { summary: "rename the mock in the test-runner setup" };
-    expect(categorizeDefect(collide).category).toBe("test-infra");
+    // A SECOND collision LOWER in the order: matches navigation-flow (redirect)
+    // AND performance (slow/laggy). Precedence: navigation-flow > performance.
+    const low: DefectInput = { summary: "the redirect is slow and laggy" };
+    expect(categorizeDefect(low).category).toBe("navigation-flow");
   });
 
   it("fallback — an unmatched input is `other` / matchedRule: fallback", () => {
-    const r = categorizeDefect({ summary: "miscellaneous unclassifiable note" });
+    const r = categorizeDefect({ summary: "general miscellaneous note" });
     expect(r.category).toBe("other");
     expect(r.matchedRule).toBe("fallback");
   });

--- a/tests/triage.cli.test.ts
+++ b/tests/triage.cli.test.ts
@@ -5,8 +5,8 @@ import type { JiraIssue } from "../src/jira/sync";
 
 /** Two synthetic open defects, both with keys (so --apply has something to write). */
 const FIXTURE_ISSUES: JiraIssue[] = [
-  { key: "X-1", summary: "handler swallows an error", descriptionText: "", commentTexts: [], issueType: "Bug" },
-  { key: "X-2", summary: "add an optional knob", descriptionText: "", commentTexts: [], issueType: "Story" },
+  { key: "X-1", summary: "the app crashed on launch", descriptionText: "", commentTexts: [], issueType: "Bug" },
+  { key: "X-2", summary: "the running total shows the wrong amount", descriptionText: "", commentTexts: [], issueType: "Bug" },
 ];
 
 /** A writer spy whose setCategory is bound to a fake — NEVER live Jira. */
@@ -48,8 +48,8 @@ describe("run(deps) — dry-run default + flag-gated outward write (AC-7)", () =
     expect(result.applied).toBe(FIXTURE_ISSUES.length);
     // Each write stamps the computed category for that key.
     expect(calls).toEqual([
-      ["X-1", "correctness-bug"],
-      ["X-2", "enhancement"],
+      ["X-1", "crash-error"],
+      ["X-2", "data-incorrect"],
     ]);
   });
 
@@ -58,7 +58,7 @@ describe("run(deps) — dry-run default + flag-gated outward write (AC-7)", () =
     // is a spy. Proves both ends bind to fakes.
     const rawIssue = {
       key: "X-9",
-      fields: { summary: "doc: link the changelog", description: null, comment: { comments: [] } },
+      fields: { summary: "the feed is slow and laggy", description: null, comment: { comments: [] } },
     };
     const fetchImpl = jest.fn(async () => ({
       ok: true,
@@ -81,6 +81,6 @@ describe("run(deps) — dry-run default + flag-gated outward write (AC-7)", () =
       log: () => undefined,
     });
     expect(calls).toHaveLength(0);
-    expect(result.counts.documentation).toBe(1);
+    expect(result.counts.performance).toBe(1);
   });
 });

--- a/tests/triage.seam.test.ts
+++ b/tests/triage.seam.test.ts
@@ -15,12 +15,12 @@ describe("AC-12 — #1280 reuse seam (importable, no CLI/env coupling)", () => {
     const envBefore = JSON.stringify(process.env);
 
     const { results, counts } = categorizeAll([
-      { key: "S-1", summary: "crash on null pointer", issueType: "Bug" },
-      { key: "S-2", summary: "update the readme doc", issueType: "Task" },
+      { key: "S-1", summary: "the app crashed on launch", issueType: "Bug" },
+      { key: "S-2", summary: "the running total shows the wrong amount", issueType: "Bug" },
     ]);
     expect(results).toHaveLength(2);
-    expect(counts["correctness-bug"]).toBe(1);
-    expect(counts.documentation).toBe(1);
+    expect(counts["crash-error"]).toBe(1);
+    expect(counts["data-incorrect"]).toBe(1);
 
     const writes: Array<[string, string]> = [];
     const fetchImpl = jest.fn(async (_url: unknown, init: unknown) => {


### PR DESCRIPTION
## What
The old defect taxonomy classified on a **developer-task** axis (correctness-bug / type-safety / test-infra / code-quality / documentation / enhancement). Real product defects are written in **symptom** language, so ~62% fell through to `other` — a wrong-axis problem, not a missing-synonym one (see the #1308 verdict).

## Change
Replace it with an operator-approved **8-bucket symptom taxonomy**, precedence first-match-wins:
`crash-error > cannot-complete > data-incorrect > missing-element > display-ui > navigation-flow > performance > other`

Deterministic, **no LLM, no outward writes**. Rules key only on generic English symptom words. `cli.ts` iterates `DEFECT_CATEGORIES` and auto-adapts; the four consumer tests' fixtures + expected values were rewritten to the new axis.

## Result
Local re-measurement over the full defect corpus: **`other` drops to 13.51%** (35/259), down from ~62%. The ≤10% stretch was honestly not reached — the residual is dominated by terse product-feature labels carrying no generic symptom verb, and closing further would require keying on product-specific tokens (forbidden in this public repo). Committed tests use **synthetic** fixtures only; the corpus is never committed.

Built via the 4-role chain (planner → plan-review → executor → execution-review, all PASS). Privacy scan clean (no product/feature/host tokens committed). `npm run typecheck` exit 0 · `npm test` 34 suites / 289 tests green.

This is **S1** of the #1284 follow-up; S2–S4 (Confluence feature/flow catalog + semantic Layer-2 mapping) follow separately.

https://claude.ai/code/session_018TnaPsVNYG78F7y2YipqWL