### PR TITLE
feat(jql): wire answerJql into production adminService so /jql actually searches (#1346)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ import { ConfluenceFetcher } from "./confluence/sync";
 import { JiraFetcher } from "./jira/sync";
 import { SlackAdapter, AppFactory } from "./slack/adapter";
 import { AdminService } from "./slack/commands";
+import { buildAnswerJql } from "./jira/answerJql";
 
 export interface RunMondayOptions {
   /** Override Bolt App factory (jest tests + AC-06 shell-spawn path). */
@@ -40,6 +41,8 @@ export interface RunMondayHandle {
   sources: KnowledgeSourcesHandle;
   /** Idempotent shutdown — stops the Slack adapter and sync timers. */
   shutdown: () => Promise<void>;
+  /** Admin surface wired onto the Slack slash commands. Exposed for tests (#1346). */
+  adminService: AdminService;
 }
 
 /**
@@ -148,6 +151,7 @@ export async function runMonday(opts: RunMondayOptions = {}): Promise<RunMondayH
     syncConfluence: (spaceKey?: string) => sources.syncConfluence(spaceKey),
     reindex: () => sources.reindexAll(),
     recordFeedback: (message: string) => recordFeedbackToSink(message),
+    answerJql: buildAnswerJql({ env: process.env }),
   };
 
   let adapter: SlackAdapter;
@@ -222,7 +226,7 @@ export async function runMonday(opts: RunMondayOptions = {}): Promise<RunMondayH
     }
   }
 
-  return { adapter, knowledge, sources, shutdown };
+  return { adapter, knowledge, sources, shutdown, adminService };
 }
 
 if (require.main === module) {

--- a/src/jira/answerJql.ts
+++ b/src/jira/answerJql.ts
@@ -1,0 +1,119 @@
+/**
+ * `answerJql` factory (#1346) — wires the already-shipped NL→JQL viewing layer
+ * (#1332) into the production Slack `adminService` so the `/jql` slash command
+ * actually searches. This module is PURE WIRING: it composes the existing engine
+ * (`buildVocab` → `buildLlmFilterMapper` → `buildJqlSearchFetcher` → `answerNlQuery`)
+ * exactly as the working CLI `scripts/jql-from-nl.js` does, reading Atlassian
+ * creds from env and running ONE read-only GET (Slack auto-run, option A).
+ *
+ * The composition lives behind a pure factory so the wiring is unit-testable with
+ * ZERO network: `deps.search` (and `deps.fetchImpl`) are injectable seams. The
+ * engine modules are READ-ONLY here — no new behavior, just the missing wire.
+ *
+ * PUBLIC repo: creds flow via env ONLY and are never logged/echoed/committed.
+ */
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+import { buildVocab } from "./labelVocab";
+import { buildLlmFilterMapper } from "./nlFilterMapper";
+import { CatalogIdSource } from "./namespacedLabels";
+import { buildJqlSearchFetcher, JqlSearchFetcher } from "./sync";
+import { answerNlQuery } from "./nlToJql";
+import { JqlReply } from "../slack/commands";
+
+/**
+ * Injectable seams for `buildAnswerJql`.
+ *
+ * - `env` — the credential source (defaults to `process.env` via the caller in
+ *   `src/index.ts`). Read for `CONFLUENCE_URL`/`CONFLUENCE_BASE_URL`,
+ *   `CONFLUENCE_EMAIL`, `CONFLUENCE_API_TOKEN`.
+ * - `search` — override the read-only Jira search seam (the zero-network test
+ *   seam). Production passes none → a real `buildJqlSearchFetcher` is built.
+ * - `fetchImpl` — override the global fetch passed to the real fetcher (tests).
+ * - `catalogPath` — override the gitignored catalog path (tests).
+ */
+export interface BuildAnswerJqlDeps {
+  env: NodeJS.ProcessEnv;
+  search?: JqlSearchFetcher;
+  fetchImpl?: typeof fetch;
+  catalogPath?: string;
+}
+
+/**
+ * Strip a trailing `/wiki` (and trailing slash) so the site root feeds Jira REST.
+ *
+ * INLINE-MIRROR of the module-private `toSiteRoot` in `src/knowledge/startup.ts:83`
+ * (NOT exported there) — the canonical twin. `scripts/jql-from-nl.js:54` mirrors
+ * the identical one-liner. Keeping it inline keeps the `jira/` module
+ * self-contained (no `jira/ → knowledge/` import edge) and the strip identical.
+ * (Cairn T1 2026-06-22: ensure the site root is stored with `/wiki` stripped.)
+ */
+function toSiteRoot(url: string): string {
+  return url.replace(/\/wiki\/?$/, "").replace(/\/$/, "");
+}
+
+/**
+ * Read the gitignored catalog (or an empty catalog if absent / unreadable).
+ *
+ * Canonical twin: `scripts/jql-from-nl.js:31-51`. The CLI resolves the catalog
+ * relative to its own `__dirname/..` (repo root); the compiled `dist/jira/...`
+ * cannot reuse that anchor, so we resolve from `process.cwd()` — which is the
+ * repo root for the production launch (`node dist/index.js`). Any other cwd (or a
+ * missing catalog) safely degrades to the empty-catalog fallback, which is the
+ * CURRENT intended production state (the feature/flow axis is inert pending #1343;
+ * the symptom axis still works). NEVER throws.
+ */
+function loadCatalog(catalogPath?: string): CatalogIdSource {
+  const resolved =
+    catalogPath ??
+    path.resolve(process.cwd(), ".ai-workspace", "catalog", "feature-catalog.json");
+  try {
+    const raw = JSON.parse(fs.readFileSync(resolved, "utf8"));
+    return {
+      features: Array.isArray(raw.features) ? raw.features : [],
+      flows: Array.isArray(raw.flows) ? raw.flows : [],
+    };
+  } catch {
+    return { features: [], flows: [] };
+  }
+}
+
+/**
+ * Build the production `answerJql(question)` method for the Slack `adminService`.
+ *
+ * Returns a function that maps an English defect question to JQL and runs ONE
+ * read-only GET. NEVER throws: missing creds → a graceful "not configured"
+ * `JqlReply`; the engine itself degrades to empty filters on any LLM error.
+ */
+export function buildAnswerJql(deps: BuildAnswerJqlDeps): (question: string) => Promise<JqlReply> {
+  return async function answerJql(question: string): Promise<JqlReply> {
+    // Step 1 — creds from env (mirrors startup.ts:120-122). Short-circuit BEFORE
+    // building any fetcher → zero-network, never throws.
+    const url = deps.env.CONFLUENCE_URL ?? deps.env.CONFLUENCE_BASE_URL;
+    const email = deps.env.CONFLUENCE_EMAIL;
+    const apiToken = deps.env.CONFLUENCE_API_TOKEN;
+    if (!url || !email || !apiToken) {
+      return { jql: "", issues: [], warnings: ["Jira credentials are not configured."] };
+    }
+
+    // Step 2 — load the gitignored catalog (empty fallback on any error).
+    const catalog = loadCatalog(deps.catalogPath);
+
+    // Step 3 — compose the seams (engine unchanged).
+    const vocab = buildVocab(catalog);
+    const mapper = buildLlmFilterMapper();
+    const search =
+      deps.search ??
+      buildJqlSearchFetcher(
+        { baseUrl: toSiteRoot(url), email, apiToken },
+        deps.fetchImpl ?? globalThis.fetch,
+      );
+
+    // Step 4 — run the ONE read-only GET (Slack auto-run, option A).
+    const result = await answerNlQuery(question, { mapper, vocab, search, run: true });
+
+    // Step 5 — map to the Slack `JqlReply` (drops the debug-only `filter`).
+    return { jql: result.jql, issues: result.issues, warnings: result.warnings };
+  };
+}

--- a/tests/answerJql.test.ts
+++ b/tests/answerJql.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Unit tests for the `buildAnswerJql` factory (#1346) — pure wiring of the
+ * NL→JQL viewing layer into the Slack `adminService`. ZERO network: the search
+ * seam is injected, and `MONDAY_TEST_MODE=1` makes the LLM mapper deterministic.
+ *
+ * NOTE ON SYNTHETIC HOSTS: these tests deliberately use `https://demo.example.com`
+ * — NOT the repo-conventional Atlassian sandbox host (the `atlassian`-branded
+ * `dot-net` form used by the other jira tests) — because the #1346 AC9 privacy
+ * grep matches that bare host token, so committing such a fixture would trip the
+ * privacy gate. Do NOT "fix" this back to the Atlassian-host form. See the plan's
+ * privacy gate + plan-review MUST-fix #2.
+ */
+import { buildAnswerJql } from "../src/jira/answerJql";
+import { JiraIssue, JqlSearchFetcher } from "../src/jira/sync";
+
+const SYNTHETIC_CREDS = {
+  // demo.example.com (NOT the Atlassian sandbox host) — see file header: AC9 privacy grep.
+  CONFLUENCE_URL: "https://demo.example.com",
+  CONFLUENCE_EMAIL: "qa@example.com",
+  CONFLUENCE_API_TOKEN: "synthetic-token",
+} as unknown as NodeJS.ProcessEnv;
+
+describe("buildAnswerJql (#1346 wiring)", () => {
+  let savedTestMode: string | undefined;
+
+  beforeEach(() => {
+    savedTestMode = process.env.MONDAY_TEST_MODE;
+    process.env.MONDAY_TEST_MODE = "1"; // deterministic stub mapper, no network.
+  });
+
+  afterEach(() => {
+    if (savedTestMode === undefined) delete process.env.MONDAY_TEST_MODE;
+    else process.env.MONDAY_TEST_MODE = savedTestMode;
+    jest.restoreAllMocks();
+  });
+
+  it("happy path: injected fake search returns a JqlReply and the search WAS called (zero network)", async () => {
+    const fakeIssues: JiraIssue[] = [
+      { key: "DEMO-1", summary: "synthetic crash", descriptionText: "", commentTexts: [] },
+    ];
+    const fakeSearch: JqlSearchFetcher = {
+      search: jest.fn(async (_jql: string) => fakeIssues),
+    };
+    // MUST-fix #2: prove no REAL network — assert global fetch is never invoked.
+    const fetchSpy = jest.spyOn(globalThis, "fetch");
+
+    const answer = buildAnswerJql({ env: SYNTHETIC_CREDS, search: fakeSearch });
+    const reply = await answer("show me crashes");
+
+    expect(typeof reply.jql).toBe("string");
+    expect(reply.jql.length).toBeGreaterThan(0);
+    // The auto-run path actually fired: the injected search was called once with the JQL.
+    expect(fakeSearch.search).toHaveBeenCalledTimes(1);
+    expect(fakeSearch.search).toHaveBeenCalledWith(reply.jql);
+    expect(reply.issues).toEqual(fakeIssues);
+    expect(Array.isArray(reply.warnings)).toBe(true);
+    // Zero real network (MUST-fix #2 — mandatory, not optional).
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("no creds: returns the graceful 'not configured' JqlReply and never builds/uses the search", async () => {
+    const fakeSearch = { search: jest.fn(async () => []) };
+    // env MISSING CONFLUENCE_API_TOKEN → step-1 short-circuit before any fetcher.
+    const env = {
+      CONFLUENCE_URL: "https://demo.example.com",
+      CONFLUENCE_EMAIL: "qa@example.com",
+    } as unknown as NodeJS.ProcessEnv;
+
+    const answer = buildAnswerJql({ env, search: fakeSearch });
+    const reply = await answer("show me crashes");
+
+    expect(reply).toEqual({
+      jql: "",
+      issues: [],
+      warnings: ["Jira credentials are not configured."],
+    });
+    expect(fakeSearch.search).not.toHaveBeenCalled();
+  });
+
+  it("never throws on a completely empty env", async () => {
+    const answer = buildAnswerJql({ env: {} as NodeJS.ProcessEnv });
+    await expect(answer("anything")).resolves.toEqual({
+      jql: "",
+      issues: [],
+      warnings: ["Jira credentials are not configured."],
+    });
+  });
+});

--- a/tests/index.adminService.test.ts
+++ b/tests/index.adminService.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Production-wiring test (#1346): the `adminService` that `runMonday` builds now
+ * exposes `answerJql`, so the Slack `/jql` command is actually wired. Zero-network:
+ * with NO Atlassian creds in env, `answerJql` short-circuits to the graceful
+ * "not configured" reply before any fetcher is built — exercising the real
+ * production code path (`buildAnswerJql({ env: process.env })`) end-to-end through
+ * `runMonday` with no real Slack/Jira.
+ *
+ * NOTE: this file never references any Atlassian sandbox host literal — it deletes
+ * the Atlassian creds rather than setting them — so the AC9 privacy grep stays clean.
+ */
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+import { runMonday } from "../src/index";
+
+const BOT_TOKEN = "bot-token-test-value";
+const APP_TOKEN = "app-token-test-value";
+
+function makeTempConfigYaml(body: string): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "monday-adminsvc-"));
+  const file = path.join(dir, "config.yaml");
+  fs.writeFileSync(file, body, "utf8");
+  return file;
+}
+
+describe("runMonday — adminService.answerJql wiring (#1346)", () => {
+  let savedEnv: Record<string, string | undefined>;
+  const CRED_KEYS = [
+    "CONFLUENCE_URL",
+    "CONFLUENCE_BASE_URL",
+    "CONFLUENCE_EMAIL",
+    "CONFLUENCE_API_TOKEN",
+  ];
+
+  beforeEach(() => {
+    savedEnv = {
+      SLACK_BOT_TOKEN: process.env.SLACK_BOT_TOKEN,
+      SLACK_APP_TOKEN: process.env.SLACK_APP_TOKEN,
+      MONDAY_TEST_MODE: process.env.MONDAY_TEST_MODE,
+    };
+    for (const k of CRED_KEYS) {
+      savedEnv[k] = process.env[k];
+      delete process.env[k]; // creds-absent → graceful zero-network path.
+    }
+    process.env.SLACK_BOT_TOKEN = BOT_TOKEN;
+    process.env.SLACK_APP_TOKEN = APP_TOKEN;
+    process.env.MONDAY_TEST_MODE = "1";
+  });
+
+  afterEach(() => {
+    for (const k of Object.keys(savedEnv)) {
+      const v = savedEnv[k];
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+  });
+
+  it("exposes answerJql on the handle's adminService and returns the graceful no-creds reply", async () => {
+    const cfg = makeTempConfigYaml("indexPath: ./tmp/index\n");
+
+    const handle = await runMonday({ configPath: cfg, exitOnError: false });
+
+    expect(typeof handle.adminService.answerJql).toBe("function");
+    const reply = await handle.adminService.answerJql!("show me crashes");
+    expect(reply).toEqual({
+      jql: "",
+      issues: [],
+      warnings: ["Jira credentials are not configured."],
+    });
+
+    await handle.shutdown();
+  });
+});


### PR DESCRIPTION
## What
Production `src/index.ts` built the Slack adapter's `adminService` with only `{getStatus, syncConfluence, reindex, recordFeedback}` — it never wired `answerJql`. So the `/jql` slash command ack'd but hit `jqlCommand`'s optional-method guard and replied **"JQL search is not configured on this bot."** instead of searching.

This wires the already-shipped #1332 NL→JQL engine into production:
- New `src/jira/answerJql.ts` — pure `buildAnswerJql({env, search?})` factory: env-cred read (graceful never-throw on missing creds) → gitignored-catalog load (empty fallback) → `buildVocab`/`buildLlmFilterMapper`/`buildJqlSearchFetcher`/`answerNlQuery` with `run:true` (one READ-ONLY GET) → `JqlReply`.
- `src/index.ts` — `answerJql: buildAnswerJql({env: process.env})` on the adminService literal; `adminService` exposed on `RunMondayHandle` for the wiring test.
- Tests: injected-fake-search happy path (mandatory fetch-spy assertion), no-creds graceful path, production-handle exposes `answerJql`.

## Safety
- READ-ONLY against Jira (no PUT/POST/DELETE introduced).
- PUBLIC repo: creds via env only; privacy denylist + token grep over the diff = 0; synthetic test hosts only.

## Verification (4-role chain, all PASS)
- `npm run build` clean, `npm run typecheck` clean, `npm test` = **397 passed** (+3 new).
- Privacy gate exit 0; token grep = 0.

https://claude.ai/code/session_018TnaPsVNYG78F7y2YipqWL