### PR TITLE
fix(triage): #1333 classifier precedence — match summary only + drop bare 'flow' token

### DIFF
--- a/src/triage/categorizeDefect.ts
+++ b/src/triage/categorizeDefect.ts
@@ -67,7 +67,7 @@ export interface DefectResult {
 interface DefectRule {
   category: Exclude<DefectCategory, "other">;
   name: string;
-  /** Keyword/regex over the combined text (summary + description). */
+  /** Keyword/regex over the defect SUMMARY text. */
   text?: RegExp;
   /** Label values (lowercased) that trigger this rule. */
   labels?: string[];
@@ -112,7 +112,7 @@ const RULES: readonly DefectRule[] = [
   {
     category: "navigation-flow",
     name: "navigation-flow:keyword",
-    text: /\b(navigat\w*|redirect(?:s|ed|ing)?|back button|transition(?:s|ed|ing)?|route(?:s|d|ing)?|deep ?link|flow)\b/i,
+    text: /\b(navigat\w*|redirect(?:s|ed|ing)?|back button|transition(?:s|ed|ing)?|route(?:s|d|ing)?|deep ?link)\b/i,
   },
   {
     category: "performance",
@@ -134,7 +134,12 @@ function ruleMatches(rule: DefectRule, text: string, labels: string[], issueType
  * wins; no match → `{ category: "other", matchedRule: "fallback" }`.
  */
 export function categorizeDefect(input: DefectInput): { category: DefectCategory; matchedRule: string } {
-  const text = `${input.summary ?? ""} ${input.descriptionText ?? ""}`;
+  // Match rules on the SUMMARY only. The summary carries the user's symptom
+  // signal; the long description boilerplate (e.g. a QA "Actual result: an error
+  // occurred." line) would otherwise let a stray keyword steal precedence
+  // (#1333). `descriptionText` stays on `DefectInput` for shape-compat with
+  // `cli.ts`; it is simply no longer fed to the matcher.
+  const text = input.summary ?? "";
   const labels = (input.labels ?? []).map((l) => l.toLowerCase());
   const issueType = (input.issueType ?? "").toLowerCase();
 

--- a/tests/triage.categorizeDefect.test.ts
+++ b/tests/triage.categorizeDefect.test.ts
@@ -99,6 +99,46 @@ describe("categorizeDefect — symptom taxonomy + rules", () => {
   });
 });
 
+describe("categorizeDefect — #1333 precedence-theft fix", () => {
+  // Synthetic fixtures (invented generic-English) proving the #1333 fix:
+  // (1) rules match the SUMMARY only — a stray "error" in the description no
+  //     longer steals a ticket into crash-error; (2) the bare "flow" token is
+  //     dropped from navigation-flow so a "Flow …" naming prefix is not auto-filed
+  //     as navigation. AC-1/AC-2 are RED on master, GREEN after the fix; AC-3
+  //     guards that real navigation phrasing still classifies as navigation-flow.
+
+  it("#1333 theft-1: description boilerplate 'error' does NOT steal a data-incorrect summary", () => {
+    // Summary is a data-incorrect symptom; the description carries the QA
+    // boilerplate word "error". Pre-fix (summary+description) → crash-error.
+    // Post-fix (summary only) → data-incorrect.
+    const input: DefectInput = {
+      summary: "the running total shows the wrong amount",
+      descriptionText:
+        "Steps to reproduce: open the screen. Expected result: correct value. Actual result: an error occurred.",
+    };
+    expect(categorizeDefect(input).category).toBe("data-incorrect");
+  });
+
+  it("#1333 theft-2: a bare 'Flow' naming prefix is NOT auto-filed as navigation-flow", () => {
+    // Summary begins with the "Flow" naming prefix and contains no other symptom
+    // keyword. Pre-fix the bare "flow" token fired navigation-flow; post-fix it
+    // falls through to `other`.
+    const input: DefectInput = {
+      summary: "Flow Reports: revisit the quarterly digest wording",
+    };
+    expect(categorizeDefect(input).category).toBe("other");
+  });
+
+  it("#1333 nav-guard: genuine navigation phrasing still classifies as navigation-flow", () => {
+    // Removing the bare "flow" token must not break real navigation matching:
+    // redirect/route still trigger navigation-flow. Stays GREEN before and after.
+    const input: DefectInput = {
+      summary: "the redirect loops back to the previous route",
+    };
+    expect(categorizeDefect(input).category).toBe("navigation-flow");
+  });
+});
+
 describe("categorizeAll — grouped counts", () => {
   it("AC-6: per-category counts equal the per-result tally", () => {
     const inputs = SYNTHETIC.map((s) => s.input);


### PR DESCRIPTION
## ELI5

We have a machine that sorts bug tickets into bins by their *symptom* (crashed / shows wrong number / page won't load …). Two sorting rules were cheating:

1. The **crash/error** rule read the ticket's title *and* the long description underneath. Almost every description has the boilerplate word "error" in it, so the crash rule scooped up tickets whose real problem was "shows the wrong number" — stuffing them in the crash bin and starving two other bins.
2. The **navigation** rule listed the lone word "flow" as a trigger. Lots of titles just *start* with "Flow …" as a naming habit, so the navigation bin became a junk-drawer.

The fix: (a) make the rules read **only the title**, not the boilerplate description; and (b) delete the lone word "flow" from the navigation rule. Real navigation words (redirect / route / transition / back button / deep link) are kept.

Change is ~2 LOC in `src/triage/categorizeDefect.ts` plus three synthetic test fixtures. No bucket names / `DEFECT_CATEGORIES` / taxonomy change. `descriptionText` stays on the `DefectInput` interface (cli.ts still maps it) — only its use in regex matching is removed.

## Acceptance criteria

- **AC-1 (CORE, non-vacuous)** — a data-incorrect summary whose description contains "error" classifies as `data-incorrect`. Observed: pre-fix `crash-error` (RED) → post-fix `data-incorrect` (GREEN). ✅ Covered by test `#1333 theft-1`.
- **AC-2 (CORE, non-vacuous)** — a summary beginning with the bare "Flow" naming prefix and no other symptom keyword classifies as `other`. Observed: pre-fix `navigation-flow` (RED) → post-fix `other` (GREEN). ✅ Covered by test `#1333 theft-2`.
- **AC-3 (GUARD)** — a genuine navigation summary ("the redirect loops back to the previous route") still classifies as `navigation-flow`. Observed: `navigation-flow` both pre- and post-fix (stays GREEN). ✅ Covered by test `#1333 nav-guard`.
- **AC-4 (GUARD — no taxonomy drift)** — `DefectCategory` / `DEFECT_CATEGORIES` unchanged (diff touches only the matched-text source + navigation regex + the new fixtures). ✅
- **AC-5 (REGRESSION)** — `npm test` full suite GREEN: **38 suites, 331 tests passed**. ✅
- **AC-6 (BUILD)** — `npm run build` (tsc) succeeds with zero type errors. ✅

Non-vacuity proof: ran the three new fixtures against master's `categorizeDefect.ts` logic — theft-1 and theft-2 FAIL pre-fix (`crash-error` / `navigation-flow`) and PASS post-fix; nav-guard passes both.

## Scope / privacy

- Confined to `src/triage/categorizeDefect.ts` (matched-text source + navigation regex) and `tests/triage.categorizeDefect.test.ts` (3 added synthetic fixtures). `slug.ts` and the namespaced-label writer untouched.
- All fixtures are invented generic-English sentences — no real internal product/feature/flow names, hostnames, project/space keys, colleague identifiers, or personal email. Privacy grep for absolute home paths on both changed files returns **0**.

https://claude.ai/code/session_018TnaPsVNYG78F7y2YipqWL