### PR TITLE
feat(deploy): mechanical stale-dist prevention — redeploy + build-stamp + build-on-start wrapper (#1348)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules
 dist/
+dist-last-good/
 .env
 .env.local
 *.log

--- a/deploy/launchd/com.monday-bot.plist.template
+++ b/deploy/launchd/com.monday-bot.plist.template
@@ -21,12 +21,17 @@
     <key>Label</key>
     <string>com.monday-bot</string>
 
-    <!-- ProgramArguments: [ absolute node, absolute entrypoint ].
-         launchd does NOT use your shell's PATH, so node must be an absolute path. -->
+    <!-- ProgramArguments: launchd execs the build-on-start WRAPPER (Layer 3,
+         #1348), NOT node/dist directly. The wrapper builds on (re)launch, serves
+         the last-good dist if a build fails, skips the rebuild when dist is
+         already fresh for HEAD, and `exec`s node so wrapper-exit == node-exit
+         (no build status leaks to KeepAlive). It resolves node from the PATH set
+         below (the installer puts node's bin dir first). launchd does NOT use
+         your shell's PATH, so /bin/bash is given as an absolute interpreter. -->
     <key>ProgramArguments</key>
     <array>
-        <string><NODE_PATH></string>
-        <string><REPO_DIR>/dist/index.js</string>
+        <string>/bin/bash</string>
+        <string><REPO_DIR>/scripts/launchd-wrapper.sh</string>
     </array>
 
     <!-- Run from the repo root so process.loadEnvFile() finds <REPO_DIR>/.env

--- a/package.json
+++ b/package.json
@@ -6,8 +6,9 @@
   "type": "commonjs",
   "main": "dist/index.js",
   "scripts": {
-    "build": "tsc",
+    "build": "tsc && node scripts/write-build-stamp.js",
     "start": "node dist/index.js",
+    "redeploy": "bash scripts/redeploy-local.sh",
     "test": "jest",
     "typecheck": "tsc --noEmit && tsc --noEmit -p tsconfig.test.json",
     "eval:recall": "npm run build && node scripts/eval-recall.js",

--- a/scripts/install-launchd.sh
+++ b/scripts/install-launchd.sh
@@ -50,22 +50,31 @@ require_macos() {
     [ "$(uname -s)" = "Darwin" ] || die "this installer is for macOS (launchd) only; on Linux use PM2 (see ecosystem.config.js / README)."
 }
 
-# --- resolve + validate prerequisites, failing loudly -------------------------
-resolve_prereqs() {
+# --- render-safe prerequisites (#1348 M4) -------------------------------------
+# The ONLY things needed to RENDER the plist: node on PATH (its bin dir seeds the
+# launchd PATH) + the template file. Deliberately does NOT require a built dist/
+# or a populated .env — under the Layer-3 build-on-start wrapper, dist/ is built
+# at launch (not an install precondition), and `--print-only` is a pure
+# rendering/inspection path that must succeed on a CLEAN copy (no .env, no dist).
+resolve_render_prereqs() {
     NODE_PATH="$(command -v node || true)"
     [ -n "${NODE_PATH}" ] || die "node not found on PATH. Install Node 18+ and retry."
 
     [ -f "${TEMPLATE}" ] || die "plist template not found at ${TEMPLATE}."
 
-    [ -f "${REPO_DIR}/dist/index.js" ] || die "dist/index.js not found — run 'npm run build' first (tsc -> dist/)."
-
-    [ -f "${REPO_DIR}/.env" ] || die ".env not found in ${REPO_DIR}. Populate it (SLACK_BOT_TOKEN, SLACK_APP_TOKEN, ...) before installing; the bot self-loads it at startup."
-
     # launchd starts with a minimal env; give node's own bin dir priority, then a
-    # conventional default PATH so child tools still resolve.
+    # conventional default PATH so the wrapper + child tools still resolve.
     local node_bin_dir
     node_bin_dir="$(dirname "${NODE_PATH}")"
     PATH_VALUE="${node_bin_dir}:/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+}
+
+# --- activation-only prerequisites --------------------------------------------
+# Checked before we actually load the agent. The dist/index.js-exists guard is
+# GONE (the wrapper builds dist on start). .env is still required to ACTIVATE,
+# since the bot self-loads it at startup — but it is NOT required merely to render.
+resolve_activation_prereqs() {
+    [ -f "${REPO_DIR}/.env" ] || die ".env not found in ${REPO_DIR}. Populate it (SLACK_BOT_TOKEN, SLACK_APP_TOKEN, ...) before installing; the bot self-loads it at startup."
 }
 
 # --- render the template to stdout (no side effects) --------------------------
@@ -110,7 +119,8 @@ activate() {
 cmd_install() {
     local auto_activate="${1:-prompt}"
     require_macos
-    resolve_prereqs
+    resolve_render_prereqs
+    resolve_activation_prereqs
     write_plist
     echo
     print_activation_commands
@@ -137,7 +147,8 @@ cmd_install() {
 
 cmd_print_only() {
     require_macos
-    resolve_prereqs
+    # Render-safe ONLY: must succeed on a clean copy (no .env, no dist/) — AC-6.
+    resolve_render_prereqs
     echo "# Rendered plist (NOT written — --print-only):"
     echo "# would be written to: ${PLIST_DST}"
     render_plist
@@ -174,7 +185,9 @@ install-launchd.sh — run Monday 24/7 on macOS via a launchd LaunchAgent.
   uninstall      Stop (bootout) and remove the agent plist.
   --help, -h     This help.
 
-Prerequisites: 'npm run build' (produces dist/) and a populated .env in the repo root.
+Prerequisites: a populated .env in the repo root (required to ACTIVATE; the
+build-on-start wrapper compiles dist/ on launch, so a prebuilt dist/ is NOT
+required). '--print-only' renders on a clean copy with no .env/dist.
 EOF
 }
 

--- a/scripts/launchd-wrapper.sh
+++ b/scripts/launchd-wrapper.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+#
+# launchd-wrapper.sh — Layer 3 of the stale-`dist/` prevention (task #1348).
+#
+# launchd no longer execs `node dist/index.js` directly. It execs THIS wrapper,
+# which on every (re)launch:
+#
+#   1. SKIP-WHEN-FRESH-FOR-HEAD: if dist/.build-stamp SHA == `git rev-parse --short HEAD`
+#      the dist is already compiled for the checked-out source (e.g. a Layer-1
+#      redeploy just built it) -> skip the rebuild, promote dist -> last-good, exec node.
+#   2. Otherwise BUILD. If GREEN -> promote dist -> last-good, exec the fresh node.
+#      If the build FAILS:
+#        - last-good present -> log loudly, exec node from the LAST-GOOD dist
+#          (a bad build NEVER takes the team bot down).
+#        - NO last-good (cold start) -> emit the fixed cold-fail line, increment
+#          dist/.cold-fail-count, sleep a bounded backoff (so KeepAlive +
+#          ThrottleInterval can't tight-spin it), then exit non-zero.
+#
+# EXIT-CODE ISOLATION (the load-bearing safety property): on every path that runs
+# the bot the wrapper `exec`s node, so the wrapper PROCESS IS REPLACED by node and
+# `wrapper-exit == node-exit` BY CONSTRUCTION — never the build's status. A naive
+# `build; node …; exit $build_rc` would, under KeepAlive, return the build's
+# non-zero on the next clean bot exit and crash-loop the bot. That antipattern is
+# FORBIDDEN here. (`set -e` is deliberately NOT used for the same reason.)
+#
+# PUBLIC repo: this file carries NO real paths/hostnames/tokens — everything is
+# derived at runtime from the wrapper's own location ($0) and $HOME.
+#
+# Configurable (env, never hardcoded constants):
+#   COLD_FAIL_BACKOFF_BASE   base backoff seconds (default 10)
+#   COLD_FAIL_BACKOFF_MAX    backoff ceiling seconds (default 300)
+#   COLD_FAIL_MAX_RETRIES    informational cap on consecutive cold failures (default 5)
+# Test seams (so AC-7/8/9/10 are provable without launchd):
+#   WRAPPER_REPO_DIR         repo root (default: derived from $0)
+#   WRAPPER_DIST_DIR         dist dir (default <repo>/dist)
+#   WRAPPER_LAST_GOOD_DIR    last-good dist dir (default <repo>/dist-last-good)
+#   WRAPPER_BUILD_CMD        build command (default "npm run build"); set to a
+#                            failing command to exercise the fallback paths
+#   WRAPPER_NODE             node binary (default: `command -v node`)
+#   WRAPPER_HEAD_SHA         override HEAD sha (default `git rev-parse --short HEAD`)
+#
+set -uo pipefail
+
+# --- resolve locations from $0 (no baked paths) -------------------------------
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="${WRAPPER_REPO_DIR:-$(cd "${SCRIPT_DIR}/.." && pwd)}"
+DIST_DIR="${WRAPPER_DIST_DIR:-${REPO_DIR}/dist}"
+LAST_GOOD_DIR="${WRAPPER_LAST_GOOD_DIR:-${REPO_DIR}/dist-last-good}"
+BUILD_CMD="${WRAPPER_BUILD_CMD:-npm run build}"
+NODE_BIN="${WRAPPER_NODE:-$(command -v node || true)}"
+
+COLD_FAIL_BACKOFF_BASE="${COLD_FAIL_BACKOFF_BASE:-10}"
+COLD_FAIL_BACKOFF_MAX="${COLD_FAIL_BACKOFF_MAX:-300}"
+COLD_FAIL_MAX_RETRIES="${COLD_FAIL_MAX_RETRIES:-5}"
+
+COLD_FAIL_LINE="build-stamp: COLD-START FAILURE — no last-good dist and build failed; cannot start"
+
+log() { echo "launchd-wrapper: $*"; }
+
+head_sha() {
+    if [ -n "${WRAPPER_HEAD_SHA:-}" ]; then
+        echo "${WRAPPER_HEAD_SHA}"
+        return 0
+    fi
+    git -C "${REPO_DIR}" rev-parse --short HEAD 2>/dev/null
+}
+
+stamp_sha() {
+    local f="${1}/.build-stamp"
+    [ -f "${f}" ] || return 0
+    sed -nE 's/^sha=([0-9a-f]+) .*/\1/p' "${f}" | head -1
+}
+
+# Copy a built dist to last-good. Only ever called AFTER a green build / verified
+# skip, so last-good is always a previously-working artifact (never a failed build).
+promote_last_good() {
+    [ -f "${DIST_DIR}/index.js" ] || return 0
+    rm -rf "${LAST_GOOD_DIR}.tmp" 2>/dev/null || true
+    cp -R "${DIST_DIR}" "${LAST_GOOD_DIR}.tmp" || { log "WARNING: could not snapshot last-good"; return 0; }
+    rm -rf "${LAST_GOOD_DIR}" 2>/dev/null || true
+    mv "${LAST_GOOD_DIR}.tmp" "${LAST_GOOD_DIR}"
+}
+
+# Replace this wrapper process with node (PID-reuse) so wrapper-exit == node-exit.
+exec_node() {
+    local entry="$1"
+    [ -n "${NODE_BIN}" ] || { log "FATAL: node not found on PATH; cannot start."; exit 127; }
+    # Reset the cold-fail counter on any successful start.
+    rm -f "${DIST_DIR}/.cold-fail-count" 2>/dev/null || true
+    log "exec ${entry}"
+    exec "${NODE_BIN}" "${entry}"
+}
+
+# Bounded backoff for the nth consecutive cold failure: min(BASE*2^(n-1), MAX).
+cold_fail_backoff_secs() {
+    local n="$1" secs
+    secs=$(( COLD_FAIL_BACKOFF_BASE * (1 << (n - 1)) ))
+    if [ "${secs}" -gt "${COLD_FAIL_BACKOFF_MAX}" ]; then
+        secs="${COLD_FAIL_BACKOFF_MAX}"
+    fi
+    echo "${secs}"
+}
+
+cold_start_failure() {
+    mkdir -p "${DIST_DIR}"
+    local n
+    n=$(( $(cat "${DIST_DIR}/.cold-fail-count" 2>/dev/null || echo 0) + 1 ))
+    echo "${n}" > "${DIST_DIR}/.cold-fail-count"
+
+    # The fixed, loud, grep-able cold-fail line (build-stamp contract).
+    echo "${COLD_FAIL_LINE}"
+    log "consecutive cold failures: ${n} (max ${COLD_FAIL_MAX_RETRIES})"
+
+    local backoff
+    backoff="$(cold_fail_backoff_secs "${n}")"
+    log "bounded backoff: sleeping ${backoff}s before exit so KeepAlive cannot tight-spin"
+    sleep "${backoff}"
+    exit 1
+}
+
+run() {
+    local head dsha
+
+    head="$(head_sha)"
+    dsha="$(stamp_sha "${DIST_DIR}")"
+
+    # 1. Skip-when-fresh-for-HEAD — the dist is already the checked-out source.
+    if [ -n "${head}" ] && [ -n "${dsha}" ] && [ "${dsha}" = "${head}" ]; then
+        log "dist is fresh for HEAD (${head}) — skipping rebuild."
+        promote_last_good
+        exec_node "${DIST_DIR}/index.js"
+    fi
+
+    # 2. Build.
+    log "building (${BUILD_CMD}) — dist stamp '${dsha:-none}' != HEAD '${head:-unknown}'"
+    local build_rc
+    ( cd "${REPO_DIR}" && eval "${BUILD_CMD}" ); build_rc=$?
+
+    if [ "${build_rc}" -eq 0 ] && [ -f "${DIST_DIR}/index.js" ]; then
+        log "build GREEN — promoting last-good and starting fresh dist."
+        promote_last_good
+        exec_node "${DIST_DIR}/index.js"
+    fi
+
+    # 3a. Build FAILED but a last-good dist exists -> serve it (loud), never the
+    #     build's non-zero. The wrapper still `exec`s node, so exit == node's.
+    if [ -f "${LAST_GOOD_DIR}/index.js" ]; then
+        log "BUILD FAILED (rc=${build_rc}) — falling back to LAST-GOOD dist. A bad build must NOT take the bot down."
+        exec_node "${LAST_GOOD_DIR}/index.js"
+    fi
+
+    # 3b. Cold start: build failed AND no last-good -> bounded, loud failure.
+    log "BUILD FAILED (rc=${build_rc}) and NO last-good dist available."
+    cold_start_failure
+}
+
+run

--- a/scripts/redeploy-local.sh
+++ b/scripts/redeploy-local.sh
@@ -1,0 +1,180 @@
+#!/usr/bin/env bash
+#
+# redeploy-local.sh — Layer 1 of the stale-`dist/` prevention (task #1348).
+#
+# ONE mechanical command (`npm run redeploy`) that makes a local deploy either
+# provably fresh or a hard, loud failure — never a silent stale success. It runs,
+# in order:
+#
+#     pull  ->  install  ->  build (writes dist/.build-stamp for HEAD)
+#           ->  restart the launchd job  ->  VERIFY freshness against the LIVE process
+#
+# Freshness is PROVEN against the running process + the git SHA, NOT a directory
+# mtime (a dir mtime is fragile: false-PASS on `touch dist/`, false-FAIL on an
+# in-place recompile). The verify asserts BOTH:
+#   (a) the launchd service PID changed across the kickstart (it really restarted), AND
+#   (b) the LIVE build-stamp SHA == `git rev-parse --short HEAD` (the running build
+#       was compiled from the checked-out source).
+# If either fails, the script exits NON-ZERO with a stale/freshness/mismatch keyword.
+#
+# macOS / launchd only (mirrors scripts/install-launchd.sh's require_macos guard).
+#
+# Configurable (env, never hardcoded):
+#   REDEPLOY_SERVICE_TARGET   launchd service target (default gui/<uid>/com.monday-bot)
+#   REDEPLOY_LOG_FILE         stdout log to read the live build-stamp from
+#                             (default ~/Library/Logs/monday-bot.out.log)
+#   REDEPLOY_RESTART_WAIT_S   seconds to wait for the bot to re-log after kickstart (default 15)
+#   REDEPLOY_SKIP_PULL=1      skip `git pull`     (e.g. CI / offline redeploy)
+#   REDEPLOY_SKIP_INSTALL=1   skip `npm ci`       (deps already present)
+#
+# Test seams for the `--verify` subcommand (no launchd, no mutation — proves AC-2):
+#   REDEPLOY_EXPECTED_SHA     override the HEAD sha (default `git rev-parse --short HEAD`)
+#   REDEPLOY_LIVE_SHA         override the live sha (default: parsed from the log file)
+#   REDEPLOY_OLD_PID          service PID captured BEFORE the kickstart
+#   REDEPLOY_NEW_PID          service PID captured AFTER  the kickstart
+#
+set -uo pipefail
+
+LABEL="com.monday-bot"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if REPO_DIR="$(git -C "${SCRIPT_DIR}" rev-parse --show-toplevel 2>/dev/null)"; then
+    :
+else
+    REPO_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+fi
+
+SERVICE_TARGET="${REDEPLOY_SERVICE_TARGET:-gui/$(id -u 2>/dev/null || echo 0)/${LABEL}}"
+LOG_FILE="${REDEPLOY_LOG_FILE:-${HOME}/Library/Logs/monday-bot.out.log}"
+RESTART_WAIT_S="${REDEPLOY_RESTART_WAIT_S:-15}"
+
+die() {
+    echo "ERROR: $*" >&2
+    exit 1
+}
+note() { echo "  $*"; }
+
+require_macos() {
+    [ "$(uname -s)" = "Darwin" ] || die "redeploy is for macOS (launchd) only; on Linux use the PM2 path (see README)."
+}
+
+# Current short SHA of the checked-out source.
+head_sha() {
+    git -C "${REPO_DIR}" rev-parse --short HEAD 2>/dev/null
+}
+
+# PID of the launchd service, or empty when not loaded/running.
+service_pid() {
+    launchctl print "${SERVICE_TARGET}" 2>/dev/null \
+        | sed -nE 's/^[[:space:]]*pid = ([0-9]+).*/\1/p' \
+        | head -1
+}
+
+# Live build-stamp SHA, read from the most recent `build-stamp:` line in the log.
+live_sha_from_log() {
+    [ -f "${LOG_FILE}" ] || return 0
+    sed -nE 's/^build-stamp: sha=([0-9a-f]+) .*/\1/p' "${LOG_FILE}" | tail -1
+}
+
+# --- VERIFY: prove the LIVE process carries the HEAD build (AC-2) --------------
+# Pure logic over injectable inputs — NO launchctl, NO mutation, NO macOS guard.
+# Exits 0 when fresh; non-zero with a stale/freshness/mismatch keyword otherwise.
+verify_freshness() {
+    local expected live old_pid new_pid
+    expected="${REDEPLOY_EXPECTED_SHA:-$(head_sha)}"
+    live="${REDEPLOY_LIVE_SHA:-$(live_sha_from_log)}"
+    old_pid="${REDEPLOY_OLD_PID:-}"
+    new_pid="${REDEPLOY_NEW_PID:-$(service_pid)}"
+
+    [ -n "${expected}" ] || die "could not determine HEAD sha (git rev-parse --short HEAD)."
+
+    # (a) the process actually restarted: a fresh PID after the kickstart.
+    if [ -n "${old_pid}" ] && [ "${old_pid}" = "${new_pid}" ]; then
+        die "freshness check FAILED — launchd PID did not change (${old_pid}); the live process did NOT restart. Rebuild + restart did not take effect."
+    fi
+    if [ -z "${new_pid}" ]; then
+        die "freshness check FAILED — launchd service has no running PID after kickstart; the bot is not up. Investigate before trusting this deploy."
+    fi
+
+    # (b) the live build was compiled from the checked-out source.
+    if [ -z "${live}" ]; then
+        die "freshness check FAILED — no live build-stamp found; cannot prove the running build is fresh. Possible stale build (rebuild)."
+    fi
+    if [ "${live}" != "${expected}" ]; then
+        die "freshness MISMATCH — live build-stamp sha=${live} != HEAD sha=${expected}. The running process is STALE; rebuild + restart did not land. (stale)"
+    fi
+
+    echo "Freshness PROVEN: live build-stamp sha=${live} == HEAD ${expected}; service PID=${new_pid} (restarted)."
+}
+
+# --- full mechanical redeploy -------------------------------------------------
+cmd_redeploy() {
+    require_macos
+    echo "==> Redeploy: pull -> install -> build -> restart -> verify"
+
+    if [ "${REDEPLOY_SKIP_PULL:-0}" = "1" ]; then
+        note "[skip] git pull (REDEPLOY_SKIP_PULL=1)"
+    else
+        echo "==> git pull"
+        git -C "${REPO_DIR}" pull --ff-only || die "git pull failed — resolve before redeploying."
+    fi
+
+    if [ "${REDEPLOY_SKIP_INSTALL:-0}" = "1" ]; then
+        note "[skip] npm ci (REDEPLOY_SKIP_INSTALL=1)"
+    else
+        echo "==> npm ci"
+        ( cd "${REPO_DIR}" && npm ci ) || die "npm ci failed — resolve before redeploying."
+    fi
+
+    # Capture the live PID BEFORE we restart, so the verify can prove it changed.
+    local old_pid
+    old_pid="$(service_pid)"
+    echo "==> pre-restart launchd PID: ${old_pid:-<not running>}"
+
+    echo "==> npm run build (Layer 1 OWNS this build; writes dist/.build-stamp for HEAD)"
+    ( cd "${REPO_DIR}" && npm run build ) || die "build (tsc) FAILED — NOT restarting the bot; it keeps serving the previous build. Fix the build, then redeploy."
+
+    echo "==> launchctl kickstart -k ${SERVICE_TARGET}"
+    launchctl kickstart -k "${SERVICE_TARGET}" || die "launchctl kickstart failed — is the agent installed? (bash scripts/install-launchd.sh)"
+
+    echo "==> waiting up to ${RESTART_WAIT_S}s for the bot to re-log its build-stamp"
+    local expected new_pid live i
+    expected="$(head_sha)"
+    for (( i = 0; i < RESTART_WAIT_S; i++ )); do
+        sleep 1
+        new_pid="$(service_pid)"
+        live="$(live_sha_from_log)"
+        if [ -n "${new_pid}" ] && [ "${new_pid}" != "${old_pid}" ] && [ "${live}" = "${expected}" ]; then
+            break
+        fi
+    done
+
+    echo "==> verifying LIVE freshness"
+    REDEPLOY_OLD_PID="${old_pid}" REDEPLOY_NEW_PID="${new_pid:-$(service_pid)}" \
+        REDEPLOY_EXPECTED_SHA="${expected}" REDEPLOY_LIVE_SHA="${live:-$(live_sha_from_log)}" \
+        verify_freshness
+
+    echo "==> Redeploy complete — the live bot is provably running the HEAD build."
+}
+
+usage() {
+    cat <<EOF
+redeploy-local.sh — one mechanical, fresh-or-fail local redeploy (macOS/launchd).
+
+  (no args)   pull -> install -> build -> restart -> verify-or-fail.
+  --verify    run ONLY the live-freshness check (no mutation); used by tests + ad-hoc audits.
+  --help, -h  this help.
+
+Wired as: npm run redeploy
+EOF
+}
+
+main() {
+    case "${1:-redeploy}" in
+        redeploy | "") cmd_redeploy ;;
+        --verify) verify_freshness ;;
+        --help | -h) usage ;;
+        *) usage; die "unknown argument: $1" ;;
+    esac
+}
+
+main "$@"

--- a/scripts/write-build-stamp.js
+++ b/scripts/write-build-stamp.js
@@ -1,0 +1,65 @@
+#!/usr/bin/env node
+/**
+ * write-build-stamp.js — Layer 2 of the stale-`dist/` prevention (task #1348).
+ *
+ * Runs as the SECOND half of `npm run build` (`tsc && node scripts/write-build-stamp.js`),
+ * i.e. only AFTER a GREEN `tsc`. It writes the single-line build-stamp the bot reads
+ * back at startup so the running build is identifiable from the logs alone.
+ *
+ * Build-stamp contract (the single source of truth the ACs grep):
+ *   file:  dist/.build-stamp
+ *   shape: sha=<short-sha> built=<iso-timestamp>\n
+ *   e.g.   sha=a1b2c3d built=2026-06-28T12:34:56Z
+ *
+ * Privacy (PUBLIC repo): SHA + UTC timestamp ONLY. No paths, hostnames,
+ * usernames, branch names, or tokens.
+ *
+ * Configurable (env, never hardcoded magic):
+ *   BUILD_STAMP_SHA       override the short SHA (default: `git rev-parse --short HEAD`)
+ *   BUILD_STAMP_BUILT     override the ISO timestamp (default: now, UTC, no millis)
+ *   BUILD_STAMP_DIST_DIR  override the dist dir (default: <repo>/dist)
+ */
+"use strict";
+
+const { execFileSync } = require("node:child_process");
+const fs = require("node:fs");
+const path = require("node:path");
+
+function shortSha() {
+  if (process.env.BUILD_STAMP_SHA) return process.env.BUILD_STAMP_SHA;
+  try {
+    const sha = execFileSync("git", ["rev-parse", "--short", "HEAD"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+    // Contract requires >= 7 lowercase-hex chars. git's --short is >= 7 by default.
+    if (/^[0-9a-f]{7,}$/.test(sha)) return sha;
+  } catch {
+    /* fall through to the well-formed placeholder below */
+  }
+  // No git metadata (e.g. a tarball export): keep the file CONTRACT-VALID rather
+  // than emitting a malformed stamp. Seven zeros is valid lowercase hex.
+  return "0000000";
+}
+
+function builtTimestamp() {
+  if (process.env.BUILD_STAMP_BUILT) return process.env.BUILD_STAMP_BUILT;
+  // UTC ISO-8601, strip milliseconds so it matches the contract's
+  // `built=[0-9TZ:-]+$` anchor (a `.` would break the grep).
+  return new Date().toISOString().replace(/\.\d{3}Z$/, "Z");
+}
+
+function main() {
+  const distDir =
+    process.env.BUILD_STAMP_DIST_DIR || path.join(__dirname, "..", "dist");
+  const sha = shortSha();
+  const built = builtTimestamp();
+  const line = `sha=${sha} built=${built}\n`;
+
+  fs.mkdirSync(distDir, { recursive: true });
+  fs.writeFileSync(path.join(distDir, ".build-stamp"), line, "utf8");
+  // Echo so the build log shows the stamp that was written.
+  process.stdout.write(`build-stamp written: sha=${sha} built=${built}\n`);
+}
+
+main();

--- a/src/index.ts
+++ b/src/index.ts
@@ -84,6 +84,78 @@ export function recordFeedbackToSink(message: string): void {
   }
 }
 
+/**
+ * Layer 2 (#1348) — observability for the always-on launchd bot.
+ *
+ * logBuildStamp(): print the build-stamp the build step captured into
+ * `dist/.build-stamp`, so the running build is identifiable from
+ * `~/Library/Logs/monday-bot.out.log` alone. Read from `__dirname` (the dir the
+ * compiled entrypoint runs from — `dist/` in prod, or `dist-last-good/` on a
+ * Layer-3 fallback) so a degraded run truthfully logs the last-good stamp.
+ *
+ * Build-stamp contract: file line `sha=<short-sha> built=<iso>`; startup line
+ * `build-stamp: sha=<short-sha> built=<iso>`; missing/malformed degrades to the
+ * fixed literal `build-stamp: unavailable` and NEVER crashes the boot.
+ */
+function logBuildStamp(): void {
+  try {
+    const raw = fs.readFileSync(path.join(__dirname, ".build-stamp"), "utf8").trim();
+    if (/^sha=[0-9a-f]{7,} built=[0-9TZ:-]+$/.test(raw)) {
+      console.log(`build-stamp: ${raw}`);
+      return;
+    }
+  } catch {
+    /* missing / unreadable — degrade below, never throw */
+  }
+  console.log("build-stamp: unavailable");
+}
+
+/** Newest mtime (ms) across a directory tree; 0 if it can't be read. */
+function newestMtimeMs(dir: string): number {
+  let newest = 0;
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return 0;
+  }
+  for (const entry of entries) {
+    const full = path.join(dir, entry.name);
+    try {
+      if (entry.isDirectory()) {
+        newest = Math.max(newest, newestMtimeMs(full));
+      } else {
+        newest = Math.max(newest, fs.statSync(full).mtimeMs);
+      }
+    } catch {
+      /* skip unreadable entries */
+    }
+  }
+  return newest;
+}
+
+/**
+ * Layer 2 (#1348) — in-process backstop: if `src/` is newer than the compiled
+ * `dist/` the running process is STALE (someone restarted without rebuilding).
+ * Emits a loud WARNING carrying the `stale`/`rebuild` keywords. Never crashes.
+ */
+function warnIfStaleBuild(): void {
+  try {
+    const distDir = __dirname;
+    const repoRoot = path.dirname(distDir);
+    const srcNewest = newestMtimeMs(path.join(repoRoot, "src"));
+    const distNewest = newestMtimeMs(distDir);
+    if (srcNewest > 0 && distNewest > 0 && srcNewest > distNewest) {
+      console.warn(
+        "WARNING: src/ is newer than dist/ — you are running a STALE build. " +
+          "Run 'npm run build' (or 'npm run redeploy') to rebuild.",
+      );
+    }
+  } catch {
+    /* observability only — never break startup */
+  }
+}
+
 export async function runMonday(opts: RunMondayOptions = {}): Promise<RunMondayHandle> {
   const exitOnError = opts.exitOnError ?? true;
 
@@ -230,6 +302,10 @@ export async function runMonday(opts: RunMondayOptions = {}): Promise<RunMondayH
 }
 
 if (require.main === module) {
+  // Layer 2 (#1348): announce the running build + warn loudly if it's stale,
+  // on the headless launchd entrypoint (and any `node dist/index.js` run).
+  logBuildStamp();
+  warnIfStaleBuild();
   // Load .env for the CLI entry path only. Native (Node >=20.12), dependency-free.
   // A missing .env is fine — fall back to shell-exported env vars.
   try {

--- a/tests/install-launchd.test.ts
+++ b/tests/install-launchd.test.ts
@@ -46,13 +46,18 @@ describe("launchd plist template", () => {
   });
 
   it("carries every placeholder token the installer resolves", () => {
-    for (const token of ["<NODE_PATH>", "<REPO_DIR>", "<LOG_DIR>", "<PATH_VALUE>"]) {
+    for (const token of ["<REPO_DIR>", "<LOG_DIR>", "<PATH_VALUE>"]) {
       expect(template).toContain(token);
     }
-    // Entrypoint + WorkingDirectory are derived from <REPO_DIR>.
-    expect(template).toContain("<REPO_DIR>/dist/index.js");
-    // PATH is set so node resolves under launchd's minimal env.
+    // PATH is set so node (resolved by the wrapper) works under launchd's minimal env.
     expect(template).toContain("<key>PATH</key>");
+  });
+
+  it("execs the build-on-start wrapper, NOT dist/index.js directly (#1348 Layer 3)", () => {
+    // The wrapper path appears inside ProgramArguments.
+    expect(template).toContain("<REPO_DIR>/scripts/launchd-wrapper.sh");
+    // dist/index.js is no longer the direct entrypoint launchd runs.
+    expect(template).not.toContain("<REPO_DIR>/dist/index.js");
   });
 
   it("leaks NO real machine paths (PUBLIC repo)", () => {
@@ -63,11 +68,18 @@ describe("launchd plist template", () => {
 });
 
 describe("install-launchd.sh", () => {
-  it("is strict-mode and fails loudly on missing prerequisites", () => {
+  it("is strict-mode and fails loudly on missing ACTIVATION prerequisites", () => {
     expect(script).toContain("set -euo pipefail");
-    expect(script).toContain("dist/index.js"); // build guard
-    expect(script).toContain(".env"); // env guard
-    expect(script).toMatch(/command -v node/); // node-path resolution
+    // #1348 M4: the dist/index.js-exists install guard is GONE (the wrapper
+    // builds dist on start), so it must NOT reappear as a hard precondition.
+    expect(script).not.toMatch(/-f "\$\{REPO_DIR\}\/dist\/index\.js"/);
+    expect(script).toContain(".env"); // .env still required to ACTIVATE
+    expect(script).toMatch(/command -v node/); // node-path resolution (for PATH_VALUE)
+  });
+
+  it("splits render-safe prereqs from activation prereqs so --print-only never dies on missing .env/dist (#1348 M4)", () => {
+    expect(script).toContain("resolve_render_prereqs");
+    expect(script).toContain("resolve_activation_prereqs");
   });
 
   it("drives launchctl idempotently (bootout before bootstrap) and offers status/uninstall", () => {

--- a/tests/stale-dist-prevention.test.ts
+++ b/tests/stale-dist-prevention.test.ts
@@ -1,0 +1,136 @@
+/**
+ * #1348 — stale-`dist/` prevention (3 layers).
+ *
+ * Content/structure checks for the committed PUBLIC-repo-safe artifacts plus a
+ * real execution of the build-stamp writer (node is cross-platform, so this runs
+ * identically on the CI ubuntu + windows matrix). The behavioral launchd-wrapper
+ * proofs (forced-build-fail fallback, exit-code isolation, cold-start backoff)
+ * are macOS shell smokes run at ship time — CI never runs launchctl.
+ */
+
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const REPO_ROOT = join(__dirname, "..");
+const REDEPLOY = join(REPO_ROOT, "scripts", "redeploy-local.sh");
+const WRAPPER = join(REPO_ROOT, "scripts", "launchd-wrapper.sh");
+const STAMP_WRITER = join(REPO_ROOT, "scripts", "write-build-stamp.js");
+
+const redeploy = readFileSync(REDEPLOY, "utf8");
+const wrapper = readFileSync(WRAPPER, "utf8");
+const pkg = JSON.parse(readFileSync(join(REPO_ROOT, "package.json"), "utf8"));
+
+// Contract grep anchors (must match the plan's Build-stamp contract exactly).
+const STAMP_FILE_RE = /^sha=[0-9a-f]{7,} built=[0-9TZ:-]+$/;
+const COLD_FAIL_LINE =
+  "build-stamp: COLD-START FAILURE — no last-good dist and build failed; cannot start";
+
+const maybeBash = process.platform === "win32" ? it.skip : it;
+
+describe("Layer 1 — redeploy wiring (AC-1)", () => {
+  it("npm run redeploy resolves to the redeploy script", () => {
+    expect(pkg.scripts.redeploy).toBeDefined();
+    expect(pkg.scripts.redeploy).toContain("scripts/redeploy-local.sh");
+  });
+
+  it("build step writes the build-stamp", () => {
+    expect(pkg.scripts.build).toContain("write-build-stamp");
+  });
+
+  it("verifies LIVE freshness by PID-change + stamp-SHA==HEAD, no dir-mtime compare (AC-2/N1)", () => {
+    expect(redeploy).toContain("set -uo pipefail"); // NOT set -e (build rc must not abort verify)
+    expect(redeploy).toMatch(/rev-parse --short HEAD/);
+    expect(redeploy).toMatch(/build-stamp: sha=/); // parses the live stamp line
+    expect(redeploy).toMatch(/PID did not change/i); // (a) restart proof
+    expect(redeploy).toMatch(/MISMATCH|stale/i); // (b) stale keyword on failure
+    // No directory-mtime comparison in the actual logic (a `stat`-based mtime read).
+    expect(redeploy).not.toMatch(/stat\b.*(-c|-f).*%[Ym]/);
+  });
+});
+
+describe("Layer 2 — build-stamp writer (AC-3)", () => {
+  it("emits dist/.build-stamp matching the contract grep anchor", () => {
+    const dir = mkdtempSync(join(tmpdir(), "stamp-"));
+    try {
+      execFileSync(process.execPath, [STAMP_WRITER], {
+        env: { ...process.env, BUILD_STAMP_DIST_DIR: dir },
+        stdio: "pipe",
+      });
+      const line = readFileSync(join(dir, ".build-stamp"), "utf8").trim();
+      expect(line).toMatch(STAMP_FILE_RE);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("honours configurable BUILD_STAMP_SHA / BUILD_STAMP_BUILT overrides", () => {
+    const dir = mkdtempSync(join(tmpdir(), "stamp-"));
+    try {
+      execFileSync(process.execPath, [STAMP_WRITER], {
+        env: {
+          ...process.env,
+          BUILD_STAMP_DIST_DIR: dir,
+          BUILD_STAMP_SHA: "a1b2c3d",
+          BUILD_STAMP_BUILT: "2026-06-28T12:34:56Z",
+        },
+        stdio: "pipe",
+      });
+      const line = readFileSync(join(dir, ".build-stamp"), "utf8").trim();
+      expect(line).toBe("sha=a1b2c3d built=2026-06-28T12:34:56Z");
+      expect(line).toMatch(STAMP_FILE_RE);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("Layer 3 — launchd wrapper structure (AC-7/8/9/10)", () => {
+  it("execs node so wrapper-exit == node-exit (no build status leak, M2/AC-9)", () => {
+    expect(wrapper).toContain("set -uo pipefail"); // NOT set -e
+    expect(wrapper).toMatch(/exec "\$\{NODE_BIN\}"/);
+    // The forbidden antipattern (returning the BUILD's status to KeepAlive) must
+    // not appear as real code — only the exec'd node's status ever propagates.
+    // (The header comment documents the antipattern by name; strip comments first.)
+    const code = wrapper
+      .split("\n")
+      .filter((l) => !l.trimStart().startsWith("#"))
+      .join("\n");
+    expect(code).not.toMatch(/exit\s+\$\{?build_rc\}?/);
+  });
+
+  it("skips the rebuild when dist is fresh for HEAD (N2 single build owner)", () => {
+    expect(wrapper).toMatch(/rev-parse --short HEAD/);
+    expect(wrapper).toMatch(/skipping rebuild/i);
+  });
+
+  it("falls back to last-good on a failed build without clobbering it (AC-7/8)", () => {
+    expect(wrapper).toMatch(/LAST-GOOD/);
+    expect(wrapper).toMatch(/promote_last_good/);
+    // last-good is a SEPARATE dir from dist, so a failed build can't overwrite it.
+    expect(wrapper).toContain("dist-last-good");
+  });
+
+  it("cold-start emits the fixed line, counts, and backs off bounded (M3/AC-10)", () => {
+    expect(wrapper).toContain(COLD_FAIL_LINE);
+    expect(wrapper).toContain(".cold-fail-count");
+    expect(wrapper).toMatch(/COLD_FAIL_BACKOFF_BASE/);
+    expect(wrapper).toMatch(/COLD_FAIL_BACKOFF_MAX/);
+    expect(wrapper).toMatch(/COLD_FAIL_MAX_RETRIES/);
+  });
+
+  it("bakes in NO real machine paths (PUBLIC repo)", () => {
+    expect(wrapper).not.toMatch(/\/Users\//);
+    expect(redeploy).not.toMatch(/\/Users\//);
+  });
+});
+
+describe("syntax — the new shell scripts parse", () => {
+  maybeBash("redeploy-local.sh passes bash -n", () => {
+    expect(() => execFileSync("bash", ["-n", REDEPLOY], { stdio: "pipe" })).not.toThrow();
+  });
+  maybeBash("launchd-wrapper.sh passes bash -n", () => {
+    expect(() => execFileSync("bash", ["-n", WRAPPER], { stdio: "pipe" })).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Why
The always-on launchd bot runs \`node dist/index.js\` directly; \`dist/\` is gitignored, so a merged PR advances \`src/\` but never \`dist/\` — the live process keeps serving the OLD compiled build until someone manually rebuilds+restarts (the #1332 \`/jql\`-invisible incident). This makes "remember to rebuild" mechanical.

## What (3 layers)
- **Layer 1 — \`npm run redeploy\` / \`scripts/redeploy-local.sh\`**: pull → install → build → kickstart → verify-or-fail (live-stamp SHA == HEAD + PID changed).
- **Layer 2 — build-stamp**: \`build\` now writes \`dist/.build-stamp\` (\`sha=<short> built=<iso>\`); startup logs \`build-stamp: sha=… built=…\` so the live build is observable; a loud STALE warning fires when src is newer than dist.
- **Layer 3 — \`scripts/launchd-wrapper.sh\`**: build-on-start with **green-or-last-good** fallback so a bad build can't take the team bot down. \`exec\`s node (wrapper-exit == node-exit, never the build's non-zero → no KeepAlive crash-loop), skips-when-fresh-for-HEAD (single build owner), bounded cold-fail backoff. Installer's \`resolve_prereqs\` split so \`--print-only\` works on a clean copy; plist invokes the wrapper, not \`dist/index.js\` directly.

## Verification (execution-reviewer RAN these, not eyeballed)
- AC-9 exit-isolation: wrapper \`$?\`=0 even with a build that exits 17; PID-reuse confirms \`exec\`. KeepAlive crash-loop closed.
- AC-7/AC-8: forced build failure → boots from last-good with loud log; last-good byte-identical before/after.
- AC-10 cold-start: bounded backoff (1/2/4/4s), counter resets on success.
- 47 suites / **411 tests** pass. Privacy: 0 internal tokens, 0 home paths (plist is placeholder-only).

4-role chain (planner → plan-review v2 → executor → execution-review) all PASS.

Closes #1348.

https://claude.ai/code/session_018TnaPsVNYG78F7y2YipqWL