### PR TITLE
Harden 3 caller-input / error-path surfaces with non-vacuous tests (#1328)

### DIFF
--- a/src/catalog/distill.ts
+++ b/src/catalog/distill.ts
@@ -28,12 +28,15 @@ export interface DistillDeps {
  *
  * 1. Validate provenance: keep only ids present in the corpus; drop entries
  *    left with zero valid provenance ids.
- * 2. Assign a stable id `<prefix>-<slug(label)>` (empty slugs fall back to a
- *    sentinel so they remain addressable).
- * 3. Dedup: entries that slug to the SAME id are the same feature/flow — merge
- *    them, UNIONing their provenance (insertion-ordered, de-duplicated). Because
- *    same-slug entries merge here, the surviving id space is collision-free by
- *    construction, so no numeric `-2`/`-3` disambiguation is needed.
+ * 2. Assign a stable id `<prefix>-<slug(label)>`. Labels that normalize to an
+ *    EMPTY slug (symbols-only, emoji-only, whitespace-only) fall back to an
+ *    `entry` sentinel so they stay addressable — but DISTINCT empty-normalizing
+ *    labels are disambiguated (`entry`, `entry-2`, …) so two different junk
+ *    labels do NOT silently collapse into one (collision becomes detectable).
+ * 3. Dedup: NON-empty entries that slug to the SAME id are the same feature/flow
+ *    — merge them, UNIONing their provenance (insertion-ordered, de-duplicated).
+ *    An identical empty-normalizing label still merges with itself; only DISTINCT
+ *    empty-normalizing labels are kept apart.
  * 4. Sort by id ascending for deterministic output.
  */
 function buildEntries(
@@ -43,13 +46,30 @@ function buildEntries(
 ): CatalogEntry[] {
   // Map keyed by slug -> merged entry (preserves first-seen label deterministically).
   const bySlug = new Map<string, { label: string; provenance: string[] }>();
+  // Empty-normalizing labels (slug() -> "") share the `entry` fallback. Key them
+  // by their ORIGINAL label so an identical junk label still merges with itself,
+  // while DISTINCT junk labels each get a deterministic, detectable id
+  // (`entry`, `entry-2`, …) instead of silently collapsing into one entry.
+  const emptyLabelToSlug = new Map<string, string>();
 
   for (const entry of raw) {
     const provenance = (entry.provenancePageIds ?? []).filter((id) => corpusIds.has(id));
     // Drop entries with zero valid provenance (AC-PROVENANCE-PRUNE).
     if (provenance.length === 0) continue;
 
-    const s = slug(entry.label) || "entry";
+    const normalized = slug(entry.label);
+    let s: string;
+    if (normalized) {
+      s = normalized;
+    } else {
+      let fallback = emptyLabelToSlug.get(entry.label);
+      if (fallback === undefined) {
+        const n = emptyLabelToSlug.size;
+        fallback = n === 0 ? "entry" : `entry-${n + 1}`;
+        emptyLabelToSlug.set(entry.label, fallback);
+      }
+      s = fallback;
+    }
     const existing = bySlug.get(s);
     if (existing) {
       // Dedup: union provenance, keeping insertion order without duplicates.

--- a/src/ingestion/parsers/pdf.ts
+++ b/src/ingestion/parsers/pdf.ts
@@ -14,7 +14,12 @@ export async function parsePdf(filePath: string, source: string): Promise<Chunk[
     if (err instanceof Error && err.name === "PasswordException") {
       throw new Error(`${filePath} is password-protected`);
     }
-    throw err;
+    // Any other load/parse failure (corrupted, empty, malformed) is wrapped in a
+    // friendly, typed error so raw pdfjs internals / stack frames never leak to
+    // the caller. The original is preserved out-of-band via `cause` for debugging.
+    throw new Error(`${filePath} is not a readable PDF (corrupted, empty, or malformed)`, {
+      cause: err,
+    });
   }
 
   try {

--- a/src/jira/categoryWriter.ts
+++ b/src/jira/categoryWriter.ts
@@ -21,6 +21,26 @@ export interface JiraCategoryWriterOptions {
   labelPrefix?: string;
 }
 
+/**
+ * A Jira-label-safe prefix: lowercase alphanumerics joined by single internal
+ * hyphens (matches the repo's slug convention). Rejects spaces, `@`, `/`, `:`,
+ * uppercase, the empty string, and leading/trailing/double hyphens.
+ */
+const LABEL_PREFIX_RE = /^[a-z0-9]+(-[a-z0-9]+)*$/;
+
+/**
+ * Fail-loud construction-time guard for `labelPrefix` (mirrors the issueKey
+ * `TypeError` style). Throws before any PUT, so a malformed prefix can never be
+ * stamped into a Jira label that would silently fail server-side.
+ */
+export function assertValidLabelPrefix(prefix: string): void {
+  if (typeof prefix !== "string" || !LABEL_PREFIX_RE.test(prefix)) {
+    throw new TypeError(
+      `buildJiraCategoryWriter: labelPrefix ${JSON.stringify(prefix)} is not a valid Jira label prefix (lowercase alphanumerics with single internal hyphens)`,
+    );
+  }
+}
+
 export function buildJiraCategoryWriter(
   config: JiraClientConfig,
   fetchImpl: typeof fetch = globalThis.fetch,
@@ -33,6 +53,7 @@ export function buildJiraCategoryWriter(
   }
   const base = config.baseUrl.replace(/\/$/, "");
   const prefix = options.labelPrefix ?? "defect-category";
+  assertValidLabelPrefix(prefix);
 
   return {
     async setCategory(issueKey: string, category: string): Promise<void> {

--- a/test-fixtures/corrupted.pdf
+++ b/test-fixtures/corrupted.pdf
@@ -1,0 +1,3 @@
+%PDF-not-a-real-pdf
+<<garbage bytes here>>
+not-a-real-pdf-trailer

--- a/tests/catalog.test.ts
+++ b/tests/catalog.test.ts
@@ -113,6 +113,101 @@ describe("dedup — entries that slug to the same id merge, unioning provenance"
   });
 });
 
+describe("AC-SLUG-FALLBACK — a single empty-normalizing label stays addressable (#1328 Surface 2)", () => {
+  it("yields exactly one entry with the feature-entry sentinel id", async () => {
+    const distiller: CatalogDistiller = {
+      async distill() {
+        return {
+          // "!@#$" normalizes (via the shared slug()) to the empty string.
+          features: [{ label: "!@#$", provenancePageIds: ["p1"] }],
+          flows: [],
+        };
+      },
+    };
+    const catalog = await distillCatalog(PAGES, { distiller, now: FROZEN_NOW });
+    expect(catalog.features).toHaveLength(1);
+    expect(catalog.features[0].id).toBe("feature-entry");
+    expect(catalog.features[0].provenancePageIds).toEqual(["p1"]);
+  });
+});
+
+describe("AC-SLUG-COLLISION-DETECTABLE — distinct empty-normalizing labels stay distinct (#1328 Surface 2)", () => {
+  it("two different junk labels produce two detectable entries, not one silent merge", async () => {
+    const distiller: CatalogDistiller = {
+      async distill() {
+        return {
+          features: [
+            { label: "!@#$", provenancePageIds: ["p1"] },
+            { label: "🚀", provenancePageIds: ["p3"] }, // emoji-only, also empty-normalizes
+          ],
+          flows: [],
+        };
+      },
+    };
+    const catalog = await distillCatalog(PAGES, { distiller, now: FROZEN_NOW });
+    // Both survive as distinct entries (NOT one merged feature-entry).
+    expect(catalog.features).toHaveLength(2);
+    const ids = catalog.features.map((f) => f.id);
+    expect(ids).toContain("feature-entry");
+    expect(ids).toContain("feature-entry-2");
+    // Provenance is NOT unioned across the two distinct labels.
+    const byId = new Map(catalog.features.map((f) => [f.id, f]));
+    expect(byId.get("feature-entry")!.provenancePageIds).toEqual(["p1"]);
+    expect(byId.get("feature-entry-2")!.provenancePageIds).toEqual(["p3"]);
+    // Both original labels are preserved (provenance/detectability kept).
+    const labels = catalog.features.map((f) => f.label).sort();
+    expect(labels).toEqual(["!@#$", "🚀"]);
+  });
+});
+
+describe("AC-SLUG-EMPTY-NORMALIZE-EDGES — a batch of empty-normalizing labels all stay detectable (#1328 Surface 2)", () => {
+  it("symbols / emoji / whitespace / very-long all-symbol inputs each get a distinct id, deterministically", async () => {
+    const longSymbols = "#".repeat(200);
+    const distiller: CatalogDistiller = {
+      async distill() {
+        return {
+          features: [
+            { label: "!@#$", provenancePageIds: ["p1"] }, // symbols-only
+            { label: "🚀🚀", provenancePageIds: ["p2"] }, // emoji-only
+            { label: "   ", provenancePageIds: ["p3"] }, // whitespace-only
+            { label: longSymbols, provenancePageIds: ["p1"] }, // very-long all-symbol
+          ],
+          flows: [],
+        };
+      },
+    };
+    const r1 = await distillCatalog(PAGES, { distiller, now: FROZEN_NOW });
+    // Four distinct empty-normalizing labels -> four distinct, detectable ids.
+    expect(r1.features).toHaveLength(4);
+    const ids = r1.features.map((f) => f.id);
+    expect(new Set(ids).size).toBe(4);
+    for (const id of ids) {
+      expect(id.startsWith("feature-entry")).toBe(true);
+    }
+    // Deterministic across re-runs (AC-STABLEID preserved on the fallback path).
+    const r2 = await distillCatalog(PAGES, { distiller, now: FROZEN_NOW });
+    expect(JSON.stringify(r2.features)).toBe(JSON.stringify(r1.features));
+  });
+
+  it("an identical empty-normalizing label appearing twice still merges with itself", async () => {
+    const distiller: CatalogDistiller = {
+      async distill() {
+        return {
+          features: [
+            { label: "!@#$", provenancePageIds: ["p1"] },
+            { label: "!@#$", provenancePageIds: ["p3"] }, // same junk label -> one entry
+          ],
+          flows: [],
+        };
+      },
+    };
+    const catalog = await distillCatalog(PAGES, { distiller, now: FROZEN_NOW });
+    expect(catalog.features).toHaveLength(1);
+    expect(catalog.features[0].id).toBe("feature-entry");
+    expect(catalog.features[0].provenancePageIds).toEqual(["p1", "p3"]);
+  });
+});
+
 describe("AC-NO-NETWORK — zero global fetch across the full run() orchestration (N2)", () => {
   it("never touches globalThis.fetch after the whole run(deps) CLI smoke", async () => {
     const fetchSpy = jest.fn();

--- a/tests/jira.categoryWriter.test.ts
+++ b/tests/jira.categoryWriter.test.ts
@@ -1,4 +1,22 @@
-import { buildJiraCategoryWriter } from "../src/jira/categoryWriter";
+import {
+  buildJiraCategoryWriter,
+  assertValidLabelPrefix,
+} from "../src/jira/categoryWriter";
+
+const VALID_CONFIG = {
+  baseUrl: "https://example.atlassian.net",
+  email: "a@b.c",
+  apiToken: "tok",
+};
+const okFetch = () =>
+  jest.fn(async () => ({
+    ok: true,
+    status: 204,
+    statusText: "No Content",
+    async json() {
+      return {};
+    },
+  })) as unknown as typeof fetch;
 
 describe("buildJiraCategoryWriter — outward write (mocked, never live)", () => {
   it("AC-8: setCategory issues PUT /rest/api/3/issue/{key} with a labels-add body", async () => {
@@ -65,5 +83,49 @@ describe("buildJiraCategoryWriter — outward write (mocked, never live)", () =>
     );
     await expect(writer.setCategory("PROJ-1", "other")).rejects.toThrow(/403/);
     await expect(writer.setCategory("", "other")).rejects.toThrow(TypeError);
+  });
+});
+
+describe("labelPrefix validation — fail loud at construction time (#1328 Surface 3)", () => {
+  const INVALID_PREFIXES = [
+    "bad prefix", // space
+    "at@sign", // @
+    "a/b", // /
+    "has:colon", // :
+    "Defect", // uppercase
+    "", // empty
+    "-lead", // leading hyphen
+    "trail-", // trailing hyphen
+    "dou--ble", // double hyphen
+  ];
+
+  it("AC-PREFIX-REJECT: buildJiraCategoryWriter throws TypeError for each invalid prefix", () => {
+    for (const labelPrefix of INVALID_PREFIXES) {
+      expect(() => buildJiraCategoryWriter(VALID_CONFIG, okFetch(), { labelPrefix })).toThrow(
+        TypeError,
+      );
+    }
+  });
+
+  it("AC-PREFIX-REJECT (direct): assertValidLabelPrefix throws TypeError for each invalid prefix", () => {
+    for (const labelPrefix of INVALID_PREFIXES) {
+      expect(() => assertValidLabelPrefix(labelPrefix)).toThrow(TypeError);
+    }
+  });
+
+  it("AC-PREFIX-ACCEPT: valid prefixes build and stamp <prefix>:<category>", async () => {
+    for (const labelPrefix of ["defect-category", "kind", "mb-feature"]) {
+      const fetchImpl = okFetch();
+      const writer = buildJiraCategoryWriter(VALID_CONFIG, fetchImpl, { labelPrefix });
+      await writer.setCategory("PROJ-7", "crash-error");
+      const init = (fetchImpl as unknown as jest.Mock).mock.calls[0][1] as { body: string };
+      expect(JSON.parse(init.body)).toEqual({
+        update: { labels: [{ add: `${labelPrefix}:crash-error` }] },
+      });
+    }
+  });
+
+  it("AC-PREFIX-ACCEPT: the default prefix (no option) builds successfully", () => {
+    expect(() => buildJiraCategoryWriter(VALID_CONFIG, okFetch())).not.toThrow();
   });
 });

--- a/tests/pdf-error-paths.test.ts
+++ b/tests/pdf-error-paths.test.ts
@@ -1,0 +1,67 @@
+import * as path from "path";
+import { parsePdf } from "../src/ingestion/parsers/pdf";
+
+/**
+ * Surface 1 (#1328) — graceful failure for unreadable PDFs.
+ *
+ * Real synthetic fixtures (NO mocks) so the genuine pdfjs failure path is
+ * exercised: a 0-byte file and a non-PDF garbage file. The friendly wrapper must
+ * name the file + a human phrase and must NOT leak raw pdfjs internals or a stack
+ * frame. The PasswordException branch must stay ORDERED FIRST (covered by the
+ * separate tests/pdf-password.test.ts, asserted intact below).
+ */
+
+const fixturesDir = path.resolve(__dirname, "..", "test-fixtures");
+const fx = (name: string) => path.join(fixturesDir, name);
+
+const FRIENDLY_PHRASE = "is not a readable PDF (corrupted, empty, or malformed)";
+// A thrown JS stack frame looks like `\n    at <fn> (<file>:<line>:<col>)`.
+const STACK_FRAME_SHAPE = /\n\s*at\s+/;
+
+async function messageFrom(filePath: string): Promise<string> {
+  try {
+    await parsePdf(filePath, path.basename(filePath));
+  } catch (err) {
+    return (err as Error).message;
+  }
+  throw new Error(`expected parsePdf to reject for ${filePath}`);
+}
+
+describe("parsePdf — graceful failure on unreadable PDFs (#1328 Surface 1)", () => {
+  it("AC-PDF-EMPTY: a 0-byte PDF rejects with the friendly wrapper, no stack-frame leak", async () => {
+    const message = await messageFrom(fx("empty.pdf"));
+    expect(message).toContain(fx("empty.pdf"));
+    expect(message).toContain(FRIENDLY_PHRASE);
+    expect(message).not.toMatch(STACK_FRAME_SHAPE);
+    // No raw pdfjs-internal class tokens leak into the user-facing message.
+    expect(message).not.toMatch(/InvalidPDFException|MissingPDFException|UnknownErrorException/);
+  });
+
+  it("AC-PDF-CORRUPT: a non-PDF garbage file rejects with the same friendly wrapper", async () => {
+    const message = await messageFrom(fx("corrupted.pdf"));
+    expect(message).toContain(fx("corrupted.pdf"));
+    expect(message).toContain(FRIENDLY_PHRASE);
+    expect(message).not.toMatch(STACK_FRAME_SHAPE);
+    expect(message).not.toMatch(/InvalidPDFException|MissingPDFException|UnknownErrorException/);
+  });
+
+  it("preserves the original pdfjs error out-of-band via `cause` (debuggable, not user-facing)", async () => {
+    let caught: unknown;
+    try {
+      await parsePdf(fx("corrupted.pdf"), "corrupted.pdf");
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(Error);
+    // The raw internals are retained for debugging but kept OUT of the message.
+    expect((caught as Error).cause).toBeDefined();
+  });
+
+  it("AC-PDF-PASSWORD-INTACT: the still-valid happy-path sample.pdf does NOT reject", async () => {
+    // Ordering guard: a readable PDF must still parse — the generic wrapper only
+    // fires on the failure path, never on a good document. (The password-branch
+    // ordering itself is pinned by tests/pdf-password.test.ts.)
+    const chunks = await parsePdf(fx("sample.pdf"), "sample.pdf");
+    expect(chunks.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## What

Three small, disjoint, fully-ungated quality-polish surfaces hardened in one PR. Each fails clearly instead of silently doing the wrong thing or leaking internals. No happy-path behavior change; existing suite stays green (37 → 38 suites, 316 → 328 tests). Every new test is red-before-green verified.

### Surface 1 — PDF graceful failure (`src/ingestion/parsers/pdf.ts`)
A corrupt/empty/malformed PDF previously rethrew the raw pdf-library error (a scary internal stack trace). Now wrapped in a friendly typed `Error` that names the file plus a human phrase, with the original preserved out-of-band via `cause`. The password-protected branch stays ordered first. New `tests/pdf-error-paths.test.ts` drives real synthetic fixtures (a 0-byte file and a garbage file) through the genuine failure path and asserts no stack-frame or internal-class token leaks.

### Surface 2 — catalog slug collision detectable (`src/catalog/distill.ts` `buildEntries`)
Two *different* labels made only of symbols/emoji/whitespace both normalized to one fallback id and silently merged (data loss). Now disambiguated deterministically (`entry`, `entry-2`, …) keyed by the original label, so an identical junk label still merges with itself while distinct junk labels each stay addressable. The shared `slug.ts` normalize is **not** touched — it feeds both catalog ids and the namespaced label writer, so changing it would desync id ↔ label matching.

### Surface 3 — label-prefix validation (`src/jira/categoryWriter.ts`)
A caller could hand in a malformed label prefix (spaces/`@`/`/`/uppercase) that silently produced a bad label. New exported `assertValidLabelPrefix()` (lowercase alnum + single internal hyphens) is called at construction time, mirroring the existing fail-loud `TypeError`. Rejects spaces / `@` / `/` / `:` / uppercase / empty / hyphen-edges; accepts the default plus `kind` and `mb-feature`.

## Tests
`npm test` → 38 suites / 328 tests pass. `typecheck` + `build` clean. Each new test was confirmed to fail on the pre-fix code (mutation-revert each surface → red → restore). Synthetic data only (`example.atlassian.net`, `PROJ-*` keys, invented labels/slugs).

https://claude.ai/code/session_018TnaPsVNYG78F7y2YipqWL