### PR TITLE
feat: reversible unstamp — remove the bot's namespaced labels (#1342)

### DIFF
--- a/scripts/backfill-namespaced-labels.js
+++ b/scripts/backfill-namespaced-labels.js
@@ -23,6 +23,14 @@
  *   Read it:       node scripts/backfill-namespaced-labels.js            (dry-run)
  *   Apply it:      node scripts/backfill-namespaced-labels.js --apply    (outward write)
  *
+ * UNSTAMP (reverse — REMOVE all the bot's labels, #1342). DRY-RUN by default;
+ * `--apply` is the ONLY mutating path; `--keys K1,K2` scopes to those issues
+ * (a typo'd/wrong-case/closed key FAILS LOUD, non-zero exit — never a silent
+ * zero-touch "success"):
+ *   Preview removes: node scripts/backfill-namespaced-labels.js --unstamp
+ *   Remove (scoped): node scripts/backfill-namespaced-labels.js --unstamp --keys ABC-1,ABC-2 --apply
+ *   Remove (sweep):  node scripts/backfill-namespaced-labels.js --unstamp --apply
+ *
  * Env: CONFLUENCE_URL (or CONFLUENCE_BASE_URL), CONFLUENCE_EMAIL,
  *      CONFLUENCE_API_TOKEN (Jira reuses the Atlassian creds), JIRA_PROJECTS
  *      (comma-separated; the FIRST entry is backfilled). Optional JQL overrides:
@@ -38,7 +46,7 @@ const fs = require("fs");
 const path = require("path");
 
 const DIST = path.resolve(__dirname, "..", "dist");
-const { run } = require(path.join(DIST, "triage", "backfill"));
+const { run, runUnstamp } = require(path.join(DIST, "triage", "backfill"));
 const { loadKeywordExtensions } = require(path.join(DIST, "triage", "keywordExtensions"));
 const { buildNullClassifier } = require(path.join(DIST, "triage", "classifier"));
 const { buildOpenDefectsFetcher } = require(path.join(DIST, "jira", "sync"));
@@ -71,6 +79,12 @@ function splitList(raw) {
     .filter(Boolean);
 }
 
+/** Value following a `--flag` on argv (e.g. `--keys A,B` → "A,B"); else undefined. */
+function argValue(flag) {
+  const i = process.argv.indexOf(flag);
+  return i === -1 ? undefined : process.argv[i + 1];
+}
+
 /** Read the gitignored catalog (or an empty catalog if absent). */
 function loadCatalog() {
   try {
@@ -87,6 +101,8 @@ function loadCatalog() {
 async function main() {
   const apply = process.argv.includes("--apply");
   const printJql = process.argv.includes("--print-jql");
+  const unstamp = process.argv.includes("--unstamp");
+  const keys = splitList(argValue("--keys"));
   const env = process.env;
 
   const catalog = loadCatalog();
@@ -119,6 +135,29 @@ async function main() {
   };
   const projectKey = projects[0];
   const fetcher = buildOpenDefectsFetcher(config, scope, globalThis.fetch);
+
+  // UNSTAMP route (#1342): remove ALL the bot's labels. DRY-RUN by default; the
+  // writer is constructed ONLY on --apply (mirrors the add path). Counts only.
+  if (unstamp) {
+    const unstampDeps = {
+      fetchOpenDefects: () => fetcher.fetchOpenDefects(projectKey),
+      keys,
+      apply,
+    };
+    if (apply) {
+      unstampDeps.writer = buildJiraNamespacedLabelWriter(config, globalThis.fetch);
+    }
+    const unstampResult = await runUnstamp(unstampDeps);
+    if (!apply) {
+      console.log(
+        `\n(dry-run: no Jira writes performed. ${unstampResult.removable} issue(s) ` +
+          "carry bot labels. Re-run with --apply to remove them.)",
+      );
+    } else {
+      console.log(`\nremoved the bot's labels from ${unstampResult.removed} issue(s).`);
+    }
+    return;
+  }
 
   const deps = {
     fetchOpenDefects: () => fetcher.fetchOpenDefects(projectKey),

--- a/src/jira/namespacedLabelWriter.ts
+++ b/src/jira/namespacedLabelWriter.ts
@@ -1,5 +1,5 @@
 import { JiraClientConfig, basicAuthHeader } from "./sync";
-import { NS_FEATURE, NS_SYMPTOM, ValidatedLabels } from "./namespacedLabels";
+import { NS_FEATURE, NS_FLOW, NS_SYMPTOM, ValidatedLabels } from "./namespacedLabels";
 
 /**
  * OUTWARD-write seam for the bot's namespaced labels (#1322).
@@ -35,9 +35,42 @@ export interface JiraNamespacedLabelWriter {
     currentLabels: string[],
     target: ValidatedLabels,
   ): Promise<boolean>;
+
+  /**
+   * REMOVE every bot-namespace label (`mb-feature-*` / `mb-flow-*` /
+   * `mb-symptom-*`) from `issueKey`, given its CURRENT labels — the reverse of
+   * `applyLabels` ("peel off ALL the bot's stickers"). Human/other labels are
+   * provably untouched. Returns `true` if a mutating PUT was issued, `false` if
+   * the issue carried no bot labels (empty diff → NO PUT → idempotent re-run /
+   * already-clean issue makes zero network calls).
+   */
+  unstampLabels(issueKey: string, currentLabels: string[]): Promise<boolean>;
 }
 
 type LabelOp = { add: string } | { remove: string };
+
+/** The bot's three private namespaces. */
+const NS_PREFIXES = [NS_FEATURE, NS_FLOW, NS_SYMPTOM];
+
+/**
+ * Compute the diff-driven REMOVE op list for an UNSTAMP: a `{ remove }` op for
+ * EVERY current label in one of the bot's three namespaces, and NOTHING else
+ * (exported for direct unit assertion — mirrors `computeLabelOps`).
+ *
+ * Bot-namespace-only by construction: a human/other label can never enter the
+ * op list. Empty result when the issue carries no bot labels (the idempotency
+ * short-circuit consumed by the writer → no PUT).
+ */
+export function computeUnstampOps(currentLabels: string[]): LabelOp[] {
+  const current = currentLabels ?? [];
+  const ops: LabelOp[] = [];
+  for (const label of current) {
+    if (NS_PREFIXES.some((prefix) => label.startsWith(prefix))) {
+      ops.push({ remove: label });
+    }
+  }
+  return ops;
+}
 
 /** Compute the diff-driven op list (exported for direct unit assertion). */
 export function computeLabelOps(currentLabels: string[], target: ValidatedLabels): LabelOp[] {
@@ -79,31 +112,43 @@ export function buildJiraNamespacedLabelWriter(
   }
   const base = config.baseUrl.replace(/\/$/, "");
 
+  // SINGLE shared PUT site (no forked auth): both apply + unstamp diff their
+  // own op list, then route through this one `{ update: { labels: ops } }` PUT.
+  async function putLabelOps(issueKey: string, ops: LabelOp[]): Promise<boolean> {
+    // Empty-diff short-circuit: issue NO PUT at all (idempotency guarantee).
+    if (ops.length === 0) return false;
+
+    const url = `${base}/rest/api/3/issue/${encodeURIComponent(issueKey)}`;
+    const res = await fetchImpl(url, {
+      method: "PUT",
+      headers: {
+        Authorization: basicAuthHeader(config),
+        "Content-Type": "application/json",
+        Accept: "application/json",
+      },
+      body: JSON.stringify({ update: { labels: ops } }),
+    });
+    if (!res.ok) {
+      throw new Error(
+        `Jira REST API returned ${res.status} ${res.statusText} for PUT issue ${issueKey}`,
+      );
+    }
+    return true;
+  }
+
   return {
     async applyLabels(issueKey, currentLabels, target): Promise<boolean> {
       if (typeof issueKey !== "string" || issueKey.length === 0) {
         throw new TypeError("applyLabels: issueKey must be a non-empty string");
       }
-      const ops = computeLabelOps(currentLabels, target);
-      // Empty-diff short-circuit: issue NO PUT at all (idempotency guarantee).
-      if (ops.length === 0) return false;
+      return putLabelOps(issueKey, computeLabelOps(currentLabels, target));
+    },
 
-      const url = `${base}/rest/api/3/issue/${encodeURIComponent(issueKey)}`;
-      const res = await fetchImpl(url, {
-        method: "PUT",
-        headers: {
-          Authorization: basicAuthHeader(config),
-          "Content-Type": "application/json",
-          Accept: "application/json",
-        },
-        body: JSON.stringify({ update: { labels: ops } }),
-      });
-      if (!res.ok) {
-        throw new Error(
-          `Jira REST API returned ${res.status} ${res.statusText} for PUT issue ${issueKey}`,
-        );
+    async unstampLabels(issueKey, currentLabels): Promise<boolean> {
+      if (typeof issueKey !== "string" || issueKey.length === 0) {
+        throw new TypeError("unstampLabels: issueKey must be a non-empty string");
       }
-      return true;
+      return putLabelOps(issueKey, computeUnstampOps(currentLabels));
     },
   };
 }

--- a/src/triage/backfill.ts
+++ b/src/triage/backfill.ts
@@ -1,7 +1,10 @@
 import { categorizeDefect, CategoryExtensions } from "./categorizeDefect";
 import { IssueFeatureFlowClassifier } from "./classifier";
 import type { JiraIssue } from "../jira/sync";
-import type { JiraNamespacedLabelWriter } from "../jira/namespacedLabelWriter";
+import {
+  computeUnstampOps,
+  type JiraNamespacedLabelWriter,
+} from "../jira/namespacedLabelWriter";
 import {
   LabelAssignment,
   LabelCatalog,
@@ -106,4 +109,102 @@ export async function run(deps: BackfillRunDeps): Promise<BackfillRunResult> {
   );
 
   return { total: issues.length, validated, rejected, applied };
+}
+
+/**
+ * Raised when one or more requested `--keys` are NOT present in the fetched
+ * open-defects set (S1, #1342). A typo'd / lowercase / already-closed key must
+ * FAIL LOUD — never silently no-op — because `--keys` drives a LIVE add→delete
+ * smoke and a zero-touch "success" would be a dangerous false-green. Carries the
+ * COUNT only (never the key values) so the structured error stays privacy-safe.
+ */
+export class UnmatchedUnstampKeysError extends Error {
+  constructor(public readonly count: number) {
+    super(
+      `unstamp: ${count} requested --keys had no match in the fetched open-defects set ` +
+        `(typo / wrong case / already-closed?) — refusing to run`,
+    );
+    this.name = "UnmatchedUnstampKeysError";
+  }
+}
+
+/** Injected deps for the UNSTAMP core (remove ALL bot labels). */
+export interface UnstampRunDeps {
+  /** Injected open-defects read. */
+  fetchOpenDefects: () => Promise<JiraIssue[]>;
+  /** Injected writer — constructed by the shell ONLY on `--apply`. */
+  writer?: JiraNamespacedLabelWriter;
+  /** Real-write flag. Default false (dry-run). */
+  apply?: boolean;
+  /**
+   * Optional scoping: restrict the run to EXACTLY these issue keys (client-side
+   * filter over the fetched open set). An unmatched key throws
+   * `UnmatchedUnstampKeysError` (S1 fail-loud). Empty / undefined → full sweep.
+   */
+  keys?: string[];
+  /** Logger sink; defaults to `console.log`. */
+  log?: (msg: string) => void;
+}
+
+export interface UnstampRunResult {
+  /** Issues in scope (after the optional `--keys` filter). */
+  total: number;
+  /** Issues carrying ≥1 bot label (would be / were peeled). */
+  removable: number;
+  /** Issues that actually received a remove-PUT (0 in dry-run / on a clean set). */
+  removed: number;
+}
+
+/**
+ * UNSTAMP core (#1342) — fetch open defects, optionally scope to `deps.keys`,
+ * compute the bot-namespace REMOVE ops per issue, and (only with `apply` +
+ * `writer`) issue the remove-PUT. Mirrors `run`'s dry-run-default +
+ * writer-optional + counts-result contract. Logs COUNTS/STRUCTURE only.
+ *
+ * Dry-run is the DEFAULT: with `apply !== true` (or no writer) it computes +
+ * previews and issues ZERO writes. `removed` counts only issues that actually
+ * received a mutating PUT — an issue with no bot labels produces an empty op
+ * list → NO PUT → does NOT increment `removed` (the idempotency guarantee).
+ */
+export async function runUnstamp(deps: UnstampRunDeps): Promise<UnstampRunResult> {
+  const log = deps.log ?? ((msg: string) => console.log(msg));
+  const apply = deps.apply === true;
+
+  const issues = await deps.fetchOpenDefects();
+
+  let scoped = issues;
+  if (deps.keys && deps.keys.length > 0) {
+    const fetchedKeys = new Set(issues.map((i) => i.key));
+    // S1 fail-loud: an EXACT-match miss (typo / wrong case / already-closed)
+    // must abort, not silently touch zero issues.
+    const unmatched = deps.keys.filter((k) => !fetchedKeys.has(k));
+    if (unmatched.length > 0) {
+      log(
+        `unstamp: ABORT — ${unmatched.length} requested key(s) not in the fetched ` +
+          `open-defects set (count only; values withheld)`,
+      );
+      throw new UnmatchedUnstampKeysError(unmatched.length);
+    }
+    const wanted = new Set(deps.keys);
+    scoped = issues.filter((i) => wanted.has(i.key));
+  }
+
+  let removable = 0;
+  let removed = 0;
+  for (const issue of scoped) {
+    const ops = computeUnstampOps(issue.labels ?? []);
+    if (ops.length === 0) continue; // no bot labels — nothing to peel.
+    removable++;
+    if (apply && deps.writer && issue.key) {
+      const didPut = await deps.writer.unstampLabels(issue.key, issue.labels ?? []);
+      if (didPut) removed++;
+    }
+  }
+
+  log(
+    `unstamp: total=${scoped.length} removable=${removable} removed=${removed} ` +
+      `(${apply ? "APPLY" : "dry-run"})`,
+  );
+
+  return { total: scoped.length, removable, removed };
 }

--- a/tests/triage.unstamp.test.ts
+++ b/tests/triage.unstamp.test.ts
@@ -1,0 +1,204 @@
+import {
+  buildJiraNamespacedLabelWriter,
+  computeUnstampOps,
+} from "../src/jira/namespacedLabelWriter";
+import { runUnstamp, UnmatchedUnstampKeysError } from "../src/triage/backfill";
+import type { JiraIssue } from "../src/jira/sync";
+
+/**
+ * #1342 — reversible UNSTAMP (remove ALL the bot's namespaced labels).
+ *
+ * SYNTHETIC fixtures ONLY: example.atlassian.net, DEMO-* keys, and invented
+ * `mb-*` slugs. ZERO live mutation — every write goes through an injected fake
+ * `fetchImpl` SPY (mirrors tests/jira.namespacedLabels.test.ts).
+ */
+
+const CONFIG = { baseUrl: "https://example.atlassian.net", email: "a@b.c", apiToken: "tok" };
+
+function okFetchSpy(): jest.Mock {
+  return jest.fn(async () => ({
+    ok: true,
+    status: 204,
+    statusText: "No Content",
+    async json() {
+      return {};
+    },
+  }));
+}
+
+/** Minimal synthetic open-defect with the given labels. */
+function issue(key: string, labels?: string[]): JiraIssue {
+  return { key, summary: "", descriptionText: "", commentTexts: [], labels };
+}
+
+describe("AC-2 — computeUnstampOps removes ONLY bot labels (human label survives)", () => {
+  it("emits a remove for each of the three namespaces, never a human label", () => {
+    const ops = computeUnstampOps(["mb-feature-x", "mb-flow-y", "mb-symptom-z", "keep-me"]);
+    expect(ops).toContainEqual({ remove: "mb-feature-x" });
+    expect(ops).toContainEqual({ remove: "mb-flow-y" });
+    expect(ops).toContainEqual({ remove: "mb-symptom-z" });
+    // Human/other label is provably untouched — never in the op list.
+    expect(JSON.stringify(ops)).not.toContain("keep-me");
+    expect(ops).toHaveLength(3);
+  });
+
+  it("returns an EMPTY op list when no bot labels are present", () => {
+    expect(computeUnstampOps(["keep-me", "another-human-label"])).toEqual([]);
+    expect(computeUnstampOps([])).toEqual([]);
+  });
+
+  // S2: TWO labels in a SINGLE-value namespace are BOTH removed (duplicate
+  // cleanup — the exact reverse of the stamp path's "remove ALL stale single").
+  it("removes BOTH labels in a single-value namespace (two mb-feature-*)", () => {
+    const ops = computeUnstampOps(["mb-feature-x", "mb-feature-y", "keep-me"]);
+    expect(ops).toContainEqual({ remove: "mb-feature-x" });
+    expect(ops).toContainEqual({ remove: "mb-feature-y" });
+    expect(ops).toHaveLength(2);
+    expect(JSON.stringify(ops)).not.toContain("keep-me");
+  });
+});
+
+describe("AC-3 — unstamp idempotency: no bot labels → no PUT → zero network", () => {
+  it("returns false and calls the injected fetch spy 0 times on an already-clean issue", async () => {
+    const fetchImpl = okFetchSpy();
+    const writer = buildJiraNamespacedLabelWriter(CONFIG, fetchImpl as unknown as typeof fetch);
+
+    const didPut = await writer.unstampLabels("DEMO-1", ["keep-me", "another-human-label"]);
+    expect(didPut).toBe(false);
+    expect(fetchImpl).toHaveBeenCalledTimes(0);
+  });
+});
+
+describe("AC-4 — multi-namespace unstamp: all bot labels removed in ONE PUT", () => {
+  it("removes feature + two flows + symptom in a single PUT, human label untouched", async () => {
+    const fetchImpl = okFetchSpy();
+    const writer = buildJiraNamespacedLabelWriter(CONFIG, fetchImpl as unknown as typeof fetch);
+
+    const didPut = await writer.unstampLabels("DEMO-3", [
+      "mb-feature-x",
+      "mb-flow-a",
+      "mb-flow-b",
+      "mb-symptom-crash-error",
+      "keep-me",
+    ]);
+    expect(didPut).toBe(true);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+
+    const [url, init] = fetchImpl.mock.calls[0] as [string, { method: string; body: string }];
+    expect(url).toBe("https://example.atlassian.net/rest/api/3/issue/DEMO-3");
+    expect(init.method).toBe("PUT");
+
+    const ops = JSON.parse(init.body).update.labels as Array<{ add?: string; remove?: string }>;
+    expect(ops).toContainEqual({ remove: "mb-feature-x" });
+    expect(ops).toContainEqual({ remove: "mb-flow-a" });
+    expect(ops).toContainEqual({ remove: "mb-flow-b" });
+    expect(ops).toContainEqual({ remove: "mb-symptom-crash-error" });
+    expect(ops).toHaveLength(4);
+    expect(JSON.stringify(ops)).not.toContain("keep-me");
+  });
+});
+
+describe("AC-5 (N1) — unstamp dry-run issues ZERO writes (spied writer, apply:false)", () => {
+  it("constructs the writer WITH a spy, runs apply:false → spy called 0 times", async () => {
+    const fetchImpl = okFetchSpy();
+    const writer = buildJiraNamespacedLabelWriter(CONFIG, fetchImpl as unknown as typeof fetch);
+
+    const result = await runUnstamp({
+      fetchOpenDefects: async () => [issue("DEMO-1", ["mb-feature-x", "mb-symptom-crash-error"])],
+      writer,
+      apply: false,
+      log: () => undefined,
+    });
+
+    expect(fetchImpl).toHaveBeenCalledTimes(0);
+    expect(result.removed).toBe(0);
+    // Preview still reports the issue WOULD be peeled.
+    expect(result.removable).toBe(1);
+    expect(result.total).toBe(1);
+  });
+});
+
+describe("AC-6 — --keys scoping: only the targeted issue receives a remove-PUT", () => {
+  it("with keys:[DEMO-1] over two synthetic issues, only DEMO-1 is PUT", async () => {
+    const fetchImpl = okFetchSpy();
+    const writer = buildJiraNamespacedLabelWriter(CONFIG, fetchImpl as unknown as typeof fetch);
+
+    const result = await runUnstamp({
+      fetchOpenDefects: async () => [
+        issue("DEMO-1", ["mb-feature-x"]),
+        issue("DEMO-2", ["mb-flow-y"]),
+      ],
+      writer,
+      apply: true,
+      keys: ["DEMO-1"],
+      log: () => undefined,
+    });
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(fetchImpl.mock.calls[0][0]).toBe(
+      "https://example.atlassian.net/rest/api/3/issue/DEMO-1",
+    );
+    expect(result.total).toBe(1);
+    expect(result.removed).toBe(1);
+  });
+
+  it("runUnstamp over a fully clean set issues ZERO PUTs (idempotent sweep)", async () => {
+    const fetchImpl = okFetchSpy();
+    const writer = buildJiraNamespacedLabelWriter(CONFIG, fetchImpl as unknown as typeof fetch);
+
+    const result = await runUnstamp({
+      fetchOpenDefects: async () => [issue("DEMO-1", ["keep-me"]), issue("DEMO-2")],
+      writer,
+      apply: true,
+      log: () => undefined,
+    });
+
+    expect(fetchImpl).toHaveBeenCalledTimes(0);
+    expect(result.removed).toBe(0);
+    expect(result.removable).toBe(0);
+    expect(result.total).toBe(2);
+  });
+});
+
+describe("S1 — unmatched --keys FAIL LOUD (no silent zero-touch success)", () => {
+  it("throws UnmatchedUnstampKeysError and issues ZERO PUTs on a key not in the set", async () => {
+    const fetchImpl = okFetchSpy();
+    const writer = buildJiraNamespacedLabelWriter(CONFIG, fetchImpl as unknown as typeof fetch);
+
+    await expect(
+      runUnstamp({
+        fetchOpenDefects: async () => [issue("DEMO-1", ["mb-feature-x"])],
+        writer,
+        apply: true,
+        keys: ["NOPE-1"],
+        log: () => undefined,
+      }),
+    ).rejects.toThrow(UnmatchedUnstampKeysError);
+
+    expect(fetchImpl).toHaveBeenCalledTimes(0);
+  });
+
+  it("treats a wrong-CASE key as unmatched (exact match) — the typo-no-op trap", async () => {
+    const fetchImpl = okFetchSpy();
+    const writer = buildJiraNamespacedLabelWriter(CONFIG, fetchImpl as unknown as typeof fetch);
+
+    await expect(
+      runUnstamp({
+        fetchOpenDefects: async () => [issue("DEMO-1", ["mb-feature-x"])],
+        writer,
+        apply: true,
+        keys: ["demo-1"], // lowercase — would silently touch zero issues without S1.
+        log: () => undefined,
+      }),
+    ).rejects.toThrow(UnmatchedUnstampKeysError);
+
+    expect(fetchImpl).toHaveBeenCalledTimes(0);
+  });
+
+  it("carries the COUNT only — never echoes the key value (privacy-safe error)", async () => {
+    const err = new UnmatchedUnstampKeysError(2);
+    expect(err.count).toBe(2);
+    expect(err.message).toContain("2");
+    expect(err.message).not.toContain("NOPE");
+  });
+});


### PR DESCRIPTION
## What & why

The bot can ADD or swap its `mb-feature-*` / `mb-flow-*` / `mb-symptom-*` labels but never fully REMOVE them, so a stamp run was not reversible. This adds the "peel off ALL the bot's stickers" capability so the live add→delete round-trip is provable both directions.

## Shape
- **`computeUnstampOps(currentLabels)`** (pure, exported) — a `{remove}` op for EVERY label in the bot's three namespaces and nothing else. Human/other labels are provably untouched; empty result when none present.
- **`unstampLabels(issueKey, currentLabels)`** on `JiraNamespacedLabelWriter` — diff-driven `PUT /issue/{key}` through a SINGLE shared PUT helper (reuses the shared `basicAuthHeader` + injectable `fetchImpl`; no forked auth). Empty ops → NO PUT → returns `false` (idempotent / zero network on a clean issue).
- **`runUnstamp(deps)`** backfill core — fetch open defects → optional `--keys` client-side scope → compute removes per issue → (only with `apply` + `writer`) remove-PUT. Returns `{ total, removable, removed }`. Logs COUNTS/STRUCTURE only.
- **CLI `--unstamp`** — DRY-RUN by default (writes NOTHING); `--apply` is the ONLY mutating path (writer constructed only on `--apply`, mirroring the add path); `--keys K1,K2` scopes the run.

## S1 fail-loud (live-smoke safety)
An unmatched `--keys` entry (typo / wrong case / already-closed) throws `UnmatchedUnstampKeysError` → non-zero exit — never a silent zero-touch "success" that would make a live smoke a dangerous false-green. The error carries the COUNT only (key values withheld).

## AC outcomes
- AC-1 full suite green incl. new unstamp tests — **365/365 pass**; `grep -REc -i unstamp tests/` = 23 (≥4).
- AC-2 bot-only removal proven (human `keep-me` never in op list).
- AC-3 idempotency — no bot labels → `false` + fetch spy 0 calls.
- AC-4 multi-namespace removal in one PUT; **S2** two single-value-namespace (`mb-feature-x`+`mb-feature-y`) both removed.
- AC-5 (**N1**) dry-run uses a spied writer + `apply:false`, asserts 0 calls.
- AC-6 `--keys` scoping — only the targeted key PUT (spy once, `DEMO-1` URL).
- AC-7 build green; `dist` probe (`computeUnstampOps` + `runUnstamp` exported) exits 0.
- AC-8 privacy grep clean — synthetic only (`example.atlassian.net`, `DEMO-*`, invented `mb-*`).

Do NOT merge — pending execution-review.