### PR TITLE
fix(backfill): default dry-run costs ZERO real LLM spend; --real opt-in (#1355)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "monday-bot",
-  "version": "0.12.4",
+  "version": "0.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "monday-bot",
-      "version": "0.12.4",
+      "version": "0.13.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.90.0",
         "@slack/bolt": "^4.7.1",

--- a/scripts/backfill-namespaced-labels.js
+++ b/scripts/backfill-namespaced-labels.js
@@ -20,8 +20,9 @@
  * NEVER printed/committed; logs are COUNTS/STRUCTURE only.
  *
  *   Print filter:  node scripts/backfill-namespaced-labels.js --print-jql
- *   Read it:       node scripts/backfill-namespaced-labels.js            (dry-run)
- *   Apply it:      node scripts/backfill-namespaced-labels.js --apply    (outward write)
+ *   Preview (free):node scripts/backfill-namespaced-labels.js            (dry-run, symptom-only, ZERO cost)
+ *   Preview (paid):node scripts/backfill-namespaced-labels.js --real     (dry-run, real classifier — gated, no write)
+ *   Apply it:      node scripts/backfill-namespaced-labels.js --apply    (outward write — gated)
  *
  * UNSTAMP (reverse — REMOVE all the bot's labels, #1342). DRY-RUN by default;
  * `--apply` is the ONLY mutating path; `--keys K1,K2` scopes to those issues
@@ -37,15 +38,19 @@
  *      JIRA_OPEN_DEFECTS_STATUS_JQL, JIRA_DEFECT_ISSUETYPE_JQL. Optional
  *      ANTHROPIC_MODEL overrides the feature/flow matcher model.
  *
- * NOTE: the production feature/flow classifier (LLM matching issue text ->
- * catalog ids) now SHIPS (#1343) and is wired by default — the add-path stamps
- * the full `mb-feature-*` / `mb-flow-*` / `mb-symptom-*` set. The interim
- * SYMPTOM-ONLY mode (the deterministic axis only, via the null classifier) stays
- * reachable for debugging behind the `--symptom-only` escape hatch.
+ * COST MODEL (#1355): the DEFAULT no-flag run is a FREE preview — it classifies
+ * with the deterministic SYMPTOM-ONLY null classifier (no LLM, no spend) and
+ * writes NOTHING. The paid production feature/flow classifier (#1343 — an LLM
+ * matching issue text -> catalog ids, stamping the full `mb-feature-*` /
+ * `mb-flow-*` set) is an explicit OPT-IN, constructed ONLY under `--real` (a paid
+ * dry-run PREVIEW: classifies but does not write) or `--apply` (paid classify +
+ * live write). `--symptom-only` forces the free null classifier even under
+ * `--real` / `--apply`.
  *
- * SAFETY (nit 3): the live `--apply` write REFUSES to run unless the loaded
- * catalog's `reviewed` flag is set — an unreviewed (auto-distilled, unverified)
- * menu must never drive a live Jira label write. Fails closed.
+ * SAFETY (nit 3): the catalog's `reviewed` flag gates BOTH paid paths —
+ * `assertCatalogReviewed` fails closed BEFORE the production classifier is ever
+ * constructed (no unreviewed, auto-distilled menu can drive a cost-incurring
+ * run), and again before any live `--apply` Jira write.
  */
 "use strict";
 
@@ -55,8 +60,7 @@ const path = require("path");
 const DIST = path.resolve(__dirname, "..", "dist");
 const { run, runUnstamp } = require(path.join(DIST, "triage", "backfill"));
 const { loadKeywordExtensions } = require(path.join(DIST, "triage", "keywordExtensions"));
-const { buildNullClassifier } = require(path.join(DIST, "triage", "classifier"));
-const { buildFeatureFlowClassifier } = require(path.join(DIST, "triage", "featureFlowMatcher"));
+const { selectBackfillClassifier } = require(path.join(DIST, "triage", "selectBackfillClassifier"));
 const { assertCatalogReviewed } = require(path.join(DIST, "catalog", "reviewedGate"));
 const { buildOpenDefectsFetcher } = require(path.join(DIST, "jira", "sync"));
 const {
@@ -138,10 +142,12 @@ function buildProductionComplete() {
 
 async function main() {
   const apply = process.argv.includes("--apply");
+  // Paid dry-run PREVIEW: build the REAL production classifier but write NOTHING.
+  const real = process.argv.includes("--real");
   const printJql = process.argv.includes("--print-jql");
   const unstamp = process.argv.includes("--unstamp");
-  // Escape hatch: re-select the SYMPTOM-ONLY null classifier (the documented
-  // interim mode), so debugging the deterministic axis stays code-change-free.
+  // Escape hatch: force the SYMPTOM-ONLY null classifier (the documented free
+  // mode) even under --real/--apply, so debugging the deterministic axis is free.
   const symptomOnly = process.argv.includes("--symptom-only");
   const keys = splitList(argValue("--keys"));
   const env = process.env;
@@ -200,14 +206,19 @@ async function main() {
     return;
   }
 
-  // Production feature/flow matcher by default (#1343); --symptom-only re-selects
-  // the interim null classifier (deterministic symptom axis only).
-  const classifier = symptomOnly
-    ? buildNullClassifier()
-    : buildFeatureFlowClassifier(
-        { features: catalog.features, flows: catalog.flows },
-        buildProductionComplete(),
-      );
+  // Cost-safe classifier selection (#1355): FREE null classifier by default;
+  // the paid production classifier is built ONLY under --real/--apply, and the
+  // catalog-reviewed gate fires (inside the seam) BEFORE it is ever constructed.
+  // `buildProductionComplete` is passed as a FACTORY so getClient is never
+  // touched on the free/symptom paths nor against an unreviewed catalog.
+  const classifier = selectBackfillClassifier({
+    apply,
+    real,
+    symptomOnly,
+    catalog,
+    completeFactory: buildProductionComplete,
+    action: `backfill-namespaced-labels ${apply ? "--apply" : "--real"}`,
+  });
 
   const deps = {
     fetchOpenDefects: () => fetcher.fetchOpenDefects(projectKey),

--- a/src/triage/selectBackfillClassifier.ts
+++ b/src/triage/selectBackfillClassifier.ts
@@ -1,0 +1,74 @@
+/**
+ * Pure classifier-selection seam for the backfill shell (#1355).
+ *
+ * Decides WHICH `IssueFeatureFlowClassifier` the backfill injects, given the
+ * operator's flags + the loaded catalog. Extracted from the thin shell so the
+ * cost / gating precedence is unit-tested with ZERO network / model / creds.
+ *
+ * Precedence (cost-safe):
+ *   1. symptomOnly        → buildNullClassifier()  (free, deterministic; wins even
+ *                           under --real / --apply — the documented escape hatch)
+ *   2. real || apply      → assertCatalogReviewed(...) BEFORE building the paid
+ *                           production classifier — FAIL CLOSED before any spend
+ *   3. default (no flags) → buildNullClassifier()  (free symptom-only preview)
+ *
+ * The paid `complete` boundary is injected as a FACTORY (`completeFactory`) and
+ * is invoked ONLY on the gated paid path — so the default / symptom-only paths
+ * never touch the Anthropic client, and an unreviewed catalog throws BEFORE the
+ * factory (and therefore `getClient`) is ever called.
+ */
+import { buildNullClassifier, type IssueFeatureFlowClassifier } from "./classifier";
+import { buildFeatureFlowClassifier, type CompleteFn } from "./featureFlowMatcher";
+import { assertCatalogReviewed } from "../catalog/reviewedGate";
+
+export interface SelectBackfillClassifierOptions {
+  /** `--apply` — live outward write; implies the paid production classifier. */
+  apply: boolean;
+  /** `--real` — paid production classifier, dry-run PREVIEW (classifies, no write). */
+  real: boolean;
+  /** `--symptom-only` — force the free null classifier even under --real/--apply. */
+  symptomOnly: boolean;
+  /** Loaded catalog; its `reviewed` flag gates every paid path. */
+  catalog: {
+    reviewed?: boolean;
+    features: ReadonlyArray<{ id: string; label: string }>;
+    flows: ReadonlyArray<{ id: string; label: string }>;
+  };
+  /** Builds the paid `complete` boundary; invoked ONLY on the gated paid path. */
+  completeFactory: () => CompleteFn;
+  /** Action label for the fail-closed error message. */
+  action?: string;
+}
+
+/**
+ * Select the backfill's `IssueFeatureFlowClassifier`. The paid production
+ * classifier is built ONLY on an explicit `--real` / `--apply` opt-in, and the
+ * catalog-reviewed gate fires BEFORE it is constructed — so the default no-flag
+ * run is a FREE symptom-only preview and an unreviewed catalog never spends.
+ */
+export function selectBackfillClassifier(
+  opts: SelectBackfillClassifierOptions,
+): IssueFeatureFlowClassifier {
+  const { apply, real, symptomOnly, catalog, completeFactory, action } = opts;
+
+  // 1. Explicit override → free null classifier, no spend, even under --real/--apply.
+  if (symptomOnly) {
+    return buildNullClassifier();
+  }
+
+  // 2. Paid path (real preview OR live apply): FAIL CLOSED before constructing the
+  //    production classifier — an unreviewed, auto-distilled menu must never spend.
+  if (real || apply) {
+    assertCatalogReviewed(
+      catalog,
+      action ?? "backfill-namespaced-labels (real classifier)",
+    );
+    return buildFeatureFlowClassifier(
+      { features: catalog.features, flows: catalog.flows },
+      completeFactory(),
+    );
+  }
+
+  // 3. Default no-flag run → free null classifier (symptom-only preview, ZERO cost).
+  return buildNullClassifier();
+}

--- a/tests/triage.selectBackfillClassifier.test.ts
+++ b/tests/triage.selectBackfillClassifier.test.ts
@@ -1,0 +1,145 @@
+import {
+  selectBackfillClassifier,
+  type SelectBackfillClassifierOptions,
+} from "../src/triage/selectBackfillClassifier";
+import { CatalogNotReviewedError } from "../src/catalog/reviewedGate";
+import type { JiraIssue } from "../src/jira/sync";
+
+/**
+ * #1355 — the DEFAULT no-flag backfill run must cost ZERO real LLM spend, the
+ * paid production classifier is an explicit `--real` / `--apply` opt-in, and the
+ * catalog-reviewed gate must fire BEFORE the paid classifier is ever built.
+ *
+ * These prove the cost / gating precedence of the selection seam directly, with
+ * ZERO network / model / creds — a synthetic catalog + a `completeFactory` whose
+ * inner `complete` calls a `getClient` spy. The spy's call-count is the
+ * observable "did we spend?" signal.
+ */
+
+/** One synthetic issue — enough to exercise ≥1 classify() call. */
+const SYNTH_ISSUE = {
+  summary: "synthetic widget fails to load",
+  descriptionText: "synthetic body",
+} as unknown as JiraIssue;
+
+/** Reviewed synthetic catalog (invented ids — never real product vocabulary). */
+const REVIEWED_CATALOG = {
+  reviewed: true,
+  features: [{ id: "feature-synthetic", label: "Synthetic" }],
+  flows: [{ id: "flow-synthetic", label: "Synthetic Flow" }],
+};
+const UNREVIEWED_CATALOG = { ...REVIEWED_CATALOG, reviewed: false };
+
+/**
+ * A completeFactory whose inner `complete` invokes a `getClient` spy — exactly
+ * the production lazy-getClient shape. Returns both spies so a test can assert
+ * call-counts on the factory (was the paid classifier constructed?) and on
+ * getClient (was the Anthropic client ever touched?).
+ */
+function spyingFactory(reply = '{"feature":null,"flows":[],"confidence":"low"}') {
+  const getClient = jest.fn();
+  const completeFactory = jest.fn(() => {
+    return async (_prompt: string) => {
+      getClient();
+      return reply;
+    };
+  });
+  return { getClient, completeFactory };
+}
+
+function baseOpts(
+  over: Partial<SelectBackfillClassifierOptions>,
+): SelectBackfillClassifierOptions {
+  const { completeFactory } = spyingFactory();
+  return {
+    apply: false,
+    real: false,
+    symptomOnly: false,
+    catalog: UNREVIEWED_CATALOG,
+    completeFactory,
+    ...over,
+  };
+}
+
+describe("#1355 AC1 — zero-spend default", () => {
+  it("the no-flag path makes ZERO getClient calls while still classifying ≥1 issue", async () => {
+    const { getClient, completeFactory } = spyingFactory();
+    const classifier = selectBackfillClassifier(
+      baseOpts({ completeFactory, catalog: UNREVIEWED_CATALOG }),
+    );
+
+    // Process ≥1 synthetic issue — the null classifier must still run cleanly.
+    const result = await classifier.classify(SYNTH_ISSUE);
+
+    expect(result).toEqual({ flows: [] });
+    expect(completeFactory).toHaveBeenCalledTimes(0); // paid classifier never built
+    expect(getClient).toHaveBeenCalledTimes(0); // Anthropic client never touched → $0
+  });
+});
+
+describe("#1355 AC2 — fail-closed before any spend (unreviewed catalog)", () => {
+  it("--real against reviewed:false throws CatalogNotReviewedError with ZERO getClient calls", () => {
+    const { getClient, completeFactory } = spyingFactory();
+    expect(() =>
+      selectBackfillClassifier(
+        baseOpts({ real: true, completeFactory, catalog: UNREVIEWED_CATALOG }),
+      ),
+    ).toThrow(CatalogNotReviewedError);
+    // The throw precedes any client construction OR use.
+    expect(completeFactory).toHaveBeenCalledTimes(0);
+    expect(getClient).toHaveBeenCalledTimes(0);
+  });
+
+  it("--apply against reviewed:false also throws before any getClient call", () => {
+    const { getClient, completeFactory } = spyingFactory();
+    expect(() =>
+      selectBackfillClassifier(
+        baseOpts({ apply: true, completeFactory, catalog: UNREVIEWED_CATALOG }),
+      ),
+    ).toThrow(CatalogNotReviewedError);
+    expect(completeFactory).toHaveBeenCalledTimes(0);
+    expect(getClient).toHaveBeenCalledTimes(0);
+  });
+});
+
+describe("#1355 AC3 — real classifier is opt-in only", () => {
+  it("poisoned getClient never fires on the default no-flag path", async () => {
+    const completeFactory = jest.fn(() => async (_p: string) => {
+      throw new Error("POISON: getClient must not be reached on the default path");
+    });
+    const classifier = selectBackfillClassifier(
+      baseOpts({ completeFactory, catalog: UNREVIEWED_CATALOG }),
+    );
+    // Runs to completion WITHOUT firing the poison.
+    await expect(classifier.classify(SYNTH_ISSUE)).resolves.toEqual({ flows: [] });
+    expect(completeFactory).not.toHaveBeenCalled();
+  });
+
+  it("--real against a REVIEWED catalog DOES reach the production wrapper", async () => {
+    const completeFactory = jest.fn(() => async (_p: string) => {
+      throw new Error("POISON: production complete invoked");
+    });
+    const classifier = selectBackfillClassifier(
+      baseOpts({ real: true, completeFactory, catalog: REVIEWED_CATALOG }),
+    );
+    // The paid classifier was constructed (factory invoked once)...
+    expect(completeFactory).toHaveBeenCalledTimes(1);
+    // ...and classifying actually drives the production complete (poison fires).
+    await expect(classifier.classify(SYNTH_ISSUE)).rejects.toThrow(/POISON/);
+  });
+
+  it("--symptom-only forces the free null classifier even under --real", async () => {
+    const { getClient, completeFactory } = spyingFactory();
+    const classifier = selectBackfillClassifier(
+      baseOpts({
+        real: true,
+        symptomOnly: true,
+        completeFactory,
+        catalog: REVIEWED_CATALOG,
+      }),
+    );
+    await expect(classifier.classify(SYNTH_ISSUE)).resolves.toEqual({ flows: [] });
+    expect(completeFactory).toHaveBeenCalledTimes(0);
+    expect(getClient).toHaveBeenCalledTimes(0);
+  });
+});


### PR DESCRIPTION
## ELI5

Before, running the backfill tool with NO special words (the "just show me, don't touch anything" preview) still secretly woke the paid robot and asked it about every open ticket — about 60 cents of real money on a run that's supposed to be a free look. And the "is this menu hand-checked?" safety lock only clicked shut on the WRITE button, not the preview — so the paid robot could run even when the menu was never reviewed.

Now the plain no-words run uses the FREE stand-in (symptom labels only, no robot, no money). The paid robot wakes up ONLY when you clearly ask: a new `--real` word (paid preview, still writes nothing) or the existing `--apply` word (writes for real). And the safety lock now clicks shut BEFORE the robot is ever built, so an unreviewed menu can't cost a cent. Also synced the lockfile version (0.12.4 → 0.13.0).

## What changed
- New pure seam `selectBackfillClassifier({apply, real, symptomOnly, catalog, completeFactory})`. Precedence: `symptomOnly → null`; `(real || apply) → assertCatalogReviewed BEFORE building the paid classifier`; `else → null`.
- Default no-flag run = FREE null classifier (no `getClient`, $0). New `--real` = paid dry-run preview (gated, no write). `--apply` = paid classify + live write (gated). `--symptom-only` forces free null even under `--real`/`--apply`.
- Header comment corrected (default = free symptom-only; removed the stale "wired by default" claim).
- `package-lock.json` root + `packages[""]` version `0.12.4 → 0.13.0` (matches `package.json`).
- New synthetic jest seam test (`tests/triage.selectBackfillClassifier.test.ts`).

## Binary AC results
| AC | Command | Exit |
|----|---------|------|
| AC1 zero-spend default | `npx jest tests/triage.selectBackfillClassifier.test.ts` (AC1 spec: 0 getClient calls on no-flag path) | 0 |
| AC2 fail-closed before spend | same suite — `--real` AND `--apply` vs `reviewed:false` throw `CatalogNotReviewedError`, 0 getClient calls | 0 |
| AC3 real opt-in only | same suite — poison getClient never fires on default; `--real` vs reviewed catalog reaches production wrapper | 0 |
| AC4 comment consistency | `grep -n "dry-run"` shows no-flag line labeled `(dry-run …)`; `grep -Ec "wired by default"` = 0; `grep -c "explicit OPT-IN"` = 1 | matches |
| AC5 lock-sync | `node -e "...p.version==='0.13.0' && l.version==='0.13.0' && l.packages[''].version==='0.13.0'..."` | 0 |
| AC6 no regression | `npm test` (52 suites, 460 tests) | 0 |

All 6 ACs green. Seam (`selectClassifier`) WAS extracted so AC1–AC3 are unit-testable without spawning a child process.

## Privacy
PUBLIC repo. Synthetic test data only. Staged-content greps: home paths = 0, generic token sweep = 0, repo `privacy-denylist-check.sh` clean.

## Gating decision
Do NOT merge — left open for execution-review + the gated merge.

https://claude.ai/code/session_01R5rpgymipJKn4AhCTmsYpD