### PR TITLE
feat: enrich symptom classifier keywords + gitignored extension loader (#1341)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,11 @@ dist/
 .claude/
 tmp/
 
+# Local symptom-keyword extension file (#1341) — real internal vocab, NEVER committed.
+# Matches at repo root and any subdir (no leading slash). Path is supplied via
+# MONDAY_KEYWORD_EXTENSIONS_FILE; populated by the operator locally after merge.
+keyword-extensions*.json
+
 # Tier-B golden eval PRIVATE fixture (#1170): 5 real UAT questions + real
 # ground-truth source ids + a real saved index. NEVER committed to this public
 # repo. The synthetic golden-private.example.json template stays tracked.

--- a/scripts/backfill-namespaced-labels.js
+++ b/scripts/backfill-namespaced-labels.js
@@ -39,6 +39,7 @@ const path = require("path");
 
 const DIST = path.resolve(__dirname, "..", "dist");
 const { run } = require(path.join(DIST, "triage", "backfill"));
+const { loadKeywordExtensions } = require(path.join(DIST, "triage", "keywordExtensions"));
 const { buildNullClassifier } = require(path.join(DIST, "triage", "classifier"));
 const { buildOpenDefectsFetcher } = require(path.join(DIST, "jira", "sync"));
 const {
@@ -123,6 +124,9 @@ async function main() {
     fetchOpenDefects: () => fetcher.fetchOpenDefects(projectKey),
     classifier: buildNullClassifier(),
     catalog: membershipFromCatalog(catalog),
+    // Optional keyword extensions read from a gitignored local file (path via
+    // MONDAY_KEYWORD_EXTENSIONS_FILE). Absent/malformed → {} → classify as today.
+    extensions: loadKeywordExtensions(undefined, (msg) => console.error(msg)),
     apply,
   };
   // The writer is constructed ONLY on --apply (dry-run never builds it).

--- a/scripts/categorize-defects.js
+++ b/scripts/categorize-defects.js
@@ -27,6 +27,7 @@ const path = require("path");
 
 const DIST = path.resolve(__dirname, "..", "dist");
 const { run } = require(path.join(DIST, "triage", "cli"));
+const { loadKeywordExtensions } = require(path.join(DIST, "triage", "keywordExtensions"));
 const { buildOpenDefectsFetcher } = require(path.join(DIST, "jira", "sync"));
 const { buildJiraCategoryWriter } = require(path.join(DIST, "jira", "categoryWriter"));
 
@@ -69,6 +70,9 @@ async function main() {
 
   const deps = {
     fetchOpenDefects: () => fetcher.fetchOpenDefects(projectKey),
+    // Optional keyword extensions read from a gitignored local file (path via
+    // MONDAY_KEYWORD_EXTENSIONS_FILE). Absent/malformed → {} → classify as today.
+    extensions: loadKeywordExtensions(undefined, (msg) => console.error(msg)),
     apply,
   };
   // The writer is constructed ONLY on --apply (dry-run never builds it).

--- a/src/triage/backfill.ts
+++ b/src/triage/backfill.ts
@@ -1,4 +1,4 @@
-import { categorizeDefect } from "./categorizeDefect";
+import { categorizeDefect, CategoryExtensions } from "./categorizeDefect";
 import { IssueFeatureFlowClassifier } from "./classifier";
 import type { JiraIssue } from "../jira/sync";
 import type { JiraNamespacedLabelWriter } from "../jira/namespacedLabelWriter";
@@ -36,6 +36,11 @@ export interface BackfillRunDeps {
   apply?: boolean;
   /** Logger sink; defaults to `console.log`. */
   log?: (msg: string) => void;
+  /**
+   * Optional runtime keyword extensions (compiled by the shell's loader from a
+   * gitignored local file). When absent, classification is identical to today.
+   */
+  extensions?: CategoryExtensions;
 }
 
 export interface BackfillRunResult {
@@ -59,13 +64,16 @@ export async function run(deps: BackfillRunDeps): Promise<BackfillRunResult> {
   let applied = 0;
 
   for (const issue of issues) {
-    const { category } = categorizeDefect({
-      key: issue.key,
-      summary: issue.summary,
-      descriptionText: issue.descriptionText,
-      labels: issue.labels,
-      issueType: issue.issueType,
-    });
+    const { category } = categorizeDefect(
+      {
+        key: issue.key,
+        summary: issue.summary,
+        descriptionText: issue.descriptionText,
+        labels: issue.labels,
+        issueType: issue.issueType,
+      },
+      deps.extensions,
+    );
     const ff = await deps.classifier.classify(issue);
     const assignment: LabelAssignment = {
       feature: ff.feature,

--- a/src/triage/categorizeDefect.ts
+++ b/src/triage/categorizeDefect.ts
@@ -64,6 +64,18 @@ export interface DefectResult {
   matchedRule: string;
 }
 
+/**
+ * Compiled, runtime-supplied extra keyword patterns, keyed by matchable category
+ * (every `DefectCategory` EXCEPT `other`, which owns no rule). Each value is a list
+ * of already-compiled `RegExp` objects — PLAIN DATA passed IN, so the matcher does
+ * ZERO I/O and stays pure (the file read lives in the loader + the shells, #1341).
+ * An extension for category C is evaluated at C's EXISTING precedence rank (see
+ * `categorizeDefect`), never appended after `other`.
+ */
+export type CategoryExtensions = Partial<
+  Record<Exclude<DefectCategory, "other">, RegExp[]>
+>;
+
 interface DefectRule {
   category: Exclude<DefectCategory, "other">;
   name: string;
@@ -92,22 +104,22 @@ const RULES: readonly DefectRule[] = [
   {
     category: "cannot-complete",
     name: "cannot-complete:keyword",
-    text: /\b(can ?not|cant|can.?t|unable|not able|doesn.?t|does not|won.?t|will not|fail(?:s|ed|ing|ure)?|not work(?:ing)?|no response|unresponsive|block(?:s|ed)?|disabled|greyed|grayed|stop(?:s|ped|ping)? working|unavailable|reject(?:s|ed|ing)?)\b/i,
+    text: /\b(can ?not|cant|can.?t|unable|not able|doesn.?t|does not|won.?t|will not|could ?n.?t|would ?n.?t|did ?n.?t|expire[ds]?|fail(?:s|ed|ing|ure)?|not work(?:ing)?|no response|unresponsive|block(?:s|ed)?|disabled|greyed|grayed|stop(?:s|ped|ping)? working|unavailable|reject(?:s|ed|ing)?)\b/i,
   },
   {
     category: "data-incorrect",
     name: "data-incorrect:keyword",
-    text: /\b(wrong|incorrect|mismatch|not match|inaccurate|miscalc(?:ulat\w*)?|invalid|should be|instead of|not correct|calcul\w*|amount|price|fee|total|count|balance|number|value|duplicat\w*|wrongly|null|reflect(?:s|ed|ing)?|update(?:s|d|ing)?|outdated|sync(?:s|ed|ing|hroni\w*)?|reset(?:s|ting)?)\b/i,
+    text: /\b(wrong|incorrect|mismatch|not match|inaccurate|accurate|miscalc(?:ulat\w*)?|invalid|should be|instead of|not correct|calcul\w*|amount|price|fee|total|count|balance|number|value|duplicat\w*|wrongly|null|reflect(?:s|ed|ing)?|update(?:s|d|ing)?|outdated|sync(?:s|ed|ing|hroni\w*)?|reset(?:s|ting)?)\b/i,
   },
   {
     category: "missing-element",
     name: "missing-element:keyword",
-    text: /\b(missing|not show(?:n|ing)?|not display(?:ed|ing)?|not appear(?:ing)?|blank|empty|no data|not visible|disappear(?:s|ed|ing)?|absent|without|gone|nothing show)\b/i,
+    text: /\b(missing|not show(?:n|ing)?|not display(?:ed|ing)?|not appear(?:ing)?|not there|blank|empty|no data|not visible|disappear(?:s|ed|ing)?|absent|without|gone|nothing show)\b/i,
   },
   {
     category: "display-ui",
     name: "display-ui:keyword",
-    text: /\b(ui|layout|align(?:ment|ed)?|overlap(?:s|ping|ped)?|cut ?off|button|icon|colou?r|font|spacing|display|design|truncat\w*|responsive|scroll(?:s|ing)?|padding|margin|image|photo|text|label|popup|pop-up|modal|banner|grey|gray|black|white|keyboard|swipe|tap|stack(?:s|ed|ing)?|indicator|toggle|theme)\b/i,
+    text: /\b(ui|layout|align(?:ment|ed)?|overlap(?:s|ping|ped)?|cut ?off|button|icon|colou?r|font|spacing|display|design|truncat\w*|responsive|scroll(?:s|ing)?|padding|margin|image|photo|text|label|popup|pop-up|pop ?up|modal|banner|grey|gray|black|white|keyboard|swipe|tap|stack(?:s|ed|ing)?|indicator|toggle|theme)\b/i,
   },
   {
     category: "navigation-flow",
@@ -133,7 +145,10 @@ function ruleMatches(rule: DefectRule, text: string, labels: string[], issueType
  * the same `{ category, matchedRule }`. First matching rule in precedence order
  * wins; no match → `{ category: "other", matchedRule: "fallback" }`.
  */
-export function categorizeDefect(input: DefectInput): { category: DefectCategory; matchedRule: string } {
+export function categorizeDefect(
+  input: DefectInput,
+  extraRules?: CategoryExtensions,
+): { category: DefectCategory; matchedRule: string } {
   // Match rules on the SUMMARY only. The summary carries the user's symptom
   // signal; the long description boilerplate (e.g. a QA "Actual result: an error
   // occurred." line) would otherwise let a stray keyword steal precedence
@@ -147,6 +162,16 @@ export function categorizeDefect(input: DefectInput): { category: DefectCategory
     if (ruleMatches(rule, text, labels, issueType)) {
       return { category: rule.category, matchedRule: rule.name };
     }
+    // Runtime extensions for THIS rule's category are tested immediately after
+    // its base rule, i.e. at the category's EXISTING precedence rank (one rule
+    // per category). A higher base rule still short-circuits first
+    // (first-match-wins unchanged); extensions match the SAME summary `text`,
+    // preserving the #1333 summary-only guarantee. The `:ext` suffix makes an
+    // extension-driven match observable without leaking the pattern.
+    const ext = extraRules?.[rule.category];
+    if (ext && ext.some((re) => re.test(text))) {
+      return { category: rule.category, matchedRule: `${rule.name}:ext` };
+    }
   }
   return { category: "other", matchedRule: "fallback" };
 }
@@ -156,7 +181,10 @@ export function categorizeDefect(input: DefectInput): { category: DefectCategory
  * seeded with EVERY category at 0 (so the shape is stable + no category is
  * silently absent), then incremented per result.
  */
-export function categorizeAll(inputs: DefectInput[]): {
+export function categorizeAll(
+  inputs: DefectInput[],
+  extraRules?: CategoryExtensions,
+): {
   results: DefectResult[];
   counts: Record<DefectCategory, number>;
 } {
@@ -165,7 +193,7 @@ export function categorizeAll(inputs: DefectInput[]): {
     number
   >;
   const results: DefectResult[] = inputs.map((input) => {
-    const { category, matchedRule } = categorizeDefect(input);
+    const { category, matchedRule } = categorizeDefect(input, extraRules);
     counts[category] += 1;
     return { key: input.key, category, matchedRule };
   });

--- a/src/triage/cli.ts
+++ b/src/triage/cli.ts
@@ -1,5 +1,6 @@
 import {
   categorizeAll,
+  CategoryExtensions,
   DEFECT_CATEGORIES,
   DefectCategory,
   DefectInput,
@@ -28,6 +29,11 @@ export interface CategorizeRunDeps {
   apply?: boolean;
   /** Logger sink; defaults to `console.log`. */
   log?: (msg: string) => void;
+  /**
+   * Optional runtime keyword extensions (compiled by the shell's loader from a
+   * gitignored local file). When absent, classification is identical to today.
+   */
+  extensions?: CategoryExtensions;
 }
 
 export interface CategorizeRunResult {
@@ -53,7 +59,7 @@ export async function run(deps: CategorizeRunDeps): Promise<CategorizeRunResult>
 
   const issues = await deps.fetchOpenDefects();
   const inputs = issues.map(toDefectInput);
-  const { results, counts } = categorizeAll(inputs);
+  const { results, counts } = categorizeAll(inputs, deps.extensions);
 
   // Per-defect planned category (preview).
   log(`Categorized ${results.length} open defect(s) (${apply ? "APPLY" : "dry-run"}):`);

--- a/src/triage/index.ts
+++ b/src/triage/index.ts
@@ -3,7 +3,13 @@ export {
   categorizeAll,
   DEFECT_CATEGORIES,
 } from "./categorizeDefect";
-export type { DefectCategory, DefectInput, DefectResult } from "./categorizeDefect";
+export type {
+  DefectCategory,
+  DefectInput,
+  DefectResult,
+  CategoryExtensions,
+} from "./categorizeDefect";
+export { loadKeywordExtensions, KEYWORD_EXTENSIONS_ENV } from "./keywordExtensions";
 export { run } from "./cli";
 export type { CategorizeRunDeps, CategorizeRunResult } from "./cli";
 export { buildNullClassifier } from "./classifier";

--- a/src/triage/keywordExtensions.ts
+++ b/src/triage/keywordExtensions.ts
@@ -1,0 +1,126 @@
+/**
+ * Keyword-extension loader (#1341) — the ONLY I/O ring for the runtime keyword
+ * extensions. The pure matcher (`categorizeDefect`) stays I/O-free; this module
+ * reads a local, GITIGNORED JSON file, validates + compiles its patterns, and
+ * hands the matcher PLAIN DATA (`CategoryExtensions`) via the two shells.
+ *
+ * The file's real internal vocabulary must NEVER be committed to this public
+ * repo — it lives at a gitignored path (`keyword-extensions*.json`) and is
+ * populated by the operator locally AFTER merge. WHERE the file lives is the
+ * single responsibility of the `MONDAY_KEYWORD_EXTENSIONS_FILE` env var.
+ *
+ * Graceful-degradation contract: an absent / empty / unreadable / malformed /
+ * partially-invalid file NEVER throws to the caller — it degrades to `{}` (or a
+ * partial result keeping the valid entries), so classification is IDENTICAL to
+ * having no extensions at all. Only TRULY unexpected errors (not the expected
+ * file-missing / parse / shape / bad-pattern cases) are allowed to surface.
+ */
+import * as fs from "fs";
+import {
+  CategoryExtensions,
+  DefectCategory,
+  DEFECT_CATEGORIES,
+} from "./categorizeDefect";
+
+/** Env var naming WHERE the local extensions file lives (matches the repo's `MONDAY_` prefix). */
+export const KEYWORD_EXTENSIONS_ENV = "MONDAY_KEYWORD_EXTENSIONS_FILE";
+
+/** Matchable categories = every `DefectCategory` except the rule-less `other`. */
+function isMatchableCategory(key: string): key is Exclude<DefectCategory, "other"> {
+  return key !== "other" && (DEFECT_CATEGORIES as readonly string[]).includes(key);
+}
+
+/** A read error we EXPECT and degrade-on (file missing / unreadable / a directory). */
+function isExpectedReadError(err: unknown): boolean {
+  if (err == null || typeof err !== "object") return false;
+  const code = (err as NodeJS.ErrnoException).code;
+  // ENOENT (missing), EACCES (permission), EISDIR (path is a dir), ENOTDIR — all
+  // mean "the file isn't a readable JSON file here", which is a degrade case.
+  return (
+    code === "ENOENT" ||
+    code === "EACCES" ||
+    code === "EISDIR" ||
+    code === "ENOTDIR"
+  );
+}
+
+/**
+ * Load + compile runtime keyword extensions.
+ *
+ * Path source: `filePath ?? process.env.MONDAY_KEYWORD_EXTENSIONS_FILE`. An empty
+ * / undefined resolved path means "no extensions" → `{}` (no file read).
+ *
+ * File shape: `{ "<DefectCategory>": ["<regex-source>", ...], ... }`. Each pattern
+ * string is compiled with `new RegExp(pattern, "i")` (case-insensitive, matching
+ * the base-rule style). Every degradation mode below returns `{}` or a partial
+ * result and NEVER throws:
+ *   - missing / unreadable file, or path is a directory  → `{}`
+ *   - empty file / invalid JSON / root is not a plain object → `{}`
+ *   - a key that is not a matchable `DefectCategory` (incl. `"other"`) → skip key
+ *   - a value that is not an array of strings → skip that category
+ *   - a pattern that fails to compile → skip that one pattern, keep the rest
+ */
+export function loadKeywordExtensions(
+  filePath?: string,
+  log?: (msg: string) => void,
+): CategoryExtensions {
+  const note = (msg: string) => {
+    if (log) log(`keyword-extensions: ${msg}`);
+  };
+
+  const resolved = filePath ?? process.env[KEYWORD_EXTENSIONS_ENV];
+  if (!resolved || resolved.trim() === "") {
+    return {};
+  }
+
+  let raw: string;
+  try {
+    raw = fs.readFileSync(resolved, "utf8");
+  } catch (err) {
+    if (isExpectedReadError(err)) {
+      note(`file not readable at ${resolved} — using no extensions`);
+      return {};
+    }
+    // Truly unexpected I/O failure — surface it rather than masking a real bug.
+    throw err;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    note("file is not valid JSON — using no extensions");
+    return {};
+  }
+
+  if (parsed == null || typeof parsed !== "object" || Array.isArray(parsed)) {
+    note("file root is not a JSON object — using no extensions");
+    return {};
+  }
+
+  const out: CategoryExtensions = {};
+  for (const [key, value] of Object.entries(parsed as Record<string, unknown>)) {
+    if (!isMatchableCategory(key)) {
+      note(`skipping unknown category key "${key}"`);
+      continue;
+    }
+    if (!Array.isArray(value) || !value.every((v) => typeof v === "string")) {
+      note(`skipping category "${key}" — value is not an array of strings`);
+      continue;
+    }
+
+    const compiled: RegExp[] = [];
+    for (const pattern of value as string[]) {
+      try {
+        compiled.push(new RegExp(pattern, "i"));
+      } catch {
+        note(`skipping invalid pattern in "${key}"`);
+      }
+    }
+    if (compiled.length > 0) {
+      out[key] = compiled;
+    }
+  }
+
+  return out;
+}

--- a/tests/triage.categorizeDefect.test.ts
+++ b/tests/triage.categorizeDefect.test.ts
@@ -139,6 +139,57 @@ describe("categorizeDefect — #1333 precedence-theft fix", () => {
   });
 });
 
+describe("#1341 keyword enrichment", () => {
+  // PART A — five generic keyword adds (the `jump` add was dropped per
+  // plan-review S1 to avoid stealing display/scroll "jump" symptoms). Each
+  // fixture is SYNTHETIC and isolates its NEW keyword: the only token that
+  // triggers the target category is the newly-added one.
+  const PART_A: Array<{ summary: string; expected: DefectCategory; note: string }> = [
+    { summary: "the eta is not accurate", expected: "data-incorrect", note: "A1 accurate" },
+    { summary: "the upload didn't finish", expected: "cannot-complete", note: "A3 didn't" },
+    { summary: "the session expired", expected: "cannot-complete", note: "A4 expired" },
+    { summary: "the link expires too early", expected: "cannot-complete", note: "A4 expires (S3 widening)" },
+    { summary: "the save control is not there", expected: "missing-element", note: "A5 not there" },
+    { summary: "a pop up covers the panel", expected: "display-ui", note: "A6 pop up" },
+  ];
+
+  it.each(PART_A)("PART A: %o classifies to its target category", ({ summary, expected }) => {
+    expect(categorizeDefect({ summary }).category).toBe(expected);
+  });
+
+  // Extension-via-injected-object (no file I/O) — proves the B.3 precedence
+  // wiring directly. `frobnicate`/`wibble` are invented terms that match no
+  // built-in rule, so they isolate the extension behavior cleanly.
+  it("extension term lands in its category with a :ext matchedRule", () => {
+    const extraRules = { performance: [/frobnicate/i] };
+    const r = categorizeDefect({ summary: "the page will frobnicate on open" }, extraRules);
+    expect(r.category).toBe("performance");
+    expect(r.matchedRule.endsWith(":ext")).toBe(true);
+  });
+
+  it("a higher BASE rule still outranks a lower-rank extension", () => {
+    const extraRules = { performance: [/frobnicate/i] };
+    // Also hits crash-error (crashed) at rank 1 — base wins over a performance ext.
+    const r = categorizeDefect(
+      { summary: "the app crashed while it tried to frobnicate" },
+      extraRules,
+    );
+    expect(r.category).toBe("crash-error");
+  });
+
+  it("an extension is evaluated at its category's RANK, not appended after other", () => {
+    const extraRules = { "missing-element": [/frobnicate/i] };
+    const r = categorizeDefect({ summary: "the widget will frobnicate" }, extraRules);
+    expect(r.category).toBe("missing-element");
+  });
+
+  it("no-extensions parity: a synthetic term matches nothing built-in (one-arg → other)", () => {
+    expect(categorizeDefect({ summary: "the page will frobnicate on open" }).category).toBe(
+      "other",
+    );
+  });
+});
+
 describe("categorizeAll — grouped counts", () => {
   it("AC-6: per-category counts equal the per-result tally", () => {
     const inputs = SYNTHETIC.map((s) => s.input);

--- a/tests/triage.keywordExtensions.test.ts
+++ b/tests/triage.keywordExtensions.test.ts
@@ -1,0 +1,144 @@
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import {
+  loadKeywordExtensions,
+  KEYWORD_EXTENSIONS_ENV,
+} from "../src/triage/keywordExtensions";
+import { categorizeDefect, categorizeAll } from "../src/triage/categorizeDefect";
+
+/**
+ * Loader contract tests (#1341). All fixtures are SYNTHETIC (invented terms only:
+ * `frobnicate`, `wibble`). Hermetic: no test depends on the real process env or a
+ * real on-disk file — each writes its own temp file and the env-var cases
+ * snapshot/clear/restore `MONDAY_KEYWORD_EXTENSIONS_FILE` so an ambient value in
+ * the developer's shell cannot pollute the assertions.
+ */
+describe("loadKeywordExtensions — graceful loader contract", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "kw-ext-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  /** Write a temp file with the given contents and return its path. */
+  function writeTmp(name: string, contents: string): string {
+    const p = path.join(tmpDir, name);
+    fs.writeFileSync(p, contents, "utf8");
+    return p;
+  }
+
+  it("valid file → compiled RegExp per category; feeds categorizeDefect", () => {
+    const file = writeTmp(
+      "keyword-extensions.json",
+      JSON.stringify({ performance: ["frobnicate"], "missing-element": ["wibble"] }),
+    );
+    const loaded = loadKeywordExtensions(file);
+
+    expect(loaded.performance?.length).toBe(1);
+    expect(loaded.performance?.[0].test("the page will frobnicate")).toBe(true);
+    expect(loaded["missing-element"]?.[0].test("the wibble is absent here")).toBe(true);
+
+    // End-to-end: the loaded object routes a synthetic term to its category.
+    expect(categorizeDefect({ summary: "the page will frobnicate" }, loaded).category).toBe(
+      "performance",
+    );
+  });
+
+  it("missing file → {}", () => {
+    const loaded = loadKeywordExtensions(path.join(tmpDir, "does-not-exist.json"));
+    expect(loaded).toEqual({});
+  });
+
+  it("path is a directory → {} (unexpected-but-handled read error)", () => {
+    const loaded = loadKeywordExtensions(tmpDir);
+    expect(loaded).toEqual({});
+  });
+
+  it("empty file → {}", () => {
+    const file = writeTmp("empty.json", "");
+    expect(loadKeywordExtensions(file)).toEqual({});
+  });
+
+  it("malformed JSON → {}", () => {
+    const file = writeTmp("bad.json", "{ not json");
+    expect(loadKeywordExtensions(file)).toEqual({});
+  });
+
+  it("non-object root (array) → {}", () => {
+    const file = writeTmp("arr.json", JSON.stringify(["frobnicate"]));
+    expect(loadKeywordExtensions(file)).toEqual({});
+  });
+
+  it("unknown category key is skipped; valid keys survive", () => {
+    const file = writeTmp(
+      "mixed.json",
+      JSON.stringify({ "totally-not-a-category": ["x"], performance: ["frobnicate"] }),
+    );
+    const loaded = loadKeywordExtensions(file);
+    expect(loaded).not.toHaveProperty("totally-not-a-category");
+    expect(loaded.performance?.[0].test("frobnicate")).toBe(true);
+  });
+
+  it("the rule-less `other` key is rejected", () => {
+    const file = writeTmp("other.json", JSON.stringify({ other: ["x"] }));
+    expect(loadKeywordExtensions(file)).toEqual({});
+  });
+
+  it("non-array value for a category is skipped", () => {
+    const file = writeTmp(
+      "nonarr.json",
+      JSON.stringify({ performance: "frobnicate", "missing-element": ["wibble"] }),
+    );
+    const loaded = loadKeywordExtensions(file);
+    expect(loaded).not.toHaveProperty("performance");
+    expect(loaded["missing-element"]?.[0].test("wibble")).toBe(true);
+  });
+
+  it("bad pattern is skipped; the rest of the category survives", () => {
+    const file = writeTmp("badpat.json", JSON.stringify({ performance: ["(", "frobnicate"] }));
+    const loaded = loadKeywordExtensions(file);
+    expect(loaded.performance?.length).toBe(1);
+    expect(loaded.performance?.[0].test("frobnicate")).toBe(true);
+  });
+
+  describe("env-var path source (hermetic snapshot/restore)", () => {
+    let saved: string | undefined;
+
+    beforeEach(() => {
+      saved = process.env[KEYWORD_EXTENSIONS_ENV];
+      delete process.env[KEYWORD_EXTENSIONS_ENV];
+    });
+
+    afterEach(() => {
+      if (saved === undefined) delete process.env[KEYWORD_EXTENSIONS_ENV];
+      else process.env[KEYWORD_EXTENSIONS_ENV] = saved;
+    });
+
+    it("absent env var (no arg) → {}", () => {
+      expect(loadKeywordExtensions(undefined)).toEqual({});
+    });
+
+    it("env var pointing at a valid file is honored", () => {
+      const file = writeTmp("via-env.json", JSON.stringify({ performance: ["frobnicate"] }));
+      process.env[KEYWORD_EXTENSIONS_ENV] = file;
+      const loaded = loadKeywordExtensions();
+      expect(loaded.performance?.[0].test("frobnicate")).toBe(true);
+    });
+  });
+
+  it("identical-behavior proof: missing extensions ⇒ counts unchanged", () => {
+    const inputs = [
+      { summary: "the application crashed unexpectedly" },
+      { summary: "the running total shows the wrong amount" },
+      { summary: "general miscellaneous note" },
+    ];
+    const base = categorizeAll(inputs);
+    const withMissing = categorizeAll(inputs, loadKeywordExtensions("/nonexistent/path.json"));
+    expect(withMissing.counts).toEqual(base.counts);
+  });
+});


### PR DESCRIPTION
## What

Two changes to the deterministic symptom classifier (`src/triage/categorizeDefect.ts`), plus a gitignored external-extension mechanism.

### PART A — five generic keyword adds (no rule reorder; precedence unchanged)
Reduces false-negatives that previously fell into the `other` bucket:

| Category | Added | Catches |
|---|---|---|
| data-incorrect | `accurate` | "the eta is not accurate" |
| cannot-complete | `couldn't` / `wouldn't` / `didn't` | "the upload didn't finish" |
| cannot-complete | `expire[ds]?` | "the session expired", "the link expires" |
| missing-element | `not there` | "the save control is not there" |
| display-ui | `pop up` | "a pop up covers the panel" |

The `jump` add proposed in the plan was **dropped** (plan-review S1): "jump" is most often a display/scroll symptom, and at data-incorrect's higher rank it would have stolen those via first-match-wins.

### PART B — optional external keyword-extension loader (graceful)
- `categorizeDefect(input, extraRules?)` / `categorizeAll(inputs, extraRules?)` gain an **optional** second param of plain pre-compiled `RegExp` data. The matcher stays pure (no I/O); every existing one-arg call site is byte-for-byte unchanged. Extensions are evaluated at each category's **existing** precedence rank, with a `:ext` matchedRule suffix.
- New I/O-isolated loader `src/triage/keywordExtensions.ts` reads a gitignored local JSON file (path via `MONDAY_KEYWORD_EXTENSIONS_FILE`, matching the repo's `MONDAY_` prefix), validates + compiles patterns, and **degrades to `{}` on every expected failure** (missing / unreadable / empty / malformed / unknown-key / `other`-key / non-array / bad-pattern) — never throws for those; truly unexpected I/O errors still surface.
- Wired at **both** live shells (`scripts/categorize-defects.js`, `scripts/backfill-namespaced-labels.js`) threading `extensions` through `deps` — no dead slot.
- `.gitignore` ignores `keyword-extensions*.json` at any depth. The real internal vocab stays **gitignored** and is populated by the operator locally **after merge** — it never lands in this public repo.

## Test coverage
- PART A: one synthetic, keyword-isolated fixture per add.
- Extension precedence proofs: lands at its rank (not after `other`), a higher base rule still outranks a lower-rank extension, `:ext` suffix observable, one-arg parity → `other`.
- Loader: every degradation mode, hermetic (temp files + env snapshot/clear/restore).
- Build clean (`tsc`), full suite green (354 tests).

All fixtures are synthetic (`frobnicate` / `wibble` / generic English); privacy grep over the diff is 0.

Refs #1064
Closes #1341