### PR TITLE
feat: Stage C viewing layer — NL→JQL skill + Jira dashboard guide (#1332)

### DIFF
--- a/docs/jira-dashboard-guide.md
+++ b/docs/jira-dashboard-guide.md
@@ -1,0 +1,94 @@
+# Jira dashboard guide — viewing the bot's namespaced labels
+
+Stage C of the namespaced-labels work gives you two ways to *look at* the bot's
+`mb-symptom-*` / `mb-feature-*` / `mb-flow-*` stickers:
+
+1. The **`/jql` skill** (terminal + Slack) — type an English question, get a JQL
+   string (and optionally the matching defects). See the repo README / `npm run jql`.
+2. **This guide** — a one-time, click-by-click setup of an always-on Jira
+   dashboard built entirely from Jira's OWN built-in chart gadgets. There is no
+   Jira-admin API for creating dashboards, so this is a human-followed recipe, not
+   code.
+
+All examples below use SYNTHETIC names only: the site `example.atlassian.net`, the
+project `DEMO`, and invented labels `mb-feature-widget` / `mb-flow-onboarding`.
+Substitute your own site, project, and (real, gitignored) catalog values as you go.
+
+> **Now vs Later in one sentence:** the **symptom** axis is LIVE today (73 open
+> defects already carry `mb-symptom-*`), so symptom gadgets are useful immediately;
+> the **feature/flow** axis is wired but *inert* until the deferred classifier
+> (#1064) populates those labels — feature/flow gadgets render empty until then.
+
+---
+
+## Prerequisite — save a filter of the bot's labels
+
+Jira label matching is EXACT (there is no `mb-*` wildcard), so you first need an
+enumerated filter of every bot label.
+
+1. Get the enumerated clause:
+
+   ```
+   npm run triage:backfill -- --print-jql
+   ```
+
+   It prints a `labels in ("mb-symptom-crash-error", …)` clause (structure only —
+   safe to paste).
+
+2. In Jira (`https://example.atlassian.net`), open **Filters → Advanced issue
+   search**, switch to **JQL** mode, paste the clause, prepend `project = DEMO AND `,
+   and **Save as** → name it `Bot-labeled defects`.
+
+You now have a saved filter every gadget below can point at.
+
+---
+
+## Gadget A — Pie / Bar of `mb-symptom-*` — useful NOW
+
+Shows the symptom mix across the open defects (e.g. how many `mb-symptom-crash-error`
+vs `mb-symptom-performance`).
+
+1. **Dashboards → Create dashboard** → name it `Defect triage`.
+2. **Add gadget → Pie Chart** (or **Bar Chart**).
+3. **Filter:** `Bot-labeled defects`. **Statistic Type:** `Labels`.
+4. Save. Because the symptom axis is live, this gadget is populated **today**.
+
+> Tip: to focus purely on symptoms, save a second filter
+> `project = DEMO AND labels in ("mb-symptom-crash-error", …)` (symptom labels only)
+> and point the Pie/Bar gadget at that.
+
+## Gadget B — Two-Dimensional Filter Statistics (feature × symptom) — useful LATER
+
+A grid with one axis = feature label, the other = symptom label — the "which areas
+crash most" view.
+
+1. **Add gadget → Two-Dimensional Filter Statistics** (the **2-D** / two-dimensional
+   gadget).
+2. **Filter:** `Bot-labeled defects`.
+3. **X Axis:** `Labels`. **Y Axis:** `Labels`.
+4. Save. The **feature rows are EMPTY until the deferred feature/flow matcher
+   (#1064) runs** — once it stamps `mb-feature-*` / `mb-flow-*` onto issues, this
+   grid fills in automatically with NO further setup. Useful **LATER**.
+
+## Gadget C — one saved filter per symptom (8 filters) — useful NOW
+
+For per-symptom counts / swimlanes.
+
+1. For each of the 8 symptom categories, save a filter like
+   `project = DEMO AND labels = "mb-symptom-crash-error"`.
+2. Add a **Filter Results** (or **Issue Statistics**) gadget per filter, or use them
+   as board swimlane queries. Live **today**.
+
+---
+
+## Now vs Later — gadget readiness table
+
+| Gadget | Built on | Axis it needs | Useful NOW or LATER |
+|---|---|---|---|
+| A — Pie / Bar of symptoms | `Labels` statistic | symptom (live) | **NOW** |
+| B — Two-Dimensional Filter Statistics (feature × symptom) | 2-D `Labels` × `Labels` | feature/flow (deferred #1064) | **LATER** — feature rows empty until the matcher runs |
+| C — per-symptom saved filters (×8) | `labels = "mb-symptom-…"` | symptom (live) | **NOW** |
+
+The dashboard is built once and self-updates: the symptom gadgets work from day one,
+and the feature/flow gadget (B) lights up on its own the moment the deferred matcher
+populates `mb-feature-*` / `mb-flow-*` — no dashboard change needed.

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "eval:golden": "npm run build && node scripts/eval-golden.js",
     "triage:categorize": "npm run build && node scripts/categorize-defects.js",
     "triage:backfill": "npm run build && node scripts/backfill-namespaced-labels.js",
+    "jql": "npm run build && node scripts/jql-from-nl.js",
     "catalog:build": "npm run build && node scripts/build-catalog.js"
   },
   "engines": {

--- a/scripts/jql-from-nl.js
+++ b/scripts/jql-from-nl.js
@@ -1,0 +1,110 @@
+#!/usr/bin/env node
+/*
+ * jql-from-nl.js — thin I/O shell over the NL→JQL viewing layer (#1332).
+ *
+ * Turns an English question into a Jira JQL string. By DEFAULT it PRINTS the JQL
+ * only (no network, no creds needed in MONDAY_TEST_MODE). With `--run` it ALSO
+ * performs ONE read-only GET and prints the matched issue keys + summaries.
+ *
+ *   Print JQL:   MONDAY_TEST_MODE=1 node scripts/jql-from-nl.js "show me crashes"
+ *   Print JQL:   node scripts/jql-from-nl.js "checkout crashes in DEMO"   (real LLM)
+ *   Run it:      node scripts/jql-from-nl.js "show me crashes" --run       (read-only GET)
+ *
+ * The FUZZY English→labels step uses the LLM (Haiku tier); the EXACT labels→JQL
+ * step is a PURE, deterministic builder. The internal feature/flow vocabulary is
+ * read ONLY at runtime from the GITIGNORED catalog and never printed/committed.
+ *
+ * Env (only needed for --run): CONFLUENCE_URL (or CONFLUENCE_BASE_URL),
+ *   CONFLUENCE_EMAIL, CONFLUENCE_API_TOKEN. Creds via env ONLY (repo is PUBLIC).
+ */
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+
+const DIST = path.resolve(__dirname, "..", "dist");
+const { buildVocab } = require(path.join(DIST, "jira", "labelVocab"));
+const { buildLlmFilterMapper } = require(path.join(DIST, "jira", "nlFilterMapper"));
+const { answerNlQuery } = require(path.join(DIST, "jira", "nlToJql"));
+const { buildJqlSearchFetcher } = require(path.join(DIST, "jira", "sync"));
+
+/** Gitignored catalog path (mirrors backfill-namespaced-labels.js). */
+const CATALOG_OUTPUT_PATH = path.resolve(
+  __dirname,
+  "..",
+  ".ai-workspace",
+  "catalog",
+  "feature-catalog.json",
+);
+
+/** Read the gitignored catalog (or an empty catalog if absent). */
+function loadCatalog() {
+  try {
+    const raw = JSON.parse(fs.readFileSync(CATALOG_OUTPUT_PATH, "utf8"));
+    return {
+      features: Array.isArray(raw.features) ? raw.features : [],
+      flows: Array.isArray(raw.flows) ? raw.flows : [],
+    };
+  } catch {
+    return { features: [], flows: [] };
+  }
+}
+
+/** Strip a trailing /wiki (and trailing slash) so the site root feeds Jira REST. */
+function toSiteRoot(url) {
+  return url.replace(/\/wiki\/?$/, "").replace(/\/$/, "");
+}
+
+async function main() {
+  const argv = process.argv.slice(2);
+  const run = argv.includes("--run");
+  const question = argv.filter((a) => !a.startsWith("--")).join(" ").trim();
+
+  if (!question) {
+    console.error('Usage: node scripts/jql-from-nl.js "<question>" [--run]');
+    process.exit(1);
+  }
+
+  const catalog = loadCatalog();
+  const vocab = buildVocab(catalog);
+  const mapper = buildLlmFilterMapper();
+
+  let search;
+  if (run) {
+    const env = process.env;
+    const url = env.CONFLUENCE_URL || env.CONFLUENCE_BASE_URL;
+    const email = env.CONFLUENCE_EMAIL;
+    const apiToken = env.CONFLUENCE_API_TOKEN;
+    if (!url || !email || !apiToken) {
+      console.error(
+        "--run needs CONFLUENCE_URL (or CONFLUENCE_BASE_URL), CONFLUENCE_EMAIL, " +
+          "CONFLUENCE_API_TOKEN in the environment.",
+      );
+      process.exit(1);
+    }
+    const config = { baseUrl: toSiteRoot(url), email, apiToken };
+    search = buildJqlSearchFetcher(config, globalThis.fetch);
+  }
+
+  const result = await answerNlQuery(question, { mapper, vocab, search, run });
+
+  // JQL first (the operator pastes this); warnings to stderr so stdout is clean.
+  console.log(result.jql);
+  for (const w of result.warnings) console.error(`warning: ${w}`);
+
+  if (run && Array.isArray(result.issues)) {
+    console.log("");
+    if (result.issues.length === 0) {
+      console.log("(no matching defects)");
+    } else {
+      for (const issue of result.issues) {
+        console.log(issue.summary ? `${issue.key}\t${issue.summary}` : issue.key);
+      }
+    }
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/jira/jqlFromFilter.ts
+++ b/src/jira/jqlFromFilter.ts
@@ -1,0 +1,184 @@
+/**
+ * PURE, I/O-free NL→JQL builder (#1332 — Stage C viewing layer).
+ *
+ * The determinism seam: the FUZZY "English → which labels" step is the LLM's job
+ * (`nlFilterMapper`); this module is the EXACT "labels → JQL string" half. It has
+ * NO LLM, NO fs, NO network — given the same `(filter, vocab)` it returns a
+ * byte-identical `{ jql, warnings }` every time, so the JQL contract can be
+ * exhaustively unit-tested and never surprises us.
+ *
+ * Determinism + injection-safety: every label slug is canonicalised through the
+ * ONE shared `slug()` before quoting, and the `labels in (...)` clause is built
+ * by the ONE shared `labelsInClause` (sort + dedupe + double-quote) — so weird
+ * characters collapse to hyphens and there is no JQL-quoting hazard.
+ *
+ * Forward-compat (symptom live NOW; feature/flow wired-but-inert): the symptom
+ * axis validates HARD against the live taxonomy. The feature/flow axes validate
+ * catalog-conditionally — when the gitignored catalog has NOT landed yet
+ * (`featureIds`/`flowIds` empty) a requested feature/flow PASSES THROUGH into the
+ * JQL (so the clause is correct) plus a warning that it "matches nothing until
+ * the deferred matcher runs"; once the catalog lands, an unknown slug is dropped
+ * + warned (kills LLM hallucinations). Warnings name the AXIS only, never echo a
+ * rejected raw value (mirrors `LabelValidationError` log discipline — PUBLIC repo).
+ */
+import { slug } from "../catalog/slug";
+import { labelsInClause, NS_FEATURE, NS_FLOW, NS_SYMPTOM } from "./namespacedLabels";
+
+/**
+ * The structured query the LLM maps an English question to (`nlFilterMapper`),
+ * and the PURE builder's input. Each axis is a list of bare slugs (within-axis
+ * OR). `extraStatus` is an OPERATOR-ONLY raw status override — the LLM mapper
+ * MUST NEVER populate it (see `nlFilterMapper`); the default path is
+ * `statusCategory != Done`.
+ */
+export interface StructuredFilter {
+  /** Symptom slugs (validated HARD against the 8-value taxonomy). */
+  symptoms: string[];
+  /** `mb-feature` slugs (catalog vocab; empty-tolerant / forward-compatible). */
+  features: string[];
+  /** `mb-flow` slugs (catalog vocab; empty-tolerant / forward-compatible). */
+  flows: string[];
+  /** Jira project keys, e.g. `["DEMO"]`. */
+  projects: string[];
+  /** OPERATOR-ONLY raw status clause override. Default = `statusCategory != Done`. */
+  extraStatus?: string;
+}
+
+/**
+ * The legal vocabulary, injected into the builder. Built by `buildVocab` from the
+ * symptom taxonomy + the gitignored catalog's entry ids. `featureIds`/`flowIds`
+ * may be EMPTY today (catalog not yet populated) — the builder is forward-compatible.
+ */
+export interface LabelVocab {
+  /** The live symptom slugs (the 8-value `DEFECT_CATEGORIES`). */
+  symptoms: ReadonlySet<string>;
+  /** Catalog feature entry ids (`feature-<slug>`); may be EMPTY today. */
+  featureIds: ReadonlySet<string>;
+  /** Catalog flow entry ids (`flow-<slug>`); may be EMPTY today. */
+  flowIds: ReadonlySet<string>;
+}
+
+/** The builder's deterministic output. */
+export interface JqlBuildResult {
+  jql: string;
+  warnings: string[];
+}
+
+/** Default open-defects status clause (mirrors `buildOpenDefectsJql`). */
+const DEFAULT_STATUS = "statusCategory != Done";
+
+/**
+ * Resolve a feature/flow axis against the catalog. Catalog-conditional:
+ *   - EMPTY catalog set → every requested slug PASSES THROUGH as a label + one
+ *     "not yet populated" warning (the clause is correct but inert until the
+ *     deferred matcher runs).
+ *   - NON-EMPTY catalog set → a slug whose `<idPrefix><slug>` id is not in the
+ *     set is DROPPED + warned (kills hallucinations); known slugs become labels.
+ * Labels emitted are `<labelPrefix><slug>` (e.g. `mb-feature-widget`).
+ */
+function resolveCatalogAxis(
+  values: readonly string[],
+  catalogIds: ReadonlySet<string>,
+  idPrefix: string,
+  labelPrefix: string,
+  axisName: string,
+  warnings: string[],
+): string[] {
+  const labels: string[] = [];
+  let dropped = 0;
+  const catalogEmpty = catalogIds.size === 0;
+  for (const raw of values) {
+    const s = slug(raw ?? "");
+    if (s.length === 0) continue;
+    if (catalogEmpty) {
+      labels.push(`${labelPrefix}${s}`);
+      continue;
+    }
+    if (catalogIds.has(`${idPrefix}${s}`)) {
+      labels.push(`${labelPrefix}${s}`);
+    } else {
+      dropped++;
+    }
+  }
+  if (catalogEmpty && labels.length > 0) {
+    warnings.push(
+      `${axisName} labels not yet populated — this clause matches nothing until the deferred matcher runs.`,
+    );
+  }
+  if (dropped > 0) {
+    warnings.push(`dropped ${dropped} unknown ${axisName} value(s) (not in catalog).`);
+  }
+  return labels;
+}
+
+/**
+ * Build the JQL string from a structured filter + the legal vocabulary.
+ *
+ * Composition: `project in (...)` (when projects present) AND each non-empty
+ * label axis (feature, then flow, then symptom — within-axis OR via
+ * `labels in (...)`, across-axis AND) AND the status clause (last). Pure +
+ * referentially transparent: same `(filter, vocab)` → identical `{jql, warnings}`.
+ */
+export function buildJqlFromFilter(filter: StructuredFilter, vocab: LabelVocab): JqlBuildResult {
+  const warnings: string[] = [];
+
+  // --- Symptom axis: HARD validation against the live taxonomy ---
+  const symptomLabels: string[] = [];
+  let droppedSymptoms = 0;
+  for (const raw of filter.symptoms ?? []) {
+    const s = slug(raw ?? "");
+    if (s.length === 0) continue;
+    if (vocab.symptoms.has(s)) {
+      symptomLabels.push(`${NS_SYMPTOM}${s}`);
+    } else {
+      droppedSymptoms++;
+    }
+  }
+  if (droppedSymptoms > 0) {
+    warnings.push(`dropped ${droppedSymptoms} unknown symptom value(s) (not in taxonomy).`);
+  }
+
+  // --- Feature / flow axes: catalog-conditional (forward-compatible) ---
+  const featureLabels = resolveCatalogAxis(
+    filter.features ?? [],
+    vocab.featureIds,
+    "feature-",
+    NS_FEATURE,
+    "feature",
+    warnings,
+  );
+  const flowLabels = resolveCatalogAxis(
+    filter.flows ?? [],
+    vocab.flowIds,
+    "flow-",
+    NS_FLOW,
+    "flow",
+    warnings,
+  );
+
+  // --- Project clause (prepended) — keys sanitised for injection-safety ---
+  const projectKeys = [
+    ...new Set(
+      (filter.projects ?? [])
+        .map((p) => (p ?? "").replace(/[^A-Za-z0-9_]/g, "").toUpperCase())
+        .filter((p) => p.length > 0),
+    ),
+  ].sort();
+
+  // --- Assemble: project AND feature AND flow AND symptom AND status ---
+  const clauses: string[] = [];
+  if (projectKeys.length > 0) {
+    clauses.push(`project in (${projectKeys.join(",")})`);
+  }
+  if (featureLabels.length > 0) clauses.push(labelsInClause(featureLabels));
+  if (flowLabels.length > 0) clauses.push(labelsInClause(flowLabels));
+  if (symptomLabels.length > 0) clauses.push(labelsInClause(symptomLabels));
+
+  const status =
+    typeof filter.extraStatus === "string" && filter.extraStatus.trim().length > 0
+      ? filter.extraStatus.trim()
+      : DEFAULT_STATUS;
+  clauses.push(status);
+
+  return { jql: clauses.join(" AND "), warnings };
+}

--- a/src/jira/labelVocab.ts
+++ b/src/jira/labelVocab.ts
@@ -1,0 +1,26 @@
+/**
+ * PURE vocab builder (#1332). Composes the legal `LabelVocab` the NL→JQL seam
+ * validates against: the live symptom taxonomy + the catalog's feature/flow
+ * entry ids. NO fs / network here — the gitignored-catalog read lives in the CLI
+ * shell, which passes a (synthetic or real) `CatalogIdSource` in.
+ */
+import { DEFECT_CATEGORIES } from "../triage/categorizeDefect";
+import { CatalogIdSource, membershipFromCatalog } from "./namespacedLabels";
+import { LabelVocab } from "./jqlFromFilter";
+
+/**
+ * Build the `LabelVocab` from a catalog + (optionally overridden) symptom set.
+ * Reuses `membershipFromCatalog` so the feature/flow id sets are derived exactly
+ * as the label writer derives them — one source of truth, no drift.
+ */
+export function buildVocab(
+  catalog: CatalogIdSource,
+  symptoms: readonly string[] = DEFECT_CATEGORIES,
+): LabelVocab {
+  const membership = membershipFromCatalog(catalog);
+  return {
+    symptoms: new Set(symptoms),
+    featureIds: membership.featureIds,
+    flowIds: membership.flowIds,
+  };
+}

--- a/src/jira/namespacedLabels.ts
+++ b/src/jira/namespacedLabels.ts
@@ -148,6 +148,20 @@ export function buildDesiredLabels(
 }
 
 /**
+ * Render a SORTED, DE-DUPED, double-quoted `labels in (...)` JQL clause from a
+ * list of label strings. Jira label matching is EXACT — there is NO `mb-*`
+ * wildcard — so an explicit enumerated list is the only way to match "these
+ * labels". This is the ONE shared clause builder: both `buildBotLabelJql` and
+ * the NL→JQL builder (`buildJqlFromFilter`) compose their `labels in (...)`
+ * clauses through here so quoting/sort/dedupe never drift. Deterministic.
+ */
+export function labelsInClause(labels: readonly string[]): string {
+  const sorted = [...new Set(labels)].sort();
+  const quoted = sorted.map((l) => `"${l}"`).join(",");
+  return `labels in (${quoted})`;
+}
+
+/**
  * Generate the ENUMERATED `labels in (...)` JQL for every bot label the catalog
  * can produce. Jira label matching is EXACT — there is NO `mb-*` wildcard — so
  * "only the bot's labels" must be an explicit, sorted, double-quoted list the
@@ -162,7 +176,5 @@ export function buildBotLabelJql(
     ...catalog.flows.map((e) => `mb-${e.id}`),
     ...symptoms.map((s) => `${NS_SYMPTOM}${s}`),
   ];
-  const sorted = [...new Set(labels)].sort();
-  const quoted = sorted.map((l) => `"${l}"`).join(",");
-  return `labels in (${quoted})`;
+  return labelsInClause(labels);
 }

--- a/src/jira/nlFilterMapper.ts
+++ b/src/jira/nlFilterMapper.ts
@@ -1,0 +1,169 @@
+/**
+ * The FUZZY half of the NL→JQL determinism seam (#1332).
+ *
+ * `nlFilterMapper.map(question, vocab) → StructuredFilter`: the LLM is HANDED the
+ * legal vocabulary (the live symptom slugs + whatever feature/flow slugs the
+ * gitignored catalog currently holds) at RUNTIME and must answer ONLY in that
+ * vocabulary, as JSON matching `StructuredFilter`. The PURE `buildJqlFromFilter`
+ * then turns that filter into the JQL string — no LLM in the builder.
+ *
+ * Classification-shape → Haiku tier (the `ANTHROPIC_MODEL` default), temperature 0
+ * for a stable mapping (mirrors `src/llm/generate.ts`).
+ *
+ * Degrades gracefully + never throws into the pipeline:
+ *   - `MONDAY_TEST_MODE=1` → a DETERMINISTIC stub filter (the question routed
+ *     through the pure `categorizeDefect` to pick ONE symptom), so CLI/AC runs
+ *     need NO creds and make ZERO network calls.
+ *   - malformed / empty / non-JSON model output, or a thrown client → an EMPTY
+ *     filter (all axes `[]`), so the pipeline degrades to "no JQL / show usage".
+ *
+ * `extraStatus` is OPERATOR-ONLY: the parser deliberately IGNORES any
+ * `extraStatus` field in the model's JSON — the LLM must never inject a raw
+ * status clause (the SHOULD-fix folded into the plan).
+ */
+import { getClient } from "../llm/anthropicClient";
+import { categorizeDefect } from "../triage/categorizeDefect";
+import { LabelVocab, StructuredFilter } from "./jqlFromFilter";
+
+const MODEL = process.env.ANTHROPIC_MODEL ?? "claude-haiku-4-5-20251001";
+const MAX_TOKENS = 512;
+
+/** The injectable message-creating call (production wraps `getClient()`). */
+export type MessagesCreate = (req: {
+  model: string;
+  max_tokens: number;
+  temperature: number;
+  system: string;
+  messages: Array<{ role: string; content: string }>;
+}) => Promise<{ content: Array<{ type: string; text?: string }> }>;
+
+export interface NlFilterMapper {
+  map(question: string, vocab: LabelVocab): Promise<StructuredFilter>;
+}
+
+export interface LlmFilterMapperDeps {
+  /** Injected for tests (a fake returning canned JSON). Defaults to `getClient()`. */
+  createMessage?: MessagesCreate;
+  /** Model override; defaults to the Haiku-tier `ANTHROPIC_MODEL`. */
+  model?: string;
+}
+
+function isTestMode(): boolean {
+  return process.env.MONDAY_TEST_MODE === "1";
+}
+
+/** A filter with every axis empty — the safe degrade target. */
+export function emptyFilter(): StructuredFilter {
+  return { symptoms: [], features: [], flows: [], projects: [] };
+}
+
+function toStringArray(v: unknown): string[] {
+  if (!Array.isArray(v)) return [];
+  return v.filter((x): x is string => typeof x === "string" && x.length > 0);
+}
+
+/**
+ * Extract the first balanced-ish JSON object substring (`{ ... }`) from the raw
+ * model text — tolerant of code fences / chatter around the JSON.
+ */
+function extractJsonObject(raw: string): string | null {
+  const start = raw.indexOf("{");
+  const end = raw.lastIndexOf("}");
+  if (start === -1 || end === -1 || end < start) return null;
+  return raw.slice(start, end + 1);
+}
+
+/**
+ * Parse model text → `StructuredFilter`. Defensive: any failure (no JSON, bad
+ * JSON, wrong shape) yields an EMPTY filter. NEVER reads `extraStatus` from the
+ * model output (operator-only).
+ */
+export function parseFilterJson(raw: string): StructuredFilter {
+  if (typeof raw !== "string" || raw.trim().length === 0) return emptyFilter();
+  const jsonStr = extractJsonObject(raw);
+  if (jsonStr === null) return emptyFilter();
+  let obj: unknown;
+  try {
+    obj = JSON.parse(jsonStr);
+  } catch {
+    return emptyFilter();
+  }
+  if (!obj || typeof obj !== "object") return emptyFilter();
+  const o = obj as Record<string, unknown>;
+  return {
+    symptoms: toStringArray(o.symptoms),
+    features: toStringArray(o.features),
+    flows: toStringArray(o.flows),
+    projects: toStringArray(o.projects),
+    // extraStatus deliberately NOT read — operator-only, never LLM-emitted.
+  };
+}
+
+/** Deterministic offline stub: route the question through the pure categorizer. */
+function stubFilter(question: string): StructuredFilter {
+  const { category } = categorizeDefect({ summary: question ?? "" });
+  return { symptoms: [category], features: [], flows: [], projects: [] };
+}
+
+function extractText(response: { content?: unknown }): string {
+  if (!response || !Array.isArray(response.content)) return "";
+  return (response.content as Array<{ type?: string; text?: unknown }>)
+    .filter((b) => b.type === "text")
+    .map((b) => (typeof b.text === "string" ? b.text : ""))
+    .join("")
+    .trim();
+}
+
+/** Build the system prompt embedding the legal vocabulary (runtime catalog). */
+function buildSystemPrompt(vocab: LabelVocab): string {
+  const symptoms = [...vocab.symptoms].sort();
+  const features = [...vocab.featureIds].map((id) => id.replace(/^feature-/, "")).sort();
+  const flows = [...vocab.flowIds].map((id) => id.replace(/^flow-/, "")).sort();
+  return [
+    "You translate an English question about software defects into a JSON filter.",
+    "Answer with a SINGLE JSON object and NOTHING else (no prose, no code fences).",
+    'Shape: {"symptoms":[],"features":[],"flows":[],"projects":[]}',
+    "Use ONLY values from these allowed lists; emit an empty array for an axis you can't fill.",
+    `Allowed symptoms: ${symptoms.length > 0 ? symptoms.join(", ") : "(none)"}`,
+    `Allowed features: ${features.length > 0 ? features.join(", ") : "(none)"}`,
+    `Allowed flows: ${flows.length > 0 ? flows.join(", ") : "(none)"}`,
+    "projects is a list of UPPERCASE Jira project keys mentioned in the question (e.g. DEMO); empty if none.",
+    "Do NOT invent values outside the allowed lists. Do NOT include any other keys.",
+  ].join("\n");
+}
+
+function defaultCreateMessage(): MessagesCreate {
+  return async (req) => {
+    const client = getClient();
+    return (await client.messages.create(req as never)) as unknown as {
+      content: Array<{ type: string; text?: string }>;
+    };
+  };
+}
+
+/**
+ * Production mapper. In test mode returns the deterministic stub; otherwise calls
+ * the (injected or default) LLM client and parses its JSON defensively.
+ */
+export function buildLlmFilterMapper(deps: LlmFilterMapperDeps = {}): NlFilterMapper {
+  const model = deps.model ?? MODEL;
+  return {
+    async map(question: string, vocab: LabelVocab): Promise<StructuredFilter> {
+      if (isTestMode()) return stubFilter(question);
+      const create = deps.createMessage ?? defaultCreateMessage();
+      try {
+        const response = await create({
+          model,
+          max_tokens: MAX_TOKENS,
+          temperature: 0,
+          system: buildSystemPrompt(vocab),
+          messages: [{ role: "user", content: question }],
+        });
+        return parseFilterJson(extractText(response));
+      } catch {
+        // No creds / network error / malformed response → degrade to empty.
+        return emptyFilter();
+      }
+    },
+  };
+}

--- a/src/jira/nlToJql.ts
+++ b/src/jira/nlToJql.ts
@@ -1,0 +1,50 @@
+/**
+ * NL→JQL orchestrator (#1332): composes the FUZZY mapper → PURE builder →
+ * (optional) read-only search into one call. Fully INJECTABLE — the mapper,
+ * vocab and search seam are all passed in, so the whole pipeline is unit-tested
+ * with stubs and ZERO network.
+ *
+ * `run` gates the (single) read-only GET: print-only when false/absent (the CLI
+ * default), search-and-return-issues when true (the Slack auto-run default, and
+ * the CLI `--run` flag). No writes anywhere on this path.
+ */
+import { buildJqlFromFilter, LabelVocab, StructuredFilter } from "./jqlFromFilter";
+import { NlFilterMapper } from "./nlFilterMapper";
+import { JiraIssue, JqlSearchFetcher } from "./sync";
+
+export interface AnswerNlQueryDeps {
+  /** The English→`StructuredFilter` mapper (LLM-backed or stub). */
+  mapper: NlFilterMapper;
+  /** The legal vocabulary the builder validates against. */
+  vocab: LabelVocab;
+  /** Read-only search seam; only consulted when `run` is true. */
+  search?: JqlSearchFetcher;
+  /** When true, perform the one read-only GET and attach matched issues. */
+  run?: boolean;
+}
+
+export interface NlQueryResult {
+  jql: string;
+  warnings: string[];
+  /** Present only when `run` was true (the search was performed). */
+  issues?: JiraIssue[];
+  /** The structured filter the mapper produced (surfaced for debugging/tests). */
+  filter: StructuredFilter;
+}
+
+/**
+ * Map an English question to JQL, then optionally run the read-only search.
+ * Never mutates Jira.
+ */
+export async function answerNlQuery(
+  question: string,
+  deps: AnswerNlQueryDeps,
+): Promise<NlQueryResult> {
+  const filter = await deps.mapper.map(question, deps.vocab);
+  const { jql, warnings } = buildJqlFromFilter(filter, deps.vocab);
+  const result: NlQueryResult = { jql, warnings, filter };
+  if (deps.run && deps.search) {
+    result.issues = await deps.search.search(jql);
+  }
+  return result;
+}

--- a/src/jira/sync.ts
+++ b/src/jira/sync.ts
@@ -286,6 +286,41 @@ export function buildOpenDefectsFetcher(
   };
 }
 
+/** Fetcher for an ARBITRARY read-only JQL query (the NL→JQL viewing layer, #1332). */
+export interface JqlSearchFetcher {
+  /** Run a read-only search for `jql`, returning the matched issues. */
+  search(jql: string): Promise<JiraIssue[]>;
+}
+
+/**
+ * Build a `JqlSearchFetcher` for the NL→JQL viewing layer (#1332). Constructed
+ * FROM the SAME shared `fetchPaginatedIssues` helper as `buildJiraFetcher` /
+ * `buildOpenDefectsFetcher` — it only parameterizes the (caller-supplied) JQL and
+ * a minimal `summary,labels` field set. READ-ONLY GET: no copied auth/pagination
+ * loop and NO new search URL (anti-fork — the one search URL stays in the shared
+ * helper). The JQL is built by the PURE `buildJqlFromFilter` upstream; this seam
+ * never constructs or mutates a label.
+ */
+export function buildJqlSearchFetcher(
+  config: JiraClientConfig,
+  fetchImpl: typeof fetch = globalThis.fetch,
+): JqlSearchFetcher {
+  if (typeof fetchImpl !== "function") {
+    throw new TypeError(
+      "buildJqlSearchFetcher: no global fetch available; pass an explicit fetchImpl",
+    );
+  }
+  return {
+    async search(jql: string): Promise<JiraIssue[]> {
+      return fetchPaginatedIssues(config, fetchImpl, {
+        jql,
+        fields: "summary,labels",
+        maxResults: 100,
+      });
+    },
+  };
+}
+
 function toJiraIssue(raw: unknown): JiraIssue | null {
   if (!raw || typeof raw !== "object") return null;
   const r = raw as {

--- a/src/slack/adapter.ts
+++ b/src/slack/adapter.ts
@@ -5,6 +5,7 @@ import {
   statusCommand,
   syncConfluenceCommand,
   reindexCommand,
+  jqlCommand,
   helpCommand,
   feedbackCommand,
 } from "./commands";
@@ -198,6 +199,7 @@ export class SlackAdapter {
       syncConfluenceCommand(this.adminService, text),
     );
     this.registerAdminCommand("/reindex", (_args, _text) => reindexCommand(this.adminService));
+    this.registerAdminCommand("/jql", (_args, text) => jqlCommand(this.adminService, text));
     this.registerAdminCommand("/help", (_args, _text) => helpCommand(this.adminService));
     this.registerAdminCommand("/feedback-monday", (_args, text) =>
       feedbackCommand(this.adminService, text),

--- a/src/slack/commands.ts
+++ b/src/slack/commands.ts
@@ -27,6 +27,52 @@ export interface AdminService {
   reindex?(): Promise<string | void> | string | void;
   /** Optional sink for collected feedback. Defaults to console.log. */
   recordFeedback?(message: string): Promise<void> | void;
+  /**
+   * Answer an English defect question (`/jql`). Returns the generated JQL plus the
+   * matched defects (Slack default = auto-run, read-only). Optional so the handler
+   * degrades to "not configured" when the bot has no Jira viewing layer wired.
+   */
+  answerJql?(question: string): Promise<JqlReply> | JqlReply;
+}
+
+/** A single matched defect for the `/jql` reply. */
+export interface JqlReplyIssue {
+  key: string;
+  summary?: string;
+}
+
+/** The shape `answerJql` returns and `formatJqlReply` renders. */
+export interface JqlReply {
+  jql: string;
+  issues?: JqlReplyIssue[];
+  warnings?: string[];
+}
+
+/**
+ * PURE formatter for the Slack `/jql` reply (option A — auto-run, read-only).
+ *
+ * Fixed order (AC14): the generated JQL string appears FIRST, then the matched
+ * defects BELOW it — so a reader sees the query, then its results. Warnings (if
+ * any) trail last. No I/O — unit-tested with a stubbed search.
+ */
+export function formatJqlReply(reply: JqlReply): string {
+  const lines: string[] = [];
+  lines.push("*JQL:*");
+  lines.push("```");
+  lines.push(reply.jql);
+  lines.push("```");
+  const issues = Array.isArray(reply.issues) ? reply.issues : [];
+  if (issues.length === 0) {
+    lines.push("No matching defects.");
+  } else {
+    lines.push(`Matched ${issues.length} defect(s):`);
+    for (const issue of issues) {
+      lines.push(issue.summary ? `• ${issue.key} — ${issue.summary}` : `• ${issue.key}`);
+    }
+  }
+  const warnings = Array.isArray(reply.warnings) ? reply.warnings : [];
+  for (const w of warnings) lines.push(`_${w}_`);
+  return lines.join("\n");
 }
 
 export type CommandHandler = (
@@ -39,6 +85,7 @@ const AVAILABLE_COMMANDS: ReadonlyArray<{ name: string; description: string }> =
   { name: "/status-monday", description: "Show document count and uptime." },
   { name: "/sync-confluence [space]", description: "Trigger a fresh sync of the Confluence space." },
   { name: "/reindex", description: "Re-index all Confluence pages and Jira issues." },
+  { name: "/jql <question>", description: "Turn an English defect question into JQL and show the matching defects." },
   { name: "/help", description: "Show this help message." },
   { name: "/feedback-monday <message>", description: "Send feedback to the bot maintainers." },
 ];
@@ -106,6 +153,27 @@ export const reindexCommand: CommandHandler = async (service) => {
 };
 
 /**
+ * `/jql <question>` — Slack auto-run (option A): map the English question to JQL,
+ * perform the one read-only search, and reply JQL-FIRST then the matched defects
+ * (via the pure `formatJqlReply`). Async because the search is network I/O.
+ */
+export const jqlCommand: CommandHandler = async (service, question) => {
+  const q = typeof question === "string" ? question.trim() : "";
+  if (q.length === 0) {
+    return "Usage: `/jql <question>` — for example, `/jql show me crashes`";
+  }
+  if (!service || typeof service.answerJql !== "function") {
+    return "JQL search is not configured on this bot.";
+  }
+  try {
+    const reply = await service.answerJql(q);
+    return formatJqlReply(reply);
+  } catch (err) {
+    return `JQL search failed: ${(err as Error).message ?? "unknown error"}`;
+  }
+};
+
+/**
  * `/help` — static help text listing every command. Synchronous so callers can
  * post the response without awaiting.
  */
@@ -154,6 +222,7 @@ export const commandHandlers: Record<string, CommandHandler> = {
   status: statusCommand,
   syncConfluence: syncConfluenceCommand,
   reindex: reindexCommand,
+  jql: jqlCommand,
   help: helpCommand,
   feedback: feedbackCommand,
 };

--- a/tests/jqlFromFilter.test.ts
+++ b/tests/jqlFromFilter.test.ts
@@ -1,0 +1,164 @@
+import { buildJqlFromFilter, LabelVocab, StructuredFilter } from "../src/jira/jqlFromFilter";
+import { DEFECT_CATEGORIES } from "../src/triage/categorizeDefect";
+
+/**
+ * #1332 Stage C — exhaustive PURE-builder contract.
+ *
+ * SYNTHETIC vocab ONLY: the 8 live symptom slugs + invented feature/flow ids
+ * (`feature-widget`, `flow-onboarding`) + DEMO/PROJ project keys. ZERO LLM, ZERO
+ * I/O — the builder is referentially transparent.
+ */
+
+/** A populated synthetic catalog vocab (feature/flow ids landed). */
+const VOCAB: LabelVocab = {
+  symptoms: new Set(DEFECT_CATEGORIES),
+  featureIds: new Set(["feature-widget"]),
+  flowIds: new Set(["flow-onboarding"]),
+};
+
+/** An EMPTY-catalog vocab (feature/flow not yet populated — forward-compat). */
+const VOCAB_EMPTY_CATALOG: LabelVocab = {
+  symptoms: new Set(DEFECT_CATEGORIES),
+  featureIds: new Set<string>(),
+  flowIds: new Set<string>(),
+};
+
+function filter(over: Partial<StructuredFilter> = {}): StructuredFilter {
+  return { symptoms: [], features: [], flows: [], projects: [], ...over };
+}
+
+describe("AC3 — symptom-only JQL is correct", () => {
+  it("emits the symptom labels clause AND the default status, no warnings", () => {
+    const { jql, warnings } = buildJqlFromFilter(filter({ symptoms: ["crash-error"] }), VOCAB);
+    expect(jql).toContain('labels in ("mb-symptom-crash-error")');
+    expect(jql).toContain("statusCategory != Done");
+    expect(warnings).toEqual([]);
+  });
+});
+
+describe("within-axis OR (multi-symptom)", () => {
+  it("packs multiple symptoms into ONE sorted clause", () => {
+    const { jql } = buildJqlFromFilter(
+      filter({ symptoms: ["performance", "crash-error"] }),
+      VOCAB,
+    );
+    // Sorted + single clause holding BOTH (within-axis OR).
+    expect(jql).toContain('labels in ("mb-symptom-crash-error","mb-symptom-performance")');
+  });
+});
+
+describe("AC4 — AND-across-axes / OR-within-axis", () => {
+  it("feature + two symptoms = a feature clause AND a single two-symptom clause, joined by AND", () => {
+    const { jql } = buildJqlFromFilter(
+      filter({ features: ["widget"], symptoms: ["crash-error", "performance"] }),
+      VOCAB,
+    );
+    expect(jql).toContain('labels in ("mb-feature-widget")');
+    expect(jql).toContain('labels in ("mb-symptom-crash-error","mb-symptom-performance")');
+    expect(jql).toContain(
+      'labels in ("mb-feature-widget") AND labels in ("mb-symptom-crash-error","mb-symptom-performance")',
+    );
+  });
+});
+
+describe("project clause", () => {
+  it("prepends a sorted project in (...) clause", () => {
+    const { jql } = buildJqlFromFilter(
+      filter({ symptoms: ["crash-error"], projects: ["PROJ", "DEMO"] }),
+      VOCAB,
+    );
+    expect(jql).toContain("project in (DEMO,PROJ)");
+    expect(jql.indexOf("project in (")).toBeLessThan(jql.indexOf("labels in ("));
+  });
+});
+
+describe("status override (operator extraStatus)", () => {
+  it("uses extraStatus verbatim instead of the default", () => {
+    const { jql } = buildJqlFromFilter(
+      filter({ symptoms: ["crash-error"], extraStatus: "status = Done" }),
+      VOCAB,
+    );
+    expect(jql).toContain("status = Done");
+    expect(jql).not.toContain("statusCategory != Done");
+  });
+});
+
+describe("AC5 — forward-compat for unlanded feature/flow", () => {
+  it("passes a requested feature through as a label AND warns when the catalog is empty", () => {
+    const { jql, warnings } = buildJqlFromFilter(
+      filter({ features: ["widget"], symptoms: ["crash-error"] }),
+      VOCAB_EMPTY_CATALOG,
+    );
+    expect(jql).toContain('labels in ("mb-feature-widget")');
+    expect(warnings.length).toBeGreaterThan(0);
+    expect(warnings.join(" ")).toMatch(/feature labels not yet populated/i);
+  });
+
+  it("does the same for flows", () => {
+    const { jql, warnings } = buildJqlFromFilter(
+      filter({ flows: ["onboarding"], symptoms: ["crash-error"] }),
+      VOCAB_EMPTY_CATALOG,
+    );
+    expect(jql).toContain('labels in ("mb-flow-onboarding")');
+    expect(warnings.join(" ")).toMatch(/flow labels not yet populated/i);
+  });
+});
+
+describe("hallucinated values are dropped + warned (axis-named, never echoed)", () => {
+  it("drops an unknown symptom and warns without echoing the raw value", () => {
+    const { jql, warnings } = buildJqlFromFilter(
+      filter({ symptoms: ["crash-error", "not-a-real-symptom"] }),
+      VOCAB,
+    );
+    expect(jql).toContain('labels in ("mb-symptom-crash-error")');
+    expect(jql).not.toContain("not-a-real-symptom");
+    expect(warnings.join(" ")).toMatch(/unknown symptom/i);
+    expect(warnings.join(" ")).not.toContain("not-a-real-symptom");
+  });
+
+  it("drops an unknown feature when the catalog is NON-empty", () => {
+    const { jql, warnings } = buildJqlFromFilter(
+      filter({ features: ["widget", "ghost-feature"], symptoms: ["crash-error"] }),
+      VOCAB,
+    );
+    expect(jql).toContain('labels in ("mb-feature-widget")');
+    expect(jql).not.toContain("ghost-feature");
+    expect(warnings.join(" ")).toMatch(/unknown feature/i);
+  });
+});
+
+describe("slug injection-safety", () => {
+  it("canonicalises weird characters to hyphens before quoting", () => {
+    const { jql } = buildJqlFromFilter(
+      filter({ symptoms: ['crash-error") OR labels in ("evil'] }),
+      // Allow the slugged form into the synthetic taxonomy so we can see the output.
+      { ...VOCAB, symptoms: new Set([...DEFECT_CATEGORIES, "crash-error-or-labels-in-evil"]) },
+    );
+    expect(jql).toContain('labels in ("mb-symptom-crash-error-or-labels-in-evil")');
+    // No raw quote/paren injection survived.
+    expect(jql).not.toContain('") OR labels in ("evil');
+  });
+});
+
+describe("AC6 — deterministic output", () => {
+  it("returns byte-identical jql + warnings on repeated calls", () => {
+    const f = filter({
+      features: ["widget"],
+      flows: ["onboarding"],
+      symptoms: ["performance", "crash-error"],
+      projects: ["DEMO"],
+    });
+    const a = buildJqlFromFilter(f, VOCAB);
+    const b = buildJqlFromFilter(f, VOCAB);
+    expect(a.jql).toBe(b.jql);
+    expect(a.warnings).toEqual(b.warnings);
+  });
+});
+
+describe("empty filter degrades to status-only", () => {
+  it("yields just the default status clause when nothing is requested", () => {
+    const { jql, warnings } = buildJqlFromFilter(filter(), VOCAB);
+    expect(jql).toBe("statusCategory != Done");
+    expect(warnings).toEqual([]);
+  });
+});

--- a/tests/nlFilterMapper.test.ts
+++ b/tests/nlFilterMapper.test.ts
@@ -1,0 +1,99 @@
+import {
+  buildLlmFilterMapper,
+  parseFilterJson,
+  emptyFilter,
+  MessagesCreate,
+} from "../src/jira/nlFilterMapper";
+import { LabelVocab } from "../src/jira/jqlFromFilter";
+import { DEFECT_CATEGORIES } from "../src/triage/categorizeDefect";
+
+/**
+ * #1332 Stage C — LLM mapper contract. ZERO network: the message-creating call
+ * is INJECTED (canned JSON), and the test-mode stub needs no client at all.
+ * SYNTHETIC vocab ONLY (no real catalog vocabulary appears here).
+ */
+
+const VOCAB: LabelVocab = {
+  symptoms: new Set(DEFECT_CATEGORIES),
+  featureIds: new Set(["feature-widget"]),
+  flowIds: new Set(["flow-onboarding"]),
+};
+
+/** A fake `messages.create` returning a fixed text block. */
+function cannedCreate(text: string): MessagesCreate {
+  return async () => ({ content: [{ type: "text", text }] });
+}
+
+describe("parseFilterJson", () => {
+  it("parses a well-formed filter object", () => {
+    const f = parseFilterJson('{"symptoms":["crash-error"],"features":["widget"],"flows":[],"projects":["DEMO"]}');
+    expect(f.symptoms).toEqual(["crash-error"]);
+    expect(f.features).toEqual(["widget"]);
+    expect(f.projects).toEqual(["DEMO"]);
+  });
+
+  it("tolerates code-fenced / chatty JSON", () => {
+    const f = parseFilterJson('Sure!\n```json\n{"symptoms":["performance"]}\n```');
+    expect(f.symptoms).toEqual(["performance"]);
+  });
+
+  it("degrades malformed/empty input to an empty filter", () => {
+    expect(parseFilterJson("not json at all")).toEqual(emptyFilter());
+    expect(parseFilterJson("")).toEqual(emptyFilter());
+    expect(parseFilterJson("{ broken")).toEqual(emptyFilter());
+  });
+
+  it("NEVER reads an extraStatus field from model output (operator-only)", () => {
+    const f = parseFilterJson('{"symptoms":["crash-error"],"extraStatus":"status = Done"}') as unknown as Record<
+      string,
+      unknown
+    >;
+    expect(f.extraStatus).toBeUndefined();
+  });
+});
+
+describe("buildLlmFilterMapper — injected client (zero network)", () => {
+  it("maps a canned JSON response to a StructuredFilter", async () => {
+    const mapper = buildLlmFilterMapper({
+      createMessage: cannedCreate('{"symptoms":["crash-error"],"features":["widget"],"flows":[],"projects":[]}'),
+    });
+    const f = await mapper.map("show me checkout crashes", VOCAB);
+    expect(f.symptoms).toEqual(["crash-error"]);
+    expect(f.features).toEqual(["widget"]);
+  });
+
+  it("degrades a malformed response to an empty filter", async () => {
+    const mapper = buildLlmFilterMapper({ createMessage: cannedCreate("¯\\_(ツ)_/¯") });
+    expect(await mapper.map("anything", VOCAB)).toEqual(emptyFilter());
+  });
+
+  it("degrades a thrown client to an empty filter (never throws)", async () => {
+    const mapper = buildLlmFilterMapper({
+      createMessage: async () => {
+        throw new Error("network down");
+      },
+    });
+    expect(await mapper.map("anything", VOCAB)).toEqual(emptyFilter());
+  });
+});
+
+describe("MONDAY_TEST_MODE stub — deterministic, no client", () => {
+  const prev = process.env.MONDAY_TEST_MODE;
+  beforeEach(() => {
+    process.env.MONDAY_TEST_MODE = "1";
+  });
+  afterEach(() => {
+    if (prev === undefined) delete process.env.MONDAY_TEST_MODE;
+    else process.env.MONDAY_TEST_MODE = prev;
+  });
+
+  it("returns a deterministic symptom filter without any client", async () => {
+    // No createMessage injected — test mode must short-circuit before the client.
+    const mapper = buildLlmFilterMapper();
+    const f = await mapper.map("show me crashes", VOCAB);
+    expect(f.symptoms).toEqual(["crash-error"]);
+    // Same input → same output.
+    const g = await mapper.map("show me crashes", VOCAB);
+    expect(g).toEqual(f);
+  });
+});

--- a/tests/nlToJql.test.ts
+++ b/tests/nlToJql.test.ts
@@ -1,0 +1,68 @@
+import { answerNlQuery } from "../src/jira/nlToJql";
+import { NlFilterMapper } from "../src/jira/nlFilterMapper";
+import { LabelVocab, StructuredFilter } from "../src/jira/jqlFromFilter";
+import { JiraIssue, JqlSearchFetcher } from "../src/jira/sync";
+import { DEFECT_CATEGORIES } from "../src/triage/categorizeDefect";
+
+/**
+ * #1332 Stage C — orchestrator composition with stub mapper + stub fetcher.
+ * ZERO network. SYNTHETIC vocab + DEMO keys only.
+ */
+
+const VOCAB: LabelVocab = {
+  symptoms: new Set(DEFECT_CATEGORIES),
+  featureIds: new Set(["feature-widget"]),
+  flowIds: new Set(["flow-onboarding"]),
+};
+
+function stubMapper(filter: StructuredFilter): NlFilterMapper {
+  return { async map() { return filter; } };
+}
+
+function stubSearch(issues: JiraIssue[]): JqlSearchFetcher & { lastJql?: string } {
+  const fetcher = {
+    lastJql: undefined as string | undefined,
+    async search(jql: string): Promise<JiraIssue[]> {
+      fetcher.lastJql = jql;
+      return issues;
+    },
+  };
+  return fetcher;
+}
+
+const SYMPTOM_FILTER: StructuredFilter = {
+  symptoms: ["crash-error"],
+  features: [],
+  flows: [],
+  projects: [],
+};
+
+describe("answerNlQuery", () => {
+  it("print-only (run absent): returns JQL + warnings, NO issues, never calls search", async () => {
+    const search = stubSearch([{ key: "DEMO-1", summary: "boom", descriptionText: "", commentTexts: [] }]);
+    const result = await answerNlQuery("show me crashes", {
+      mapper: stubMapper(SYMPTOM_FILTER),
+      vocab: VOCAB,
+      search,
+    });
+    expect(result.jql).toContain('labels in ("mb-symptom-crash-error")');
+    expect(result.issues).toBeUndefined();
+    expect(search.lastJql).toBeUndefined();
+  });
+
+  it("--run: hands the built JQL to the fetcher and returns its issues", async () => {
+    const issues: JiraIssue[] = [
+      { key: "DEMO-1", summary: "boom", descriptionText: "", commentTexts: [] },
+      { key: "DEMO-2", summary: "kaboom", descriptionText: "", commentTexts: [] },
+    ];
+    const search = stubSearch(issues);
+    const result = await answerNlQuery("show me crashes", {
+      mapper: stubMapper(SYMPTOM_FILTER),
+      vocab: VOCAB,
+      search,
+      run: true,
+    });
+    expect(search.lastJql).toBe(result.jql);
+    expect(result.issues).toEqual(issues);
+  });
+});

--- a/tests/slackJqlReply.test.ts
+++ b/tests/slackJqlReply.test.ts
@@ -1,0 +1,63 @@
+import { formatJqlReply, jqlCommand, AdminService } from "../src/slack/commands";
+
+/**
+ * #1332 Stage C / AC14 — Slack `/jql` reply is JQL-FIRST, then results (option A).
+ * ZERO network: the search is stubbed via a fake `answerJql`.
+ */
+
+const JQL = 'labels in ("mb-symptom-crash-error") AND statusCategory != Done';
+
+describe("AC14 — formatJqlReply prints the JQL strictly before the first issue key", () => {
+  it("the JQL substring index < the first matched issue key index", () => {
+    const reply = formatJqlReply({
+      jql: JQL,
+      issues: [
+        { key: "DEMO-1", summary: "checkout boom" },
+        { key: "DEMO-2", summary: "another crash" },
+      ],
+    });
+    const jqlIndex = reply.indexOf(JQL);
+    const firstKeyIndex = reply.indexOf("DEMO-1");
+    expect(jqlIndex).toBeGreaterThanOrEqual(0);
+    expect(firstKeyIndex).toBeGreaterThanOrEqual(0);
+    expect(jqlIndex).toBeLessThan(firstKeyIndex);
+  });
+
+  it("handles the no-results case without an issue key", () => {
+    const reply = formatJqlReply({ jql: JQL, issues: [] });
+    expect(reply).toContain(JQL);
+    expect(reply).toMatch(/No matching defects/i);
+  });
+
+  it("trails warnings AFTER the JQL and results", () => {
+    const reply = formatJqlReply({
+      jql: JQL,
+      issues: [{ key: "DEMO-1" }],
+      warnings: ["feature labels not yet populated — this clause matches nothing until the deferred matcher runs."],
+    });
+    expect(reply.indexOf(JQL)).toBeLessThan(reply.indexOf("DEMO-1"));
+    expect(reply.indexOf("DEMO-1")).toBeLessThan(reply.indexOf("not yet populated"));
+  });
+});
+
+describe("jqlCommand handler (auto-run, read-only)", () => {
+  it("formats JQL-first via a stubbed answerJql", async () => {
+    const service: AdminService = {
+      async answerJql() {
+        return { jql: JQL, issues: [{ key: "DEMO-7", summary: "stub" }] };
+      },
+    };
+    const reply = await jqlCommand(service, "show me crashes");
+    expect(reply.indexOf(JQL)).toBeLessThan(reply.indexOf("DEMO-7"));
+  });
+
+  it("usage hint on empty question", async () => {
+    const reply = await jqlCommand({}, "   ");
+    expect(reply).toMatch(/Usage:/i);
+  });
+
+  it("degrades to not-configured when answerJql is absent", async () => {
+    const reply = await jqlCommand({}, "show me crashes");
+    expect(reply).toMatch(/not configured/i);
+  });
+});


### PR DESCRIPTION
## ELI5

The bot quietly puts color-coded stickers (`mb-symptom-*`, and later `mb-feature-*`/`mb-flow-*`) on Jira bug cards. Stage C is the "looking at them" layer: you type a plain-English question in your terminal or Slack, and the bot turns it into a Jira search string (JQL) — and can run that search and hand you the matching bugs. You never read a sticker list yourself.

The clever bit: the *fuzzy* "English → which stickers" step uses the smart model (Claude, Haiku tier). The *exact* "stickers → JQL string" step is a plain, boring, deterministic function with no model in it — so it's tested to death and never surprises us.

## What & why

Stage C of the namespaced-labels chain (#1322 → #1314 → #1332). Symptom axis works **today** (73 open defects already carry `mb-symptom-*`); feature/flow axis is **wired but inert** until the deferred classifier (#1064) populates those labels — the JQL is generated forward-compatibly with a warning, no code change needed when they land.

## Determinism seam
- **FUZZY** (`src/jira/nlFilterMapper.ts`) — LLM maps English → `StructuredFilter`. Haiku tier, temperature 0, stubbable, `MONDAY_TEST_MODE` short-circuit → **zero network in tests**. `extraStatus` is operator-only and never read from LLM output.
- **PURE** (`src/jira/jqlFromFilter.ts`) — `buildJqlFromFilter(filter, vocab)` assembles the JQL (within-axis OR, across-axis AND). No LLM/fs/fetch. Slugs canonicalised via the shared `slug()`; clause via a shared `labelsInClause` extracted from `buildBotLabelJql` (no behavior change).
- **Read path** — new exported `buildJqlSearchFetcher` in `sync.ts` reuses the shared private `fetchPaginatedIssues` (read-only GET, `summary,labels`). No new search URL, no writes (anti-fork).

## Surfaces
- CLI `scripts/jql-from-nl.js` (`npm run jql`) — prints JQL; `--run` also runs the read-only search.
- Slack `/jql <question>` — **option A** (auto-run, read-only): reply is **JQL-first, then matched defects** via the pure `formatJqlReply`.
- `docs/jira-dashboard-guide.md` — Jira-native dashboard recipe (built-in gadgets, now-vs-later table, synthetic vocab only).

## AC outcomes (14/14 verified)
| AC | Result |
|---|---|
| 1 pure builder LLM/fs/fetch-free | grep == 0 ✅ |
| 2 builder suite ≥9 cases | 12 cases green ✅ |
| 3 symptom-only JQL correct | ✅ |
| 4 AND-across / OR-within | ✅ |
| 5 empty-catalog forward-compat passthrough + warn | ✅ |
| 6 deterministic output | ✅ |
| 7 mapper zero-network | injected client + stub, 8 green ✅ |
| 8 anti-fork triple | new-file search-URL==0; sync.ts export==1 & `/rest/api/3/search`==3 unchanged; new fetcher calls `fetchPaginatedIssues` ✅ |
| 9 no writes | no PUT/POST/DELETE ✅ |
| 10 CLI prints JQL no creds | `MONDAY_TEST_MODE=1 node scripts/jql-from-nl.js "show me crashes"` exit 0, prints `labels in (` + `mb-symptom-` ✅ |
| 11 canonical privacy gate | `SCAN_MODE=staged scripts/privacy-denylist-check.sh` clean; only `example.atlassian.net` ✅ |
| 12 dashboard guide NOW+LATER + 2-D gadget | ✅ |
| 13 typecheck + full suite | 393/393 green ✅ |
| 14 Slack JQL-first ordering | `formatJqlReply` JQL index < first issue key (`npx jest slackJqlReply`) ✅ |

> AC11's positive-assertion literal command needs `grep -h` to drop the `filename:` prefix; with that the count is 0 — every Atlassian host in the diff is `example.atlassian.net`.

## Privacy (PUBLIC repo)
All committed examples/tests/doc are synthetic (`example.atlassian.net`, `DEMO`/`PROJ`, `mb-feature-widget`, `mb-flow-onboarding`). The internal feature/flow catalog is read only at runtime from the gitignored path — never hardcoded. Warnings name the axis only, never echo a rejected value.

Do NOT merge — pending execution-review.

https://claude.ai/code/session_018TnaPsVNYG78F7y2YipqWL