### PR TITLE
fix(jql): scope NL→JQL defect search to a configured default project

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,6 +25,12 @@ SLACK_APP_TOKEN=replace-with-your-app-token
 # comma-separated list of project keys to enable Jira issue indexing.
 # JIRA_PROJECTS=PROJA,PROJB
 
+# Optional — DEFAULT defect-search scope (#1363). Comma-separated project
+# key(s). When a /jql question names NO project, the read-only search is scoped
+# to these instead of scanning the WHOLE site. A project named in the question
+# always wins. Unset → unchanged (no project fence is forced).
+# JIRA_DEFAULT_PROJECTS=PROJA
+
 # Optional — Anthropic API key for LLM-backed answers. Without this the bot
 # falls back to extractive snippets only.
 # ANTHROPIC_API_KEY=replace-with-your-anthropic-key

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -16,6 +16,25 @@ export class MissingEnvVarError extends Error {
   }
 }
 
+/**
+ * Parse the optional `JIRA_DEFAULT_PROJECTS` env value into a list of project
+ * keys (#1363). Comma-separated, trimmed, empties dropped — mirrors the
+ * `JIRA_PROJECTS` convention (see `splitList` in `src/knowledge/startup.ts`).
+ *
+ * Deliberately does NOT uppercase: the pure JQL builder already
+ * uppercases/sanitises every project key for injection-safety
+ * (`jqlFromFilter.ts` — `project in (...)` clause), so re-uppercasing here would
+ * be redundant. Kept as a standalone, side-effect-free helper so the parse seam
+ * is unit-testable in isolation.
+ */
+export function parseDefaultProjects(value: string | undefined): string[] {
+  if (!value) return [];
+  return value
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
 export function validateEnv(env: NodeJS.ProcessEnv = process.env): AppEnv {
   const missing = REQUIRED_ENV_VARS.filter((key) => !env[key]?.trim());
   if (missing.length > 0) {

--- a/src/jira/answerJql.ts
+++ b/src/jira/answerJql.ts
@@ -15,6 +15,7 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 
+import { parseDefaultProjects } from "../config/env";
 import { buildVocab } from "./labelVocab";
 import { buildLlmFilterMapper } from "./nlFilterMapper";
 import { CatalogIdSource } from "./namespacedLabels";
@@ -27,7 +28,8 @@ import { JqlReply } from "../slack/commands";
  *
  * - `env` — the credential source (defaults to `process.env` via the caller in
  *   `src/index.ts`). Read for `CONFLUENCE_URL`/`CONFLUENCE_BASE_URL`,
- *   `CONFLUENCE_EMAIL`, `CONFLUENCE_API_TOKEN`.
+ *   `CONFLUENCE_EMAIL`, `CONFLUENCE_API_TOKEN`, and the optional
+ *   `JIRA_DEFAULT_PROJECTS` (#1363 — default defect-search scope).
  * - `search` — override the read-only Jira search seam (the zero-network test
  *   seam). Production passes none → a real `buildJqlSearchFetcher` is built.
  * - `fetchImpl` — override the global fetch passed to the real fetcher (tests).
@@ -110,8 +112,17 @@ export function buildAnswerJql(deps: BuildAnswerJqlDeps): (question: string) => 
         deps.fetchImpl ?? globalThis.fetch,
       );
 
-    // Step 4 — run the ONE read-only GET (Slack auto-run, option A).
-    const result = await answerNlQuery(question, { mapper, vocab, search, run: true });
+    // Step 4 — run the ONE read-only GET (Slack auto-run, option A). #1363 —
+    // scope an empty-filter question to the configured default project(s) so the
+    // search no longer degrades to a whole-site scan (unset → unchanged).
+    const defaultProjects = parseDefaultProjects(deps.env.JIRA_DEFAULT_PROJECTS);
+    const result = await answerNlQuery(question, {
+      mapper,
+      vocab,
+      search,
+      run: true,
+      defaultProjects,
+    });
 
     // Step 5 — map to the Slack `JqlReply` (drops the debug-only `filter`).
     return { jql: result.jql, issues: result.issues, warnings: result.warnings };

--- a/src/jira/nlToJql.ts
+++ b/src/jira/nlToJql.ts
@@ -21,6 +21,15 @@ export interface AnswerNlQueryDeps {
   search?: JqlSearchFetcher;
   /** When true, perform the one read-only GET and attach matched issues. */
   run?: boolean;
+  /**
+   * Configured DEFAULT defect-project key(s) (#1363). When the mapper-resolved
+   * filter names NO project, these scope the search via the builder's existing
+   * `project in (...)` clause — so an empty-filter question no longer degrades to
+   * a whole-site `statusCategory != Done` scan. A project NAMED in the question
+   * always WINS (the default is never merged over / does not override it). Unset
+   * / empty → behaviour unchanged.
+   */
+  defaultProjects?: string[];
 }
 
 export interface NlQueryResult {
@@ -41,8 +50,16 @@ export async function answerNlQuery(
   deps: AnswerNlQueryDeps,
 ): Promise<NlQueryResult> {
   const filter = await deps.mapper.map(question, deps.vocab);
-  const { jql, warnings } = buildJqlFromFilter(filter, deps.vocab);
-  const result: NlQueryResult = { jql, warnings, filter };
+  // #1363 — UPSTREAM default-project scoping. Only fill `projects` when the
+  // mapper named none AND a default is configured; a question's explicit project
+  // always wins. Build a scoped COPY (never mutate the mapper's filter).
+  const needsDefault =
+    (filter.projects?.length ?? 0) === 0 && (deps.defaultProjects?.length ?? 0) > 0;
+  const scopedFilter = needsDefault
+    ? { ...filter, projects: deps.defaultProjects! }
+    : filter;
+  const { jql, warnings } = buildJqlFromFilter(scopedFilter, deps.vocab);
+  const result: NlQueryResult = { jql, warnings, filter: scopedFilter };
   if (deps.run && deps.search) {
     result.issues = await deps.search.search(jql);
   }

--- a/tests/env.test.ts
+++ b/tests/env.test.ts
@@ -1,4 +1,4 @@
-import { MissingEnvVarError, validateEnv } from "../src/config/env";
+import { MissingEnvVarError, parseDefaultProjects, validateEnv } from "../src/config/env";
 
 describe("validateEnv", () => {
   // Test placeholders deliberately do NOT use the xoxb-/xapp-/xoxp- prefix:
@@ -53,5 +53,23 @@ describe("validateEnv", () => {
     });
     expect(env.slackBotToken).toBe(BOT_TOKEN_PLACEHOLDER);
     expect(env.slackAppToken).toBe(APP_TOKEN_PLACEHOLDER);
+  });
+});
+
+describe("parseDefaultProjects (#1363)", () => {
+  // SYNTHETIC keys only (PUBLIC repo) — the real default is env-driven.
+  it("AC5 — comma-splits, trims, and drops empties", () => {
+    expect(parseDefaultProjects("ABC, DEF ")).toEqual(["ABC", "DEF"]);
+    expect(parseDefaultProjects("ABC,,  ,DEF,")).toEqual(["ABC", "DEF"]);
+  });
+
+  it("returns an empty list for undefined / empty / whitespace-only", () => {
+    expect(parseDefaultProjects(undefined)).toEqual([]);
+    expect(parseDefaultProjects("")).toEqual([]);
+    expect(parseDefaultProjects("   ,  ")).toEqual([]);
+  });
+
+  it("does NOT uppercase — the JQL builder owns case/sanitisation (no redundant work)", () => {
+    expect(parseDefaultProjects("abc, def")).toEqual(["abc", "def"]);
   });
 });

--- a/tests/nlToJql.test.ts
+++ b/tests/nlToJql.test.ts
@@ -66,3 +66,65 @@ describe("answerNlQuery", () => {
     expect(result.issues).toEqual(issues);
   });
 });
+
+describe("answerNlQuery — default-project scoping (#1363)", () => {
+  // SYNTHETIC keys only (PUBLIC repo): ABC = configured default, DEMO = question's.
+  const EMPTY_FILTER: StructuredFilter = {
+    symptoms: [],
+    features: [],
+    flows: [],
+    projects: [],
+  };
+  const QUESTION_PROJECT_FILTER: StructuredFilter = {
+    symptoms: [],
+    features: [],
+    flows: [],
+    projects: ["DEMO"],
+  };
+
+  it("AC1/AC2 — empty filter + configured default scopes to the default, no whole-site scan", async () => {
+    const result = await answerNlQuery("any open bugs?", {
+      mapper: stubMapper(EMPTY_FILTER),
+      vocab: VOCAB,
+      defaultProjects: ["ABC"],
+    });
+    // AC1: the default fences the search.
+    expect(result.jql).toContain("project in (ABC)");
+    // AC2: it is NOT the bare whole-site scan.
+    expect(result.jql).not.toBe("statusCategory != Done");
+  });
+
+  it("AC3 — a project NAMED in the question wins over the default", async () => {
+    const result = await answerNlQuery("open bugs in DEMO", {
+      mapper: stubMapper(QUESTION_PROJECT_FILTER),
+      vocab: VOCAB,
+      defaultProjects: ["ABC"],
+    });
+    expect(result.jql).toContain("project in (DEMO)");
+    expect(result.jql).not.toContain("ABC");
+  });
+
+  it("AC4 — no default configured ⇒ behaviour unchanged (no project fence forced)", async () => {
+    const result = await answerNlQuery("any open bugs?", {
+      mapper: stubMapper(EMPTY_FILTER),
+      vocab: VOCAB,
+    });
+    expect(result.jql).not.toContain("project in");
+    expect(result.jql).toBe("statusCategory != Done");
+  });
+
+  it("does not mutate the mapper-returned filter object", async () => {
+    const original: StructuredFilter = {
+      symptoms: [],
+      features: [],
+      flows: [],
+      projects: [],
+    };
+    await answerNlQuery("any open bugs?", {
+      mapper: stubMapper(original),
+      vocab: VOCAB,
+      defaultProjects: ["ABC"],
+    });
+    expect(original.projects).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
A natural-language defect question that named no project produced a bare `statusCategory != Done` clause, so the read-only Jira search ran against the **whole site** — leaking unrelated projects and returning the entire cross-project backlog (the "232 matched" / wrong-project-keys UAT findings).

This adds an optional env-driven default project key (`JIRA_DEFAULT_PROJECTS`). When the LLM-resolved filter names no project, `answerNlQuery` fills the filter's `projects` upstream (on a copy, never mutating the mapper output) so the **existing** `project in (...)` builder clause fences the search.

- A question-named project still wins over the default.
- With no default set, behavior is unchanged.
- The LLM mapper (`nlFilterMapper.ts`) and the JQL builder (`jqlFromFilter.ts`) are untouched — disjoint from sibling lane #1364.

Fixes the project-scoping half of the #1064 UAT findings.

## Test plan
- `npm test`: 467/467 green (+7 new tests).
- AC-covered: default scopes an empty filter to `project in (ABC)` (not whole-site); no bare-status whole-site query when a default is set; question project wins over default; no-default → unchanged; env parse normalization.
- Privacy gate clean; synthetic keys only (ABC/DEMO/PROJA).

https://claude.ai/code/session_01R5rpgymipJKn4AhCTmsYpD