### PR TITLE
feat: Confluence feature/flow catalog tooling (#1314 S2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "typecheck": "tsc --noEmit && tsc --noEmit -p tsconfig.test.json",
     "eval:recall": "npm run build && node scripts/eval-recall.js",
     "eval:golden": "npm run build && node scripts/eval-golden.js",
-    "triage:categorize": "npm run build && node scripts/categorize-defects.js"
+    "triage:categorize": "npm run build && node scripts/categorize-defects.js",
+    "catalog:build": "npm run build && node scripts/build-catalog.js"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/scripts/build-catalog.js
+++ b/scripts/build-catalog.js
@@ -1,0 +1,139 @@
+#!/usr/bin/env node
+/*
+ * build-catalog.js — thin I/O shell over the injectable catalog CLI core
+ * (`dist/catalog/cli.js` -> run(deps)).
+ *
+ * Reads every page of a Confluence space (REUSING the real fetcher — no
+ * re-implemented pagination), asks ONE LLM distiller to draft a feature/flow
+ * "menu", and writes it to a GITIGNORED file the operator then reviews/edits.
+ *
+ * Privacy: the catalog carries internal product names, so it is written ONLY to
+ * the gitignored output path. stdout shows COUNTS/STRUCTURE ONLY — never a
+ * label, page body/title/id, space key, host, or email. All creds + targets
+ * come from env ONLY (gitignored .env; this repo is PUBLIC). The env-cred
+ * construction lives HERE, in the outer shell — `run(deps)` itself is cred-free
+ * and injectable so tests drive it against fakes.
+ *
+ *   Build it:  node --env-file=.env scripts/build-catalog.js
+ *
+ * Env: CONFLUENCE_URL (or CONFLUENCE_BASE_URL), CONFLUENCE_EMAIL,
+ *      CONFLUENCE_API_TOKEN, CONFLUENCE_SPACES (comma-separated; the FIRST entry
+ *      is cataloged). Optional ANTHROPIC_MODEL overrides the distiller model.
+ */
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+
+const DIST = path.resolve(__dirname, "..", "dist");
+// Reuses the REAL paginating fetcher from dist/confluence/sync (#1309) — the
+// shell wires its bound `fetchPages` in as the injected read seam; the catalog
+// module never re-implements pagination/endpoints (AC-REUSE-FETCHER).
+const { run, CATALOG_OUTPUT_PATH, CATALOG_REGENERATED_PATH, chooseWritePath } = require(
+  path.join(DIST, "catalog", "cli"),
+);
+const { buildConfluenceFetcher } = require(path.join(DIST, "confluence", "sync"));
+const { getClient } = require(path.join(DIST, "llm", "anthropicClient"));
+
+/** Strip a trailing /wiki (and trailing slash) so buildConfluenceFetcher gets the site root. */
+function toSiteRoot(url) {
+  return url.replace(/\/wiki\/?$/, "").replace(/\/$/, "");
+}
+
+function splitList(raw) {
+  return (raw || "")
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+/**
+ * The production CatalogDistiller — the single LLM boundary. Wraps
+ * getClient().messages.create() and parses a strict JSON reply. Tests NEVER
+ * reach this (they inject a fake), so the unit suite makes zero model calls.
+ */
+function buildLlmDistiller() {
+  const model = process.env.ANTHROPIC_MODEL || "claude-haiku-4-5-20251001";
+  return {
+    async distill(pages) {
+      const client = getClient();
+      const corpus = pages
+        .map((p) => `### PAGE id=${p.id} title=${JSON.stringify(p.title)}\n${p.body}`)
+        .join("\n\n");
+      const instructions =
+        "You are cataloging a product's wiki. From the pages below, produce a JSON " +
+        "object with two arrays: `features` (the product's capabilities) and `flows` " +
+        "(the journeys a user takes). Each array element is " +
+        '`{ "label": string, "provenancePageIds": string[] }`, where provenancePageIds ' +
+        "are the `id` values of the pages that entry was drawn from. Respond with JSON ONLY.";
+      const res = await client.messages.create({
+        model,
+        max_tokens: 4096,
+        temperature: 0,
+        messages: [{ role: "user", content: `${instructions}\n\n${corpus}` }],
+      });
+      const text = Array.isArray(res.content)
+        ? res.content
+            .filter((b) => b && b.type === "text" && typeof b.text === "string")
+            .map((b) => b.text)
+            .join("")
+        : "";
+      const jsonStart = text.indexOf("{");
+      const jsonEnd = text.lastIndexOf("}");
+      if (jsonStart === -1 || jsonEnd === -1 || jsonEnd <= jsonStart) {
+        throw new Error("catalog distiller: model reply contained no JSON object");
+      }
+      const parsed = JSON.parse(text.slice(jsonStart, jsonEnd + 1));
+      return {
+        features: Array.isArray(parsed.features) ? parsed.features : [],
+        flows: Array.isArray(parsed.flows) ? parsed.flows : [],
+      };
+    },
+  };
+}
+
+async function main() {
+  const env = process.env;
+  const url = env.CONFLUENCE_URL || env.CONFLUENCE_BASE_URL;
+  const email = env.CONFLUENCE_EMAIL;
+  const apiToken = env.CONFLUENCE_API_TOKEN;
+  const spaces = splitList(env.CONFLUENCE_SPACES);
+
+  if (!url || !email || !apiToken || spaces.length === 0) {
+    console.error(
+      "build-catalog: missing config. Need CONFLUENCE_URL (or CONFLUENCE_BASE_URL), " +
+        "CONFLUENCE_EMAIL, CONFLUENCE_API_TOKEN, and a non-empty CONFLUENCE_SPACES.",
+    );
+    process.exit(1);
+  }
+
+  const config = { baseUrl: toSiteRoot(url), email, apiToken };
+  const spaceKey = spaces[0];
+  const fetcher = buildConfluenceFetcher(config, globalThis.fetch);
+
+  // No-clobber sink: write to the regenerated sibling if a catalog already
+  // exists (don't overwrite operator edits); else to the primary path.
+  const writeCatalog = async (catalog) => {
+    const target = chooseWritePath(CATALOG_OUTPUT_PATH, CATALOG_REGENERATED_PATH, fs.existsSync);
+    fs.mkdirSync(path.dirname(target), { recursive: true });
+    fs.writeFileSync(target, `${JSON.stringify(catalog, null, 2)}\n`, "utf-8");
+  };
+
+  const result = await run({
+    fetchPages: (key) => fetcher.fetchPages(key),
+    distiller: buildLlmDistiller(),
+    writeCatalog,
+    spaceKey,
+  });
+
+  // Counts/structure ONLY — never a label, body, id, space key, host, or email.
+  console.log(
+    `\nDone: ${result.pagesIngested} pages ingested, ${result.featureCount} features, ` +
+      `${result.flowCount} flows distilled.`,
+  );
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/catalog/cli.ts
+++ b/src/catalog/cli.ts
@@ -1,0 +1,96 @@
+import { distillCatalog } from "./distill";
+import { CatalogDistiller, CatalogPage, FeatureCatalog } from "./types";
+
+/**
+ * Injectable CLI core for the catalog tooling (#1314 S2).
+ *
+ * Orchestrates ingest -> distill -> write. Both effectful seams are INJECTED:
+ *   - `fetchPages` is the bound method of the REUSED `src/confluence/sync.ts`
+ *     fetcher (production) or a stub (tests). NO pagination/endpoint logic lives
+ *     here — that stays in `src/confluence/sync.ts` (fixed #1309).
+ *   - `distiller` is the single LLM boundary; a fake in tests means ZERO network.
+ *   - `writeCatalog` is the sink: fs in the shell, in-memory in tests.
+ *
+ * The logger emits COUNTS/STRUCTURE ONLY — never a label, body, page id, space
+ * key, host, or email. The catalog (which carries internal product names) is
+ * written ONLY to the gitignored sink.
+ */
+export interface CatalogRunDeps {
+  /** Injected Confluence fetch (the reused fetcher's bound `fetchPages`). */
+  fetchPages: (spaceKey: string) => Promise<CatalogPage[]>;
+  /** Injected single LLM boundary. */
+  distiller: CatalogDistiller;
+  /** Injected sink — writes the gitignored file (shell) / captures in memory (test). */
+  writeCatalog: (catalog: FeatureCatalog) => Promise<void>;
+  /** Confluence space key to ingest. */
+  spaceKey: string;
+  /** Injectable clock for deterministic `generatedAt`. */
+  now?: () => number;
+  /** Counts/structure-only logger sink; defaults to `console.log`. */
+  log?: (msg: string) => void;
+}
+
+export interface CatalogRunResult {
+  featureCount: number;
+  flowCount: number;
+  pagesIngested: number;
+}
+
+/**
+ * Gitignored output path (under the already-gitignored `.ai-workspace/`). The
+ * shell derives its real write target from THIS constant, and AC-GITIGNORED
+ * asserts `git check-ignore` on it (N1) — so the AC tracks the real path the
+ * tool writes, not a drifting literal.
+ */
+export const CATALOG_OUTPUT_PATH = ".ai-workspace/catalog/feature-catalog.json";
+
+/**
+ * No-clobber sibling: when the operator already has an edited catalog at
+ * `CATALOG_OUTPUT_PATH`, a regenerate writes HERE instead so operator edits are
+ * never overwritten (they diff, then adopt).
+ */
+export const CATALOG_REGENERATED_PATH = ".ai-workspace/catalog/feature-catalog.regenerated.json";
+
+/**
+ * Pure path-picker for the no-clobber guard: write to the regenerated sibling if
+ * the primary output already exists, else to the primary. Extracted so the
+ * guard is unit-testable without touching the real filesystem.
+ */
+export function chooseWritePath(
+  outputPath: string,
+  regeneratedPath: string,
+  exists: (p: string) => boolean,
+): string {
+  return exists(outputPath) ? regeneratedPath : outputPath;
+}
+
+export async function run(deps: CatalogRunDeps): Promise<CatalogRunResult> {
+  const log = deps.log ?? ((msg: string) => console.log(msg));
+
+  if (typeof deps.spaceKey !== "string" || deps.spaceKey.length === 0) {
+    throw new TypeError("catalog run: deps.spaceKey must be a non-empty string");
+  }
+
+  // 1. Ingest via the injected (reused) fetcher — no pagination logic here.
+  const pages = await deps.fetchPages(deps.spaceKey);
+  log(`Ingested ${pages.length} pages.`);
+
+  // 2. Distill (the single LLM call lives inside the injected distiller).
+  const catalog = await distillCatalog(pages, { distiller: deps.distiller, now: deps.now });
+
+  // 3. Write the gitignored catalog via the injected sink.
+  await deps.writeCatalog(catalog);
+
+  // 4. Log COUNTS/STRUCTURE ONLY — never a label, body, id, space key, host, email.
+  log(`Distilled ${catalog.features.length} features, ${catalog.flows.length} flows.`);
+  log(
+    `Catalog written to ${CATALOG_OUTPUT_PATH} (gitignored). Open it to review/edit, ` +
+      `then flip "reviewed": true.`,
+  );
+
+  return {
+    featureCount: catalog.features.length,
+    flowCount: catalog.flows.length,
+    pagesIngested: pages.length,
+  };
+}

--- a/src/catalog/distill.ts
+++ b/src/catalog/distill.ts
@@ -1,0 +1,117 @@
+import {
+  CatalogDistiller,
+  CatalogEntry,
+  CatalogPage,
+  FeatureCatalog,
+  RawCatalogEntry,
+} from "./types";
+
+/**
+ * Pure, injectable distill core (#1314 S2).
+ *
+ * Takes the corpus pages + an injected `CatalogDistiller`, and returns a
+ * validated `FeatureCatalog`. The ONLY effectful thing it does is call
+ * `deps.distiller.distill(pages)` (stubbed in tests). Everything after that is
+ * deterministic, in-memory transformation: provenance validation, stable id
+ * assignment, dedup, and a stable sort. NO network, NO fs, NO creds.
+ */
+export interface DistillDeps {
+  distiller: CatalogDistiller;
+  /** Injectable clock for deterministic `generatedAt` in tests. */
+  now?: () => number;
+}
+
+/** Lowercase-alnum-hyphen slug. Collapses runs and trims edge hyphens. */
+function slug(label: string): string {
+  return label
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+/**
+ * Turn raw distiller entries of ONE kind (features OR flows) into validated,
+ * id-stamped, deduped, sorted `CatalogEntry[]`.
+ *
+ * 1. Validate provenance: keep only ids present in the corpus; drop entries
+ *    left with zero valid provenance ids.
+ * 2. Assign a stable id `<prefix>-<slug(label)>` (empty slugs fall back to a
+ *    sentinel so they remain addressable).
+ * 3. Dedup: entries that slug to the SAME id are the same feature/flow — merge
+ *    them, UNIONing their provenance (insertion-ordered, de-duplicated). Because
+ *    same-slug entries merge here, the surviving id space is collision-free by
+ *    construction, so no numeric `-2`/`-3` disambiguation is needed.
+ * 4. Sort by id ascending for deterministic output.
+ */
+function buildEntries(
+  raw: RawCatalogEntry[],
+  prefix: "feature" | "flow",
+  corpusIds: ReadonlySet<string>,
+): CatalogEntry[] {
+  // Map keyed by slug -> merged entry (preserves first-seen label deterministically).
+  const bySlug = new Map<string, { label: string; provenance: string[] }>();
+
+  for (const entry of raw) {
+    const provenance = (entry.provenancePageIds ?? []).filter((id) => corpusIds.has(id));
+    // Drop entries with zero valid provenance (AC-PROVENANCE-PRUNE).
+    if (provenance.length === 0) continue;
+
+    const s = slug(entry.label) || "entry";
+    const existing = bySlug.get(s);
+    if (existing) {
+      // Dedup: union provenance, keeping insertion order without duplicates.
+      for (const id of provenance) {
+        if (!existing.provenance.includes(id)) existing.provenance.push(id);
+      }
+    } else {
+      // De-duplicate provenance within a single entry too.
+      const seeded: string[] = [];
+      for (const id of provenance) {
+        if (!seeded.includes(id)) seeded.push(id);
+      }
+      bySlug.set(s, { label: entry.label, provenance: seeded });
+    }
+  }
+
+  const entries: CatalogEntry[] = [];
+  for (const [s, merged] of bySlug) {
+    entries.push({
+      id: `${prefix}-${s}`,
+      label: merged.label,
+      provenancePageIds: merged.provenance,
+    });
+  }
+
+  // Deterministic order (re-run stability is an AC).
+  entries.sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0));
+  return entries;
+}
+
+/**
+ * Distill a `FeatureCatalog` from the corpus pages using the injected distiller.
+ * `reviewed` is always `false` — the operator flips it after hand-editing.
+ */
+export async function distillCatalog(
+  pages: CatalogPage[],
+  deps: DistillDeps,
+): Promise<FeatureCatalog> {
+  if (!deps || !deps.distiller || typeof deps.distiller.distill !== "function") {
+    throw new TypeError("distillCatalog: deps.distiller with a distill() method is required");
+  }
+  const corpusIds = new Set(pages.map((p) => p.id));
+
+  const raw = await deps.distiller.distill(pages);
+  const rawFeatures = Array.isArray(raw?.features) ? raw.features : [];
+  const rawFlows = Array.isArray(raw?.flows) ? raw.flows : [];
+
+  const features = buildEntries(rawFeatures, "feature", corpusIds);
+  const flows = buildEntries(rawFlows, "flow", corpusIds);
+
+  const nowMs = deps.now ? deps.now() : Date.now();
+  return {
+    generatedAt: new Date(nowMs).toISOString(),
+    reviewed: false,
+    features,
+    flows,
+  };
+}

--- a/src/catalog/types.ts
+++ b/src/catalog/types.ts
@@ -1,0 +1,57 @@
+/**
+ * Shared schema for the Confluence feature/flow catalog (#1314 S2).
+ *
+ * The catalog is a tidy two-list "menu" distilled from the internal wiki: a list
+ * of product FEATURES and a list of user-FLOWS. It is written to a GITIGNORED
+ * file because the labels carry internal product names; nothing here is ever
+ * printed to stdout or committed.
+ *
+ * These interfaces are dependency-free (no fs, no network, no creds) so the
+ * distill core and CLI core can be unit-tested with stubs.
+ */
+
+/** Structural subset of `ConfluencePage` the distiller needs. */
+export interface CatalogPage {
+  id: string;
+  title: string;
+  body: string;
+}
+
+/** One catalog entry (a feature or a flow). */
+export interface CatalogEntry {
+  /** STABLE, deterministic id derived from the label (see distill.ts). */
+  id: string;
+  /** Human-readable name — INTERNAL; lives only in the gitignored output file. */
+  label: string;
+  /** Corpus page ids this entry was distilled from (always a subset of the corpus). */
+  provenancePageIds: string[];
+}
+
+/** The full catalog document — the stable contract S3 will consume. */
+export interface FeatureCatalog {
+  /** ISO timestamp; an injected `now()` keeps tests deterministic. */
+  generatedAt: string;
+  /** Always `false` on generation — the operator flips it after hand-editing. */
+  reviewed: boolean;
+  features: CatalogEntry[];
+  flows: CatalogEntry[];
+}
+
+/** A raw entry as returned by the distiller, BEFORE validation/id-assignment. */
+export interface RawCatalogEntry {
+  label: string;
+  provenancePageIds: string[];
+}
+
+/**
+ * The SINGLE LLM boundary of the catalog tooling. The production implementation
+ * wraps `getClient().messages.create(...)` and parses the JSON reply; tests
+ * inject a fake that returns canned raw entries, so the unit suite makes ZERO
+ * network and ZERO real model calls.
+ */
+export interface CatalogDistiller {
+  distill(pages: CatalogPage[]): Promise<{
+    features: RawCatalogEntry[];
+    flows: RawCatalogEntry[];
+  }>;
+}

--- a/tests/catalog.test.ts
+++ b/tests/catalog.test.ts
@@ -1,0 +1,260 @@
+import { execFileSync } from "node:child_process";
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+
+import { distillCatalog } from "../src/catalog/distill";
+import {
+  run,
+  chooseWritePath,
+  CATALOG_OUTPUT_PATH,
+  CATALOG_REGENERATED_PATH,
+} from "../src/catalog/cli";
+import type { CatalogDistiller, CatalogPage, FeatureCatalog } from "../src/catalog/types";
+
+/**
+ * #1314 S2 — Confluence feature/flow catalog tooling.
+ *
+ * SYNTHETIC fixtures ONLY (DEMO space, example.atlassian.net, invented
+ * titles/ids/labels). ZERO network, ZERO real LLM — both seams are injected.
+ */
+
+const PAGES: CatalogPage[] = [
+  { id: "p1", title: "Demo Page One", body: "Visitors can sign in to the demo workspace." },
+  { id: "p2", title: "Demo Page Two", body: "A shopper completes purchase at checkout." },
+  { id: "p3", title: "Demo Page Three", body: "Operators read summary dashboards." },
+];
+
+/** Canned distiller — 2 features, 1 flow, all provenance within the corpus. */
+const stubDistiller: CatalogDistiller = {
+  async distill() {
+    return {
+      features: [
+        { label: "Sign In", provenancePageIds: ["p1"] },
+        { label: "Reporting Dashboard", provenancePageIds: ["p3"] },
+      ],
+      flows: [{ label: "Checkout Flow", provenancePageIds: ["p2"] }],
+    };
+  },
+};
+
+const FROZEN_NOW = () => 0;
+
+describe("AC-DISTILL — distillCatalog over a synthetic >=3-page corpus", () => {
+  it("returns the expected feature/flow counts with valid, non-empty entries", async () => {
+    const catalog = await distillCatalog(PAGES, { distiller: stubDistiller, now: FROZEN_NOW });
+    expect(catalog.features).toHaveLength(2);
+    expect(catalog.flows).toHaveLength(1);
+
+    const corpusIds = new Set(PAGES.map((p) => p.id));
+    for (const entry of [...catalog.features, ...catalog.flows]) {
+      expect(entry.id.length).toBeGreaterThan(0);
+      expect(entry.label.length).toBeGreaterThan(0);
+      expect(entry.provenancePageIds.length).toBeGreaterThan(0);
+      for (const pid of entry.provenancePageIds) {
+        expect(corpusIds.has(pid)).toBe(true);
+      }
+    }
+    // reviewed defaults false (human-review loop preserved).
+    expect(catalog.reviewed).toBe(false);
+  });
+});
+
+describe("AC-STABLEID — re-running yields identical ids", () => {
+  it("produces byte-identical entry arrays across two runs of the same input", async () => {
+    const r1 = await distillCatalog(PAGES, { distiller: stubDistiller, now: FROZEN_NOW });
+    const r2 = await distillCatalog(PAGES, { distiller: stubDistiller, now: FROZEN_NOW });
+    expect(JSON.stringify(r1.features)).toBe(JSON.stringify(r2.features));
+    expect(JSON.stringify(r1.flows)).toBe(JSON.stringify(r2.flows));
+    // Spot-check a concrete stable id (deterministic slug).
+    expect(r1.features.map((f) => f.id)).toContain("feature-sign-in");
+    expect(r1.flows.map((f) => f.id)).toContain("flow-checkout-flow");
+  });
+});
+
+describe("AC-PROVENANCE-PRUNE — stray provenance ids dropped, empty entries removed", () => {
+  it("keeps only corpus ids and removes a zero-valid-provenance entry", async () => {
+    const distiller: CatalogDistiller = {
+      async distill() {
+        return {
+          features: [
+            // one bogus + one real id -> bogus pruned, entry kept
+            { label: "Mixed Provenance", provenancePageIds: ["BOGUS", "p1"] },
+            // only bogus -> entry removed entirely
+            { label: "All Bogus", provenancePageIds: ["NOPE"] },
+          ],
+          flows: [],
+        };
+      },
+    };
+    const catalog = await distillCatalog(PAGES, { distiller, now: FROZEN_NOW });
+    expect(catalog.features).toHaveLength(1);
+    expect(catalog.features[0].label).toBe("Mixed Provenance");
+    expect(catalog.features[0].provenancePageIds).toEqual(["p1"]);
+  });
+});
+
+describe("dedup — entries that slug to the same id merge, unioning provenance", () => {
+  it("collapses same-slug labels into one entry", async () => {
+    const distiller: CatalogDistiller = {
+      async distill() {
+        return {
+          features: [
+            { label: "Sign In", provenancePageIds: ["p1"] },
+            { label: "sign-in", provenancePageIds: ["p3"] }, // same slug
+          ],
+          flows: [],
+        };
+      },
+    };
+    const catalog = await distillCatalog(PAGES, { distiller, now: FROZEN_NOW });
+    expect(catalog.features).toHaveLength(1);
+    expect(catalog.features[0].id).toBe("feature-sign-in");
+    expect(catalog.features[0].provenancePageIds).toEqual(["p1", "p3"]);
+  });
+});
+
+describe("AC-NO-NETWORK — zero global fetch across the full run() orchestration (N2)", () => {
+  it("never touches globalThis.fetch after the whole run(deps) CLI smoke", async () => {
+    const fetchSpy = jest.fn();
+    const original = globalThis.fetch;
+    // Install a spy in place of the real fetch for the duration of the run.
+    globalThis.fetch = fetchSpy as unknown as typeof fetch;
+    try {
+      const captured: FeatureCatalog[] = [];
+      await run({
+        fetchPages: async () => PAGES,
+        distiller: stubDistiller,
+        writeCatalog: async (c) => {
+          captured.push(c);
+        },
+        spaceKey: "DEMO",
+        now: FROZEN_NOW,
+        log: () => undefined,
+      });
+      // N2: assert AFTER the full orchestration path, not just the unit.
+      expect(fetchSpy).toHaveBeenCalledTimes(0);
+      expect(captured).toHaveLength(1);
+    } finally {
+      globalThis.fetch = original;
+    }
+  });
+});
+
+describe("AC-LEAK — internal names go ONLY to the sink, never to stdout", () => {
+  it("keeps the sentinel out of every log line but present in the written catalog", async () => {
+    const SENTINEL = "ZZSECRETFEATURE";
+    const SECRET_BODY = "internal-only body about ZZSECRETFEATURE handling";
+    const leakyPages: CatalogPage[] = [
+      { id: "p1", title: "Demo Page One", body: SECRET_BODY },
+      { id: "p2", title: "Demo Page Two", body: "ordinary synthetic prose" },
+    ];
+    const leakyDistiller: CatalogDistiller = {
+      async distill() {
+        return {
+          features: [{ label: SENTINEL, provenancePageIds: ["p1"] }],
+          flows: [{ label: "Checkout Flow", provenancePageIds: ["p2"] }],
+        };
+      },
+    };
+
+    const logs: string[] = [];
+    const captured: FeatureCatalog[] = [];
+    const result = await run({
+      fetchPages: async () => leakyPages,
+      distiller: leakyDistiller,
+      writeCatalog: async (c) => {
+        captured.push(c);
+      },
+      spaceKey: "DEMO",
+      now: FROZEN_NOW,
+      log: (m) => logs.push(m),
+    });
+
+    const stdout = logs.join("\n");
+    // stdout carries counts/structure only — no label, no page body.
+    expect(stdout).not.toContain(SENTINEL);
+    expect(stdout).not.toContain(SECRET_BODY);
+    expect(stdout).not.toContain("p1");
+    // ...but the counts ARE present.
+    expect(stdout).toContain("1 features, 1 flows");
+    expect(result.featureCount).toBe(1);
+
+    // The gitignored sink DOES hold the internal label.
+    expect(captured).toHaveLength(1);
+    expect(JSON.stringify(captured[0])).toContain(SENTINEL);
+  });
+});
+
+describe("AC-GITIGNORED — the tool's real output path is gitignored (N1)", () => {
+  it("git check-ignore exits 0 for the shell's CATALOG_OUTPUT_PATH constant", () => {
+    // N1: assert against the SAME constant the shell writes to, not a literal.
+    expect(() =>
+      execFileSync("git", ["check-ignore", CATALOG_OUTPUT_PATH], {
+        cwd: process.cwd(),
+        stdio: "pipe",
+      }),
+    ).not.toThrow();
+    expect(() =>
+      execFileSync("git", ["check-ignore", CATALOG_REGENERATED_PATH], {
+        cwd: process.cwd(),
+        stdio: "pipe",
+      }),
+    ).not.toThrow();
+  });
+});
+
+describe("AC-SCHEMA — the written catalog matches the FeatureCatalog contract", () => {
+  it("passes a well-formed FeatureCatalog object to writeCatalog", async () => {
+    const captured: FeatureCatalog[] = [];
+    await run({
+      fetchPages: async () => PAGES,
+      distiller: stubDistiller,
+      writeCatalog: async (c) => {
+        captured.push(c);
+      },
+      spaceKey: "DEMO",
+      now: FROZEN_NOW,
+      log: () => undefined,
+    });
+    expect(captured).toHaveLength(1);
+    const catalog = captured[0];
+    expect(typeof catalog.generatedAt).toBe("string");
+    expect(catalog.reviewed).toBe(false);
+    expect(Array.isArray(catalog.features)).toBe(true);
+    expect(Array.isArray(catalog.flows)).toBe(true);
+    for (const entry of [...catalog.features, ...catalog.flows]) {
+      expect(typeof entry.id).toBe("string");
+      expect(typeof entry.label).toBe("string");
+      expect(Array.isArray(entry.provenancePageIds)).toBe(true);
+      expect(entry.provenancePageIds.every((p) => typeof p === "string")).toBe(true);
+    }
+  });
+});
+
+describe("AC-REUSE-FETCHER — reuses src/confluence/sync, no re-implemented pagination", () => {
+  it("the shell wires the real confluence/sync fetcher", () => {
+    const shell = readFileSync(join(__dirname, "..", "scripts", "build-catalog.js"), "utf-8");
+    expect(shell).toContain("confluence/sync");
+  });
+
+  it("no catalog source re-implements pagination/endpoints", () => {
+    const dir = join(__dirname, "..", "src", "catalog");
+    const offenders = /(_links\.next|wiki\/rest\/api\/content)/;
+    for (const file of readdirSync(dir)) {
+      if (!file.endsWith(".ts")) continue;
+      const src = readFileSync(join(dir, file), "utf-8");
+      expect(offenders.test(src)).toBe(false);
+    }
+  });
+});
+
+describe("no-clobber guard — chooseWritePath", () => {
+  it("writes the primary path when it does not exist, the sibling when it does", () => {
+    expect(chooseWritePath(CATALOG_OUTPUT_PATH, CATALOG_REGENERATED_PATH, () => false)).toBe(
+      CATALOG_OUTPUT_PATH,
+    );
+    expect(chooseWritePath(CATALOG_OUTPUT_PATH, CATALOG_REGENERATED_PATH, () => true)).toBe(
+      CATALOG_REGENERATED_PATH,
+    );
+  });
+});


### PR DESCRIPTION
## What

Adds catalog tooling for #1284 S2 (#1064 EPIC): ingest a Confluence space and distill an operator-reviewed feature + user-flow list to a gitignored, editable file.

- `src/catalog/types.ts` — catalog shapes.
- `src/catalog/distill.ts` — pure `distillCatalog(pages, deps)`: provenance-validate → stable slug ids → same-slug dedup → sort; `reviewed: false`; injectable `now()`.
- `src/catalog/cli.ts` — `run(deps)` orchestrator (injected fetchPages + distiller + writeCatalog); exports `CATALOG_OUTPUT_PATH`, `CATALOG_REGENERATED_PATH`, `chooseWritePath`.
- `scripts/build-catalog.js` — thin env-cred shell wiring the real Confluence fetcher; output is gitignored.
- `tests/catalog.test.ts` — 11 tests (synthetic data only).

## Scope

S2 tooling only. S3 mapping + S4 write-back are out of scope. The distilled catalog defaults `reviewed: false` and the real-data ingest is operator-gated (runs separately, not in CI). The catalog OUTPUT (internal feature names) is gitignored and never committed.

## Verification

- `npm run typecheck` exit 0, `npm run build` exit 0, `npm test` 304 passing / 35 suites.
- Network-isolation AC asserts `fetch` spy `toHaveBeenCalledTimes(0)` after the full `run(deps)`.
- Gitignored-output AC imports the real path constants and `git check-ignore`s them.
- All cores import only `./types` / `./distill`; network/cred wiring lives solely in `scripts/build-catalog.js`.

https://claude.ai/code/session_018TnaPsVNYG78F7y2YipqWL