### PR TITLE
Write bot-namespaced Jira labels (mb-feature-*/mb-flow-*/mb-symptom-*) + idempotent backfill

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "eval:recall": "npm run build && node scripts/eval-recall.js",
     "eval:golden": "npm run build && node scripts/eval-golden.js",
     "triage:categorize": "npm run build && node scripts/categorize-defects.js",
+    "triage:backfill": "npm run build && node scripts/backfill-namespaced-labels.js",
     "catalog:build": "npm run build && node scripts/build-catalog.js"
   },
   "engines": {

--- a/scripts/backfill-namespaced-labels.js
+++ b/scripts/backfill-namespaced-labels.js
@@ -1,0 +1,147 @@
+#!/usr/bin/env node
+/*
+ * backfill-namespaced-labels.js — thin I/O shell over the injectable backfill
+ * core (`dist/triage/backfill.js` -> run(deps)).
+ *
+ * One-time backfill: stamps the bot's `mb-feature-*` / `mb-flow-*` /
+ * `mb-symptom-*` labels onto every currently-OPEN Jira defect. Idempotent — a
+ * re-run over already-correct issues computes an empty diff and issues ZERO
+ * PUTs.
+ *
+ * DRY-RUN by DEFAULT: classifies + validates + previews, writes NOTHING. The
+ * real write-back is reachable ONLY behind an explicit `--apply` flag (operator
+ * go) — the only path that constructs the writer and mutates Jira.
+ *
+ * `--print-jql` prints the enumerated `labels in (...)` clause (no wildcard) for
+ * the operator to paste into a saved filter / board swimlanes, then exits.
+ *
+ * All creds + target come from env ONLY (gitignored .env; repo is PUBLIC). The
+ * catalog (internal product names) is read from the GITIGNORED output path and
+ * NEVER printed/committed; logs are COUNTS/STRUCTURE only.
+ *
+ *   Print filter:  node scripts/backfill-namespaced-labels.js --print-jql
+ *   Read it:       node scripts/backfill-namespaced-labels.js            (dry-run)
+ *   Apply it:      node scripts/backfill-namespaced-labels.js --apply    (outward write)
+ *
+ * Env: CONFLUENCE_URL (or CONFLUENCE_BASE_URL), CONFLUENCE_EMAIL,
+ *      CONFLUENCE_API_TOKEN (Jira reuses the Atlassian creds), JIRA_PROJECTS
+ *      (comma-separated; the FIRST entry is backfilled). Optional JQL overrides:
+ *      JIRA_OPEN_DEFECTS_STATUS_JQL, JIRA_DEFECT_ISSUETYPE_JQL.
+ *
+ * NOTE: the production feature/flow classifier (LLM matching issue text ->
+ * catalog ids) is a DEFERRED follow-up; until it ships this shell wires the
+ * SYMPTOM-ONLY null classifier (the documented interim mode).
+ */
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+
+const DIST = path.resolve(__dirname, "..", "dist");
+const { run } = require(path.join(DIST, "triage", "backfill"));
+const { buildNullClassifier } = require(path.join(DIST, "triage", "classifier"));
+const { buildOpenDefectsFetcher } = require(path.join(DIST, "jira", "sync"));
+const {
+  membershipFromCatalog,
+  buildBotLabelJql,
+} = require(path.join(DIST, "jira", "namespacedLabels"));
+const {
+  buildJiraNamespacedLabelWriter,
+} = require(path.join(DIST, "jira", "namespacedLabelWriter"));
+
+/** Gitignored catalog path (mirrors src/catalog/cli.ts CATALOG_OUTPUT_PATH). */
+const CATALOG_OUTPUT_PATH = path.resolve(
+  __dirname,
+  "..",
+  ".ai-workspace",
+  "catalog",
+  "feature-catalog.json",
+);
+
+/** Strip a trailing /wiki (and trailing slash) so the site root feeds Jira REST. */
+function toSiteRoot(url) {
+  return url.replace(/\/wiki\/?$/, "").replace(/\/$/, "");
+}
+
+function splitList(raw) {
+  return (raw || "")
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+/** Read the gitignored catalog (or an empty catalog if absent). */
+function loadCatalog() {
+  try {
+    const raw = JSON.parse(fs.readFileSync(CATALOG_OUTPUT_PATH, "utf8"));
+    return {
+      features: Array.isArray(raw.features) ? raw.features : [],
+      flows: Array.isArray(raw.flows) ? raw.flows : [],
+    };
+  } catch {
+    return { features: [], flows: [] };
+  }
+}
+
+async function main() {
+  const apply = process.argv.includes("--apply");
+  const printJql = process.argv.includes("--print-jql");
+  const env = process.env;
+
+  const catalog = loadCatalog();
+
+  if (printJql) {
+    // Enumerated, sorted, quoted `labels in (...)` — NO wildcard. Safe to print:
+    // the label STRINGS are derived from catalog ids (slugs), structure only.
+    console.log(buildBotLabelJql(catalog));
+    return;
+  }
+
+  const url = env.CONFLUENCE_URL || env.CONFLUENCE_BASE_URL;
+  const email = env.CONFLUENCE_EMAIL;
+  const apiToken = env.CONFLUENCE_API_TOKEN;
+  const projects = splitList(env.JIRA_PROJECTS);
+
+  if (!url || !email || !apiToken || projects.length === 0) {
+    console.error(
+      "backfill-namespaced-labels: missing config. Need CONFLUENCE_URL (or " +
+        "CONFLUENCE_BASE_URL), CONFLUENCE_EMAIL, CONFLUENCE_API_TOKEN, and a " +
+        "non-empty JIRA_PROJECTS.",
+    );
+    process.exit(1);
+  }
+
+  const config = { baseUrl: toSiteRoot(url), email, apiToken };
+  const scope = {
+    statusJql: env.JIRA_OPEN_DEFECTS_STATUS_JQL,
+    issueTypeJql: env.JIRA_DEFECT_ISSUETYPE_JQL,
+  };
+  const projectKey = projects[0];
+  const fetcher = buildOpenDefectsFetcher(config, scope, globalThis.fetch);
+
+  const deps = {
+    fetchOpenDefects: () => fetcher.fetchOpenDefects(projectKey),
+    classifier: buildNullClassifier(),
+    catalog: membershipFromCatalog(catalog),
+    apply,
+  };
+  // The writer is constructed ONLY on --apply (dry-run never builds it).
+  if (apply) {
+    deps.writer = buildJiraNamespacedLabelWriter(config, globalThis.fetch);
+  }
+
+  const result = await run(deps);
+
+  if (!apply) {
+    console.log(
+      "\n(dry-run: no Jira writes performed. Re-run with --apply to stamp labels.)",
+    );
+  } else {
+    console.log(`\napplied ${result.applied} issue label-set write(s).`);
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/catalog/distill.ts
+++ b/src/catalog/distill.ts
@@ -5,6 +5,7 @@ import {
   FeatureCatalog,
   RawCatalogEntry,
 } from "./types";
+import { slug } from "./slug";
 
 /**
  * Pure, injectable distill core (#1314 S2).
@@ -19,14 +20,6 @@ export interface DistillDeps {
   distiller: CatalogDistiller;
   /** Injectable clock for deterministic `generatedAt` in tests. */
   now?: () => number;
-}
-
-/** Lowercase-alnum-hyphen slug. Collapses runs and trims edge hyphens. */
-function slug(label: string): string {
-  return label
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/^-+|-+$/g, "");
 }
 
 /**

--- a/src/catalog/slug.ts
+++ b/src/catalog/slug.ts
@@ -1,0 +1,18 @@
+/**
+ * Single canonical slug source (#1322).
+ *
+ * Promoted out of `distill.ts` so the catalog id-assignment AND the
+ * `mb-`-namespaced Jira label writer share ONE lowercase-kebab function. If these
+ * ever drifted, a label string would stop matching its catalog id and the bot's
+ * "controlled vocabulary" guarantee would silently break — so there is exactly
+ * ONE slug function and both sites import it.
+ *
+ * Behaviour: lowercase, collapse every run of non-alphanumeric chars to a single
+ * hyphen, and trim leading/trailing hyphens.
+ */
+export function slug(label: string): string {
+  return label
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}

--- a/src/jira/index.ts
+++ b/src/jira/index.ts
@@ -18,3 +18,22 @@ export {
   JiraCategoryWriter,
   JiraCategoryWriterOptions,
 } from "./categoryWriter";
+export {
+  NS_FEATURE,
+  NS_FLOW,
+  NS_SYMPTOM,
+  LabelAssignment,
+  LabelCatalog,
+  CatalogIdSource,
+  ValidatedLabels,
+  LabelKind,
+  LabelValidationError,
+  membershipFromCatalog,
+  buildDesiredLabels,
+  buildBotLabelJql,
+} from "./namespacedLabels";
+export {
+  JiraNamespacedLabelWriter,
+  computeLabelOps,
+  buildJiraNamespacedLabelWriter,
+} from "./namespacedLabelWriter";

--- a/src/jira/namespacedLabelWriter.ts
+++ b/src/jira/namespacedLabelWriter.ts
@@ -1,0 +1,109 @@
+import { JiraClientConfig, basicAuthHeader } from "./sync";
+import { NS_FEATURE, NS_SYMPTOM, ValidatedLabels } from "./namespacedLabels";
+
+/**
+ * OUTWARD-write seam for the bot's namespaced labels (#1322).
+ *
+ * Reuses the SINGLE shared `basicAuthHeader` + the same
+ * `PUT /rest/api/3/issue/{key}` endpoint as the category writer (no forked auth
+ * site). `fetchImpl` is injectable so the whole path is driven by a fake in
+ * tests with ZERO live mutation.
+ *
+ * The write is a DIFF-driven remove+add op list (NOT a `{set:[...]}` replace),
+ * computed uniformly across all three namespaces vs the issue's CURRENT labels:
+ *
+ *   - SINGLE-value namespaces (`mb-feature-*`, `mb-symptom-*`): emit a `remove`
+ *     op for EVERY existing label in that namespace whose value differs from the
+ *     target (so two-or-more stale labels are ALL dropped), then an `add` for
+ *     the target ONLY if it is not already present.
+ *   - MULTI-value namespace (`mb-flow-*`): emit an `add` ONLY for each desired
+ *     flow NOT already on the issue (additive within the desired set).
+ *
+ * remove+add touches ONLY the bot's namespace, so human labels are provably
+ * untouched and a human label added between read and write survives. If the
+ * computed op list is EMPTY → NO PUT is issued (the idempotency short-circuit):
+ * a re-run over an already-correct issue makes zero network calls.
+ */
+export interface JiraNamespacedLabelWriter {
+  /**
+   * Apply the validated bot labels to `issueKey` given its CURRENT labels.
+   * Returns `true` if a mutating PUT was issued, `false` if the diff was empty
+   * (no-op / idempotent re-run → no PUT).
+   */
+  applyLabels(
+    issueKey: string,
+    currentLabels: string[],
+    target: ValidatedLabels,
+  ): Promise<boolean>;
+}
+
+type LabelOp = { add: string } | { remove: string };
+
+/** Compute the diff-driven op list (exported for direct unit assertion). */
+export function computeLabelOps(currentLabels: string[], target: ValidatedLabels): LabelOp[] {
+  const current = currentLabels ?? [];
+  const present = new Set(current);
+  const ops: LabelOp[] = [];
+
+  // SINGLE-value namespaces: remove ALL stale, then add target if absent.
+  const single: Array<[string, string | undefined]> = [
+    [NS_FEATURE, target.feature],
+    [NS_SYMPTOM, target.symptom],
+  ];
+  for (const [prefix, targetLabel] of single) {
+    if (!targetLabel) continue;
+    for (const label of current) {
+      if (label.startsWith(prefix) && label !== targetLabel) {
+        ops.push({ remove: label });
+      }
+    }
+    if (!present.has(targetLabel)) ops.push({ add: targetLabel });
+  }
+
+  // MULTI-value namespace: add only desired flows not already present.
+  for (const flow of target.flows) {
+    if (!present.has(flow)) ops.push({ add: flow });
+  }
+
+  return ops;
+}
+
+export function buildJiraNamespacedLabelWriter(
+  config: JiraClientConfig,
+  fetchImpl: typeof fetch = globalThis.fetch,
+): JiraNamespacedLabelWriter {
+  if (typeof fetchImpl !== "function") {
+    throw new TypeError(
+      "buildJiraNamespacedLabelWriter: no global fetch available; pass an explicit fetchImpl",
+    );
+  }
+  const base = config.baseUrl.replace(/\/$/, "");
+
+  return {
+    async applyLabels(issueKey, currentLabels, target): Promise<boolean> {
+      if (typeof issueKey !== "string" || issueKey.length === 0) {
+        throw new TypeError("applyLabels: issueKey must be a non-empty string");
+      }
+      const ops = computeLabelOps(currentLabels, target);
+      // Empty-diff short-circuit: issue NO PUT at all (idempotency guarantee).
+      if (ops.length === 0) return false;
+
+      const url = `${base}/rest/api/3/issue/${encodeURIComponent(issueKey)}`;
+      const res = await fetchImpl(url, {
+        method: "PUT",
+        headers: {
+          Authorization: basicAuthHeader(config),
+          "Content-Type": "application/json",
+          Accept: "application/json",
+        },
+        body: JSON.stringify({ update: { labels: ops } }),
+      });
+      if (!res.ok) {
+        throw new Error(
+          `Jira REST API returned ${res.status} ${res.statusText} for PUT issue ${issueKey}`,
+        );
+      }
+      return true;
+    },
+  };
+}

--- a/src/jira/namespacedLabels.ts
+++ b/src/jira/namespacedLabels.ts
@@ -1,0 +1,168 @@
+/**
+ * Pure, I/O-free model for the bot's namespaced Jira labels (#1322).
+ *
+ * The bot is the SOLE writer of three label namespaces, all prefixed `mb-`
+ * ("monday-bot's private sticker drawer"):
+ *   - `mb-feature-<slug>` — exactly ONE per issue (which product area).
+ *   - `mb-flow-<slug>`    — zero-or-more per issue (which user journeys).
+ *   - `mb-symptom-<cat>`  — exactly ONE per issue (the deterministic symptom).
+ *
+ * Because the bot owns the namespaces, the usual "labels rot" failure mode is
+ * recovered by a HARD validation gate: every value is canonicalised through the
+ * ONE shared `slug()` and checked for membership in the catalog (feature/flow)
+ * or the symptom taxonomy BEFORE any label string is constructed. An unknown
+ * value is refused (fail-loud) — the writer is never reached, so zero network.
+ *
+ * No fs / network / creds here: this module is unit-tested with synthetic data.
+ */
+import { slug } from "../catalog/slug";
+import { DEFECT_CATEGORIES } from "../triage/categorizeDefect";
+
+/** Namespace prefixes — the bot's private drawer. */
+export const NS_FEATURE = "mb-feature-";
+export const NS_FLOW = "mb-flow-";
+export const NS_SYMPTOM = "mb-symptom-";
+
+/**
+ * Per-issue assignment the backfill produces: a symptom (always, from the
+ * deterministic categorizer) plus an optional feature and zero-or-more flows
+ * (from the injected classifier seam). The raw string values are slugged +
+ * validated here before becoming labels.
+ */
+export interface LabelAssignment {
+  /** Optional product-area value (slugged + checked against the catalog). */
+  feature?: string;
+  /** Zero-or-more journey values (each slugged + checked against the catalog). */
+  flows: string[];
+  /** Symptom value (checked against the `DEFECT_CATEGORIES` taxonomy). */
+  symptom: string;
+}
+
+/**
+ * Membership sets the validator checks against. `featureIds` / `flowIds` carry
+ * the catalog ENTRY ids (already `feature-<slug>` / `flow-<slug>`); they are
+ * loaded by the shell from the gitignored catalog and injected (tests pass
+ * synthetic sets). The symptom axis defaults to the in-repo taxonomy.
+ */
+export interface LabelCatalog {
+  featureIds: ReadonlySet<string>;
+  flowIds: ReadonlySet<string>;
+}
+
+/** Minimal catalog shape (the gitignored `FeatureCatalog`) for set derivation. */
+export interface CatalogIdSource {
+  features: ReadonlyArray<{ id: string }>;
+  flows: ReadonlyArray<{ id: string }>;
+}
+
+/** Derive the injected membership sets from a (synthetic or real) catalog. */
+export function membershipFromCatalog(catalog: CatalogIdSource): LabelCatalog {
+  return {
+    featureIds: new Set(catalog.features.map((e) => e.id)),
+    flowIds: new Set(catalog.flows.map((e) => e.id)),
+  };
+}
+
+/**
+ * The validated, ready-to-write label set for one issue. `desired` is the FULL
+ * set of bot labels this issue should carry (feature? + flows + symptom) — the
+ * writer diffs it against the issue's CURRENT labels.
+ */
+export interface ValidatedLabels {
+  /** Full `mb-feature-<slug>` label, if a feature was assigned. */
+  feature?: string;
+  /** Full `mb-flow-<slug>` labels. */
+  flows: string[];
+  /** Full `mb-symptom-<cat>` label. */
+  symptom: string;
+  /** Every desired bot label (the writer's diff target). */
+  desired: string[];
+}
+
+/** Which axis a rejected value belonged to. */
+export type LabelKind = "feature" | "flow" | "symptom";
+
+/**
+ * Raised when a value is NOT in the catalog / taxonomy. Carries the axis + value
+ * for the caller; the persistent fail-loud LOG (see `buildDesiredLabels`) names
+ * only the axis, never the value — internal product names must not leak to a
+ * committed/structured log in a PUBLIC repo.
+ */
+export class LabelValidationError extends Error {
+  constructor(
+    public readonly kind: LabelKind,
+    public readonly value: string,
+  ) {
+    super(`namespaced-label: rejected unknown ${kind} value (not in catalog/taxonomy)`);
+    this.name = "LabelValidationError";
+  }
+}
+
+/**
+ * Canonicalise + VALIDATE an assignment, then construct the bot labels.
+ *
+ * Validation happens BEFORE any label is returned and BEFORE the writer is ever
+ * called: an unknown feature/flow/symptom emits a fail-loud (axis-only) log line
+ * and THROWS `LabelValidationError`. A valid assignment yields the full
+ * `ValidatedLabels` (feature? + flows + symptom) plus the `desired` set.
+ */
+export function buildDesiredLabels(
+  assignment: LabelAssignment,
+  catalog: LabelCatalog,
+  symptoms: ReadonlySet<string> = new Set(DEFECT_CATEGORIES),
+  log: (msg: string) => void = (m) => console.error(m),
+): ValidatedLabels {
+  let featureLabel: string | undefined;
+  if (assignment.feature !== undefined && assignment.feature !== "") {
+    const id = `feature-${slug(assignment.feature)}`;
+    if (!catalog.featureIds.has(id)) {
+      log("namespaced-label: REJECTED unknown feature (validation failed BEFORE write)");
+      throw new LabelValidationError("feature", assignment.feature);
+    }
+    featureLabel = `mb-${id}`;
+  }
+
+  const flowLabels: string[] = [];
+  for (const flow of assignment.flows ?? []) {
+    const id = `flow-${slug(flow)}`;
+    if (!catalog.flowIds.has(id)) {
+      log("namespaced-label: REJECTED unknown flow (validation failed BEFORE write)");
+      throw new LabelValidationError("flow", flow);
+    }
+    flowLabels.push(`mb-${id}`);
+  }
+
+  const symptomSlug = slug(assignment.symptom ?? "");
+  if (!symptoms.has(symptomSlug)) {
+    log("namespaced-label: REJECTED unknown symptom (validation failed BEFORE write)");
+    throw new LabelValidationError("symptom", assignment.symptom);
+  }
+  const symptomLabel = `${NS_SYMPTOM}${symptomSlug}`;
+
+  const desired = [
+    ...(featureLabel ? [featureLabel] : []),
+    ...flowLabels,
+    symptomLabel,
+  ];
+  return { feature: featureLabel, flows: flowLabels, symptom: symptomLabel, desired };
+}
+
+/**
+ * Generate the ENUMERATED `labels in (...)` JQL for every bot label the catalog
+ * can produce. Jira label matching is EXACT — there is NO `mb-*` wildcard — so
+ * "only the bot's labels" must be an explicit, sorted, double-quoted list the
+ * bot regenerates whenever the catalog grows. Deterministic string output.
+ */
+export function buildBotLabelJql(
+  catalog: CatalogIdSource,
+  symptoms: readonly string[] = DEFECT_CATEGORIES,
+): string {
+  const labels = [
+    ...catalog.features.map((e) => `mb-${e.id}`),
+    ...catalog.flows.map((e) => `mb-${e.id}`),
+    ...symptoms.map((s) => `${NS_SYMPTOM}${s}`),
+  ];
+  const sorted = [...new Set(labels)].sort();
+  const quoted = sorted.map((l) => `"${l}"`).join(",");
+  return `labels in (${quoted})`;
+}

--- a/src/triage/backfill.ts
+++ b/src/triage/backfill.ts
@@ -1,0 +1,101 @@
+import { categorizeDefect } from "./categorizeDefect";
+import { IssueFeatureFlowClassifier } from "./classifier";
+import type { JiraIssue } from "../jira/sync";
+import type { JiraNamespacedLabelWriter } from "../jira/namespacedLabelWriter";
+import {
+  LabelAssignment,
+  LabelCatalog,
+  LabelValidationError,
+  buildDesiredLabels,
+} from "../jira/namespacedLabels";
+
+/**
+ * Injectable backfill core (#1322) — mirrors `src/triage/cli.ts`.
+ *
+ * Per open issue: symptom from the deterministic `categorizeDefect` + feature/
+ * flows from the INJECTED classifier seam → VALIDATE against the catalog/
+ * taxonomy → write. Validation precedes the writer: an unknown value is counted
+ * as `rejected` and the writer is NEVER called for that issue (zero network).
+ *
+ * Dry-run is the DEFAULT: with `apply !== true` (or no writer) it computes +
+ * previews and issues ZERO writes. `applied` counts only issues that actually
+ * received a mutating PUT — an already-correct issue produces an empty diff →
+ * NO PUT → does NOT increment `applied` (the idempotency guarantee). Env-cred
+ * construction lives in the thin shell, never here.
+ */
+export interface BackfillRunDeps {
+  /** Injected open-defects read. */
+  fetchOpenDefects: () => Promise<JiraIssue[]>;
+  /** Injected feature/flow classifier seam (fake in tests). */
+  classifier: IssueFeatureFlowClassifier;
+  /** Injected catalog membership sets (synthetic in tests). */
+  catalog: LabelCatalog;
+  /** Injected writer — constructed by the shell ONLY on `--apply`. */
+  writer?: JiraNamespacedLabelWriter;
+  /** Real-write flag. Default false (dry-run). */
+  apply?: boolean;
+  /** Logger sink; defaults to `console.log`. */
+  log?: (msg: string) => void;
+}
+
+export interface BackfillRunResult {
+  /** Issues processed. */
+  total: number;
+  /** Issues whose assignment passed validation. */
+  validated: number;
+  /** Issues rejected by validation (unknown feature/flow/symptom). */
+  rejected: number;
+  /** Issues that actually received a mutating PUT (0 in dry-run / on re-run). */
+  applied: number;
+}
+
+export async function run(deps: BackfillRunDeps): Promise<BackfillRunResult> {
+  const log = deps.log ?? ((msg: string) => console.log(msg));
+  const apply = deps.apply === true;
+
+  const issues = await deps.fetchOpenDefects();
+  let validated = 0;
+  let rejected = 0;
+  let applied = 0;
+
+  for (const issue of issues) {
+    const { category } = categorizeDefect({
+      key: issue.key,
+      summary: issue.summary,
+      descriptionText: issue.descriptionText,
+      labels: issue.labels,
+      issueType: issue.issueType,
+    });
+    const ff = await deps.classifier.classify(issue);
+    const assignment: LabelAssignment = {
+      feature: ff.feature,
+      flows: ff.flows ?? [],
+      symptom: category,
+    };
+
+    let target;
+    try {
+      target = buildDesiredLabels(assignment, deps.catalog, undefined, log);
+    } catch (err) {
+      if (err instanceof LabelValidationError) {
+        // Fail-loud already logged inside the model; never reach the writer.
+        rejected++;
+        continue;
+      }
+      throw err;
+    }
+    validated++;
+
+    if (apply && deps.writer && issue.key) {
+      const didPut = await deps.writer.applyLabels(issue.key, issue.labels ?? [], target);
+      if (didPut) applied++;
+    }
+  }
+
+  log(
+    `backfill: total=${issues.length} validated=${validated} rejected=${rejected} ` +
+      `applied=${applied} (${apply ? "APPLY" : "dry-run"})`,
+  );
+
+  return { total: issues.length, validated, rejected, applied };
+}

--- a/src/triage/classifier.ts
+++ b/src/triage/classifier.ts
@@ -1,0 +1,30 @@
+import type { JiraIssue } from "../jira/sync";
+
+/**
+ * Single injected boundary that decides WHICH feature / flows a given issue maps
+ * to (#1322). Modeled on the catalog's `CatalogDistiller` seam: the production
+ * implementation (an LLM matching issue text → catalog ids) lives in the thin
+ * SHELL, never here; tests inject a fake so the whole backfill runs with ZERO
+ * network / model / creds.
+ *
+ * The PRODUCTION feature/flow classifier (prompt + accuracy tuning) is a
+ * DEFERRED follow-up under EPIC #1064 — until it lands, the backfill wires
+ * `buildNullClassifier` and runs SYMPTOM-ONLY (the deterministic axis), which is
+ * exactly the documented interim mode.
+ */
+export interface IssueFeatureFlowClassifier {
+  classify(issue: JiraIssue): Promise<{ feature?: string; flows: string[] }>;
+}
+
+/**
+ * Symptom-only fallback: assigns no feature and no flows, so the backfill stamps
+ * only the deterministic `mb-symptom-*` axis. This is the wired default until the
+ * real LLM classifier ships (see the deferred follow-up above).
+ */
+export function buildNullClassifier(): IssueFeatureFlowClassifier {
+  return {
+    async classify(): Promise<{ feature?: string; flows: string[] }> {
+      return { flows: [] };
+    },
+  };
+}

--- a/src/triage/index.ts
+++ b/src/triage/index.ts
@@ -6,3 +6,7 @@ export {
 export type { DefectCategory, DefectInput, DefectResult } from "./categorizeDefect";
 export { run } from "./cli";
 export type { CategorizeRunDeps, CategorizeRunResult } from "./cli";
+export { buildNullClassifier } from "./classifier";
+export type { IssueFeatureFlowClassifier } from "./classifier";
+export { run as runBackfill } from "./backfill";
+export type { BackfillRunDeps, BackfillRunResult } from "./backfill";

--- a/tests/jira.namespacedLabels.test.ts
+++ b/tests/jira.namespacedLabels.test.ts
@@ -1,0 +1,194 @@
+import { slug } from "../src/catalog/slug";
+import {
+  buildDesiredLabels,
+  buildBotLabelJql,
+  membershipFromCatalog,
+  LabelValidationError,
+  LabelCatalog,
+} from "../src/jira/namespacedLabels";
+import { buildJiraNamespacedLabelWriter } from "../src/jira/namespacedLabelWriter";
+import { DEFECT_CATEGORIES } from "../src/triage/categorizeDefect";
+
+/**
+ * #1322 — bot-namespaced Jira labels (mb-feature / mb-flow / mb-symptom).
+ *
+ * SYNTHETIC fixtures ONLY: example.atlassian.net, a DEMO project key, and
+ * invented slugs. ZERO live mutation — every write goes through an injected fake
+ * `fetchImpl`.
+ */
+
+const CONFIG = { baseUrl: "https://example.atlassian.net", email: "a@b.c", apiToken: "tok" };
+
+function okFetchSpy(): jest.Mock {
+  return jest.fn(async () => ({
+    ok: true,
+    status: 204,
+    statusText: "No Content",
+    async json() {
+      return {};
+    },
+  }));
+}
+
+describe("AC-3 — shared slug canonicalization + single-source", () => {
+  it("turns messy inputs into lowercase-kebab", () => {
+    expect(slug("  Sign In!! ")).toBe("sign-in");
+    expect(slug("Check—out  Flow")).toBe("check-out-flow");
+  });
+
+  it("the label model canonicalizes via the SAME slug the catalog uses", () => {
+    const messy = "  Sign In!! ";
+    const catalog: LabelCatalog = {
+      featureIds: new Set([`feature-${slug(messy)}`]),
+      flowIds: new Set(),
+    };
+    const v = buildDesiredLabels({ feature: messy, flows: [], symptom: "crash-error" }, catalog);
+    // Same symbol → the label slug equals the catalog id slug, deterministically.
+    expect(v.feature).toBe(`mb-feature-${slug(messy)}`);
+    expect(v.feature).toBe("mb-feature-sign-in");
+  });
+});
+
+describe("AC-4 — exactly-one single-value label, ALL stale removed before add", () => {
+  it("removes BOTH stale mb-feature-* labels + one add, human label untouched", async () => {
+    const fetchImpl = okFetchSpy();
+    const writer = buildJiraNamespacedLabelWriter(CONFIG, fetchImpl as unknown as typeof fetch);
+    const target = buildDesiredLabels(
+      { feature: "new", flows: [], symptom: "crash-error" },
+      { featureIds: new Set(["feature-new"]), flowIds: new Set() },
+    );
+
+    const didPut = await writer.applyLabels(
+      "DEMO-1",
+      ["mb-feature-old", "mb-feature-older", "keep-me"],
+      target,
+    );
+    expect(didPut).toBe(true);
+
+    const init = fetchImpl.mock.calls[0][1] as { body: string };
+    const ops = JSON.parse(init.body).update.labels as Array<{ add?: string; remove?: string }>;
+
+    expect(ops).toContainEqual({ remove: "mb-feature-old" });
+    expect(ops).toContainEqual({ remove: "mb-feature-older" });
+    // Exactly one mb-feature-* add (a "remove only the first match" bug would
+    // still pass the add check but FAIL the two-remove check above).
+    const featureAdds = ops.filter((o) => o.add && o.add.startsWith("mb-feature-"));
+    expect(featureAdds).toEqual([{ add: "mb-feature-new" }]);
+    // Human label never appears in any op.
+    expect(JSON.stringify(ops)).not.toContain("keep-me");
+  });
+
+  it("mirrors for double-stale mb-symptom-* labels", async () => {
+    const fetchImpl = okFetchSpy();
+    const writer = buildJiraNamespacedLabelWriter(CONFIG, fetchImpl as unknown as typeof fetch);
+    const target = buildDesiredLabels(
+      { flows: [], symptom: "crash-error" },
+      { featureIds: new Set(), flowIds: new Set() },
+    );
+
+    const didPut = await writer.applyLabels(
+      "DEMO-2",
+      ["mb-symptom-old", "mb-symptom-older", "keep-me"],
+      target,
+    );
+    expect(didPut).toBe(true);
+
+    const init = fetchImpl.mock.calls[0][1] as { body: string };
+    const ops = JSON.parse(init.body).update.labels as Array<{ add?: string; remove?: string }>;
+
+    expect(ops).toContainEqual({ remove: "mb-symptom-old" });
+    expect(ops).toContainEqual({ remove: "mb-symptom-older" });
+    const symptomAdds = ops.filter((o) => o.add && o.add.startsWith("mb-symptom-"));
+    expect(symptomAdds).toEqual([{ add: "mb-symptom-crash-error" }]);
+    expect(JSON.stringify(ops)).not.toContain("keep-me");
+  });
+});
+
+describe("AC-5 (model) — catalog validation refuses unknown, fail-loud", () => {
+  const catalog: LabelCatalog = {
+    featureIds: new Set(["feature-known"]),
+    flowIds: new Set(["flow-known"]),
+  };
+
+  it("throws + fail-loud-logs (axis only) on an unknown feature", () => {
+    const logs: string[] = [];
+    expect(() =>
+      buildDesiredLabels(
+        { feature: "nope", flows: [], symptom: "crash-error" },
+        catalog,
+        undefined,
+        (m) => logs.push(m),
+      ),
+    ).toThrow(LabelValidationError);
+    expect(logs.some((l) => l.includes("REJECTED unknown feature"))).toBe(true);
+    // Fail-loud line names only the axis, never the value (PUBLIC repo).
+    expect(logs.join("\n")).not.toContain("nope");
+  });
+
+  it("throws on an unknown flow", () => {
+    expect(() =>
+      buildDesiredLabels({ flows: ["nope"], symptom: "crash-error" }, catalog, undefined, () => {}),
+    ).toThrow(LabelValidationError);
+  });
+
+  it("throws on an unknown symptom", () => {
+    expect(() =>
+      buildDesiredLabels({ flows: [], symptom: "explode" }, catalog, undefined, () => {}),
+    ).toThrow(LabelValidationError);
+  });
+});
+
+describe("AC-6 — label-set PUT body shape (clean issue)", () => {
+  it("issues exactly ONE PUT with the expected headers + label-add set", async () => {
+    const fetchImpl = okFetchSpy();
+    const writer = buildJiraNamespacedLabelWriter(CONFIG, fetchImpl as unknown as typeof fetch);
+    const target = buildDesiredLabels(
+      { feature: "x", flows: ["a", "b"], symptom: "crash-error" },
+      membershipFromCatalog({
+        features: [{ id: "feature-x" }],
+        flows: [{ id: "flow-a" }, { id: "flow-b" }],
+      }),
+    );
+
+    const didPut = await writer.applyLabels("DEMO-7", [], target);
+    expect(didPut).toBe(true);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+
+    const [url, init] = fetchImpl.mock.calls[0] as [
+      string,
+      { method: string; headers: Record<string, string>; body: string },
+    ];
+    expect(url).toBe("https://example.atlassian.net/rest/api/3/issue/DEMO-7");
+    expect(init.method).toBe("PUT");
+    expect(init.headers.Authorization).toMatch(/^Basic /);
+    expect(init.headers["Content-Type"]).toBe("application/json");
+    expect(init.headers.Accept).toBe("application/json");
+
+    const ops = JSON.parse(init.body).update.labels as Array<{ add?: string; remove?: string }>;
+    const adds = ops.filter((o) => o.add).map((o) => o.add);
+    expect(new Set(adds)).toEqual(
+      new Set(["mb-feature-x", "mb-flow-a", "mb-flow-b", "mb-symptom-crash-error"]),
+    );
+  });
+});
+
+describe("AC-8 — bot-label JQL is enumerated, sorted, quoted, no wildcard", () => {
+  it("emits the exact labels in (...) string for a synthetic catalog", () => {
+    const catalog = {
+      features: [{ id: "feature-alpha" }, { id: "feature-beta" }],
+      flows: [{ id: "flow-gamma" }],
+    };
+    const jql = buildBotLabelJql(catalog);
+
+    expect(jql).not.toContain("*");
+
+    const expectedLabels = [
+      "mb-feature-alpha",
+      "mb-feature-beta",
+      "mb-flow-gamma",
+      ...DEFECT_CATEGORIES.map((c) => `mb-symptom-${c}`),
+    ].sort();
+    const expected = `labels in (${expectedLabels.map((l) => `"${l}"`).join(",")})`;
+    expect(jql).toBe(expected);
+  });
+});

--- a/tests/triage.backfill.test.ts
+++ b/tests/triage.backfill.test.ts
@@ -1,0 +1,144 @@
+import { run } from "../src/triage/backfill";
+import { buildJiraNamespacedLabelWriter } from "../src/jira/namespacedLabelWriter";
+import { membershipFromCatalog } from "../src/jira/namespacedLabels";
+import type { IssueFeatureFlowClassifier } from "../src/triage/classifier";
+import type { JiraIssue } from "../src/jira/sync";
+
+/**
+ * #1322 — backfill core (enumerate open defects → validate → write).
+ *
+ * SYNTHETIC fixtures ONLY: invented slugs, no live network. The writer's
+ * `fetchImpl` is a `jest.fn()` SPY so AC-7 can assert ZERO PUT calls on an
+ * already-correct re-run (empty-diff short-circuit).
+ */
+
+const CONFIG = { baseUrl: "https://example.atlassian.net", email: "a@b.c", apiToken: "tok" };
+
+/** Synthetic catalog: one feature + one flow. */
+const MEMBERSHIP = membershipFromCatalog({
+  features: [{ id: "feature-checkout" }],
+  flows: [{ id: "flow-signin" }],
+});
+
+/** Deterministic fake classifier keyed by issue. */
+const CLASSIFIER: IssueFeatureFlowClassifier = {
+  async classify(issue: JiraIssue) {
+    if (issue.key === "X-1") return { feature: "checkout", flows: ["signin"] };
+    return { feature: "checkout", flows: [] };
+  },
+};
+
+function okFetchSpy(): jest.Mock {
+  return jest.fn(async () => ({
+    ok: true,
+    status: 204,
+    statusText: "No Content",
+    async json() {
+      return {};
+    },
+  }));
+}
+
+describe("AC-7 — backfill enumerates open issues AND is idempotent (spied fetchImpl)", () => {
+  it("run#1 writes each issue; run#2 over already-correct issues issues ZERO PUTs", async () => {
+    const fetchImpl = okFetchSpy();
+    const writer = buildJiraNamespacedLabelWriter(CONFIG, fetchImpl as unknown as typeof fetch);
+
+    // Run #1: clean issues (no mb-* labels yet).
+    const run1Issues: JiraIssue[] = [
+      { key: "X-1", summary: "the app crashed on launch", descriptionText: "", commentTexts: [] },
+      {
+        key: "X-2",
+        summary: "the running total shows the wrong amount",
+        descriptionText: "",
+        commentTexts: [],
+      },
+    ];
+    const result1 = await run({
+      fetchOpenDefects: async () => run1Issues,
+      classifier: CLASSIFIER,
+      catalog: MEMBERSHIP,
+      writer,
+      apply: true,
+      log: () => undefined,
+    });
+    expect(result1.total).toBe(2);
+    expect(result1.validated).toBe(2);
+    expect(result1.rejected).toBe(0);
+    expect(result1.applied).toBe(2);
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+
+    // Run #2: the SAME issues now carrying their correct mb-* labels.
+    fetchImpl.mockClear();
+    const run2Issues: JiraIssue[] = [
+      {
+        key: "X-1",
+        summary: "the app crashed on launch",
+        descriptionText: "",
+        commentTexts: [],
+        labels: ["mb-feature-checkout", "mb-flow-signin", "mb-symptom-crash-error"],
+      },
+      {
+        key: "X-2",
+        summary: "the running total shows the wrong amount",
+        descriptionText: "",
+        commentTexts: [],
+        labels: ["mb-feature-checkout", "mb-symptom-data-incorrect"],
+      },
+    ];
+    const result2 = await run({
+      fetchOpenDefects: async () => run2Issues,
+      classifier: CLASSIFIER,
+      catalog: MEMBERSHIP,
+      writer,
+      apply: true,
+      log: () => undefined,
+    });
+    expect(result2.applied).toBe(0);
+    // The empty-diff short-circuit fired: NO PUT was issued on the re-run.
+    expect(fetchImpl).toHaveBeenCalledTimes(0);
+  });
+
+  it("dry-run default makes ZERO writes", async () => {
+    const fetchImpl = okFetchSpy();
+    const writer = buildJiraNamespacedLabelWriter(CONFIG, fetchImpl as unknown as typeof fetch);
+    const result = await run({
+      fetchOpenDefects: async () => [
+        { key: "X-1", summary: "the app crashed", descriptionText: "", commentTexts: [] },
+      ],
+      classifier: CLASSIFIER,
+      catalog: MEMBERSHIP,
+      writer,
+      apply: false,
+      log: () => undefined,
+    });
+    expect(result.applied).toBe(0);
+    expect(fetchImpl).toHaveBeenCalledTimes(0);
+  });
+});
+
+describe("AC-5 (backfill) — unknown value → rejected + ZERO fetch", () => {
+  it("rejects an unknown feature and never calls the writer's fetchImpl", async () => {
+    const fetchImpl = okFetchSpy();
+    const writer = buildJiraNamespacedLabelWriter(CONFIG, fetchImpl as unknown as typeof fetch);
+    const badClassifier: IssueFeatureFlowClassifier = {
+      async classify() {
+        return { feature: "not-in-catalog", flows: [] };
+      },
+    };
+    const result = await run({
+      fetchOpenDefects: async () => [
+        { key: "X-9", summary: "the app crashed", descriptionText: "", commentTexts: [] },
+      ],
+      classifier: badClassifier,
+      catalog: MEMBERSHIP,
+      writer,
+      apply: true,
+      log: () => undefined,
+    });
+    expect(result.rejected).toBe(1);
+    expect(result.validated).toBe(0);
+    expect(result.applied).toBe(0);
+    expect(fetchImpl).toHaveBeenCalledTimes(0);
+  });
+});


### PR DESCRIPTION
Write bot-namespaced Jira labels (mb-feature-*/mb-flow-*/mb-symptom-*) for sortable defect categorization + one-time idempotent backfill. Diff-driven remove+add writer, empty-diff short-circuit, validate-before-write against the catalog, enumerated label JQL (no wildcard), single-source slug(). 12 new tests; 316 total pass.

https://claude.ai/code/session_018TnaPsVNYG78F7y2YipqWL
