### PR TITLE
fix(jql): close NL->JQL vocabulary gap (priority + recency axes)

### DIFF
--- a/src/jira/jqlFromFilter.ts
+++ b/src/jira/jqlFromFilter.ts
@@ -40,8 +40,67 @@ export interface StructuredFilter {
   flows: string[];
   /** Jira project keys, e.g. `["DEMO"]`. */
   projects: string[];
+  /**
+   * OPTIONAL single-value priority axis — ONE closed token (e.g. `high`).
+   * Resolved against a HARDCODED token→fragment table; an unknown token is
+   * DROPPED + warned (never reaches the JQL). Omitted = no priority clause.
+   */
+  priority?: string;
+  /**
+   * OPTIONAL single-value recency/time-window axis — ONE closed token (e.g.
+   * `this-week`). Resolved against a HARDCODED token→fragment table; an unknown
+   * token is DROPPED + warned. Omitted = no recency clause.
+   */
+  recency?: string;
   /** OPERATOR-ONLY raw status clause override. Default = `statusCategory != Done`. */
   extraStatus?: string;
+}
+
+/**
+ * HARDCODED, audited closed-enum token→JQL-fragment tables for the two
+ * single-value axes. A KNOWN token emits its pre-written fragment verbatim; an
+ * unknown/hostile token is DROPPED + axis-named-warned (see `resolveSingleAxis`).
+ * The closed table IS the injection-safety mechanism: NO caller string ever
+ * reaches the JQL, so these axes deliberately BYPASS the project-key char-strip
+ * and `slug()` (which would mangle a valid date expression like `-14d` /
+ * `startOfWeek()`). Lookup is via `Map` (not a plain object) so hostile keys
+ * like `__proto__` cannot resolve to a prototype member.
+ */
+const PRIORITY_FRAGMENTS: ReadonlyMap<string, string> = new Map([
+  ["high", "priority in (High, Highest)"],
+  ["critical", "priority = Highest"],
+  ["urgent", "priority = Highest"],
+]);
+
+const RECENCY_FRAGMENTS: ReadonlyMap<string, string> = new Map([
+  ["this-week", "created >= startOfWeek()"],
+  ["last-release", "created >= -14d"],
+  ["latest", "created >= -7d"],
+]);
+
+/**
+ * Resolve a single-value closed-enum axis to its audited JQL fragment.
+ *   - axis UNSET (undefined/empty) → `null`, NO warning (no clause emitted).
+ *   - KNOWN token → the table's audited fragment.
+ *   - unknown/hostile token → `null` + ONE axis-named warning that echoes NO
+ *     raw value (mirrors the symptom/catalog drop discipline; PUBLIC repo).
+ * The raw value is used ONLY as a lookup key — it never reaches the output.
+ */
+function resolveSingleAxis(
+  raw: string | undefined,
+  table: ReadonlyMap<string, string>,
+  axisName: string,
+  warnings: string[],
+): string | null {
+  if (typeof raw !== "string") return null;
+  const key = raw.trim().toLowerCase();
+  if (key.length === 0) return null;
+  const fragment = table.get(key);
+  if (fragment === undefined) {
+    warnings.push(`dropped unknown ${axisName} value (not in the allowed set).`);
+    return null;
+  }
+  return fragment;
 }
 
 /**
@@ -165,7 +224,11 @@ export function buildJqlFromFilter(filter: StructuredFilter, vocab: LabelVocab):
     ),
   ].sort();
 
-  // --- Assemble: project AND feature AND flow AND symptom AND status ---
+  // --- Priority / recency single-value axes (closed-enum, never char-stripped) ---
+  const priorityFragment = resolveSingleAxis(filter.priority, PRIORITY_FRAGMENTS, "priority", warnings);
+  const recencyFragment = resolveSingleAxis(filter.recency, RECENCY_FRAGMENTS, "recency", warnings);
+
+  // --- Assemble: project AND feature AND flow AND symptom AND priority AND recency AND status ---
   const clauses: string[] = [];
   if (projectKeys.length > 0) {
     clauses.push(`project in (${projectKeys.join(",")})`);
@@ -173,6 +236,8 @@ export function buildJqlFromFilter(filter: StructuredFilter, vocab: LabelVocab):
   if (featureLabels.length > 0) clauses.push(labelsInClause(featureLabels));
   if (flowLabels.length > 0) clauses.push(labelsInClause(flowLabels));
   if (symptomLabels.length > 0) clauses.push(labelsInClause(symptomLabels));
+  if (priorityFragment !== null) clauses.push(priorityFragment);
+  if (recencyFragment !== null) clauses.push(recencyFragment);
 
   const status =
     typeof filter.extraStatus === "string" && filter.extraStatus.trim().length > 0

--- a/src/jira/nlFilterMapper.ts
+++ b/src/jira/nlFilterMapper.ts
@@ -62,6 +62,11 @@ function toStringArray(v: unknown): string[] {
   return v.filter((x): x is string => typeof x === "string" && x.length > 0);
 }
 
+/** A non-empty trimmed string, else `undefined` (so the optional key is omitted). */
+function toOptionalString(v: unknown): string | undefined {
+  return typeof v === "string" && v.trim().length > 0 ? v.trim() : undefined;
+}
+
 /**
  * Extract the first balanced-ish JSON object substring (`{ ... }`) from the raw
  * model text — tolerant of code fences / chatter around the JSON.
@@ -90,19 +95,104 @@ export function parseFilterJson(raw: string): StructuredFilter {
   }
   if (!obj || typeof obj !== "object") return emptyFilter();
   const o = obj as Record<string, unknown>;
-  return {
+  const filter: StructuredFilter = {
     symptoms: toStringArray(o.symptoms),
     features: toStringArray(o.features),
     flows: toStringArray(o.flows),
     projects: toStringArray(o.projects),
     // extraStatus deliberately NOT read — operator-only, never LLM-emitted.
   };
+  // Optional single-value axes: only ADD the key when present + non-empty, so a
+  // filter with neither still `toEqual`s `emptyFilter()` (degrade-path contract).
+  // The closed-enum table in the builder is the injection guard — we pass the
+  // raw token through verbatim (unknown tokens are dropped THERE, not here).
+  const priority = toOptionalString(o.priority);
+  if (priority !== undefined) filter.priority = priority;
+  const recency = toOptionalString(o.recency);
+  if (recency !== undefined) filter.recency = recency;
+  return filter;
 }
 
-/** Deterministic offline stub: route the question through the pure categorizer. */
-function stubFilter(question: string): StructuredFilter {
-  const { category } = categorizeDefect({ summary: question ?? "" });
-  return { symptoms: [category], features: [], flows: [], projects: [] };
+/**
+ * Closed PRIORITY vocabulary — an English signal → ONE canonical token the pure
+ * builder's `PRIORITY_FRAGMENTS` table knows. First match wins.
+ */
+const PRIORITY_SIGNALS: ReadonlyArray<readonly [RegExp, string]> = [
+  [/\b(critical|sev\s?0|blocker)\b/i, "critical"],
+  [/\b(urgent|asap)\b/i, "urgent"],
+  [/\b(high[-\s]?priority|highest|top[-\s]?priority|p0|p1|important)\b/i, "high"],
+];
+
+/**
+ * Closed RECENCY vocabulary — an English signal → ONE canonical token the pure
+ * builder's `RECENCY_FRAGMENTS` table knows. First match wins.
+ */
+const RECENCY_SIGNALS: ReadonlyArray<readonly [RegExp, string]> = [
+  [/\b(this week|past week|last 7 days)\b/i, "this-week"],
+  [/\b(last release|previous release|prior release)\b/i, "last-release"],
+  [/\b(latest|recently|recent|newest|today)\b/i, "latest"],
+];
+
+/** The allowed closed-enum tokens, surfaced to the production LLM in the prompt. */
+const PRIORITY_TOKENS = ["high", "critical", "urgent"] as const;
+const RECENCY_TOKENS = ["this-week", "last-release", "latest"] as const;
+
+function extractPriorityToken(text: string): string | undefined {
+  for (const [re, token] of PRIORITY_SIGNALS) if (re.test(text)) return token;
+  return undefined;
+}
+
+function extractRecencyToken(text: string): string | undefined {
+  for (const [re, token] of RECENCY_SIGNALS) if (re.test(text)) return token;
+  return undefined;
+}
+
+/**
+ * The SHARED deterministic extraction — pure, zero-I/O. Returns ONLY axes backed
+ * by a GENUINE signal:
+ *   - a NON-FALLBACK symptom (`categorizeDefect` matchedRule !== "fallback"),
+ *   - a recognised priority token,
+ *   - a recognised recency token.
+ * If the question yields NONE of these (categorizer lands in `other`/fallback and
+ * there is no priority/recency word), it returns `emptyFilter()` UNCHANGED — so a
+ * fallback-only question stays empty (preserves the "show usage" degrade UX and
+ * safe composition with the orthogonal project-scoping lane). Used by BOTH the
+ * test-mode stub AND the empty/error floor, so the two share ONE notion of "genuine".
+ */
+export function deterministicSignalFilter(question: string): StructuredFilter {
+  const text = question ?? "";
+  const filter = emptyFilter();
+  const { category, matchedRule } = categorizeDefect({ summary: text });
+  if (matchedRule !== "fallback") filter.symptoms = [category];
+  const priority = extractPriorityToken(text);
+  if (priority !== undefined) filter.priority = priority;
+  const recency = extractRecencyToken(text);
+  if (recency !== undefined) filter.recency = recency;
+  return filter;
+}
+
+/** Is this filter all-empty (every axis blank, no priority/recency/extraStatus)? */
+function isEmptyFilter(f: StructuredFilter): boolean {
+  return (
+    (f.symptoms?.length ?? 0) === 0 &&
+    (f.features?.length ?? 0) === 0 &&
+    (f.flows?.length ?? 0) === 0 &&
+    (f.projects?.length ?? 0) === 0 &&
+    f.priority === undefined &&
+    f.recency === undefined &&
+    (f.extraStatus === undefined || f.extraStatus.trim().length === 0)
+  );
+}
+
+/**
+ * The GATED deterministic floor: when the mapped filter is all-empty (unmapped
+ * words OR a model error / no-creds degrade), fall back to the shared genuine-
+ * signal extraction. If that finds NO genuine signal it returns `emptyFilter()`
+ * unchanged — the floor does NOT fire, the empty→"show usage" path is preserved.
+ */
+function applyDeterministicFloor(question: string, filter: StructuredFilter): StructuredFilter {
+  if (!isEmptyFilter(filter)) return filter;
+  return deterministicSignalFilter(question);
 }
 
 function extractText(response: { content?: unknown }): string {
@@ -122,12 +212,15 @@ function buildSystemPrompt(vocab: LabelVocab): string {
   return [
     "You translate an English question about software defects into a JSON filter.",
     "Answer with a SINGLE JSON object and NOTHING else (no prose, no code fences).",
-    'Shape: {"symptoms":[],"features":[],"flows":[],"projects":[]}',
-    "Use ONLY values from these allowed lists; emit an empty array for an axis you can't fill.",
+    'Shape: {"symptoms":[],"features":[],"flows":[],"projects":[],"priority":"","recency":""}',
+    "Use ONLY values from these allowed lists; emit an empty array (or an empty string for priority/recency) for an axis you can't fill.",
     `Allowed symptoms: ${symptoms.length > 0 ? symptoms.join(", ") : "(none)"}`,
+    "Map generic symptom words to the closest allowed symptom slug — e.g. crash/freeze/hang/error/bug/exception → crash-error; cannot/can't/unable/fails/blocked → cannot-complete; wrong/incorrect/mismatch/duplicate → data-incorrect; missing/blank/empty/not shown → missing-element; layout/button/font/colour/UI → display-ui; navigate/redirect/back button → navigation-flow; slow/lag/delay/timeout → performance.",
     `Allowed features: ${features.length > 0 ? features.join(", ") : "(none)"}`,
     `Allowed flows: ${flows.length > 0 ? flows.join(", ") : "(none)"}`,
     "projects is a list of UPPERCASE Jira project keys mentioned in the question (e.g. DEMO); empty if none.",
+    `priority is exactly ONE token from [${PRIORITY_TOKENS.join(", ")}] when the question implies priority (high priority/critical/urgent); empty string otherwise.`,
+    `recency is exactly ONE token from [${RECENCY_TOKENS.join(", ")}] when the question implies a time window (this week/last release/latest); empty string otherwise.`,
     "Do NOT invent values outside the allowed lists. Do NOT include any other keys.",
   ].join("\n");
 }
@@ -149,8 +242,10 @@ export function buildLlmFilterMapper(deps: LlmFilterMapperDeps = {}): NlFilterMa
   const model = deps.model ?? MODEL;
   return {
     async map(question: string, vocab: LabelVocab): Promise<StructuredFilter> {
-      if (isTestMode()) return stubFilter(question);
+      // Test mode short-circuits to the shared deterministic extraction (no client).
+      if (isTestMode()) return deterministicSignalFilter(question);
       const create = deps.createMessage ?? defaultCreateMessage();
+      let filter: StructuredFilter;
       try {
         const response = await create({
           model,
@@ -159,11 +254,14 @@ export function buildLlmFilterMapper(deps: LlmFilterMapperDeps = {}): NlFilterMa
           system: buildSystemPrompt(vocab),
           messages: [{ role: "user", content: question }],
         });
-        return parseFilterJson(extractText(response));
+        filter = parseFilterJson(extractText(response));
       } catch {
         // No creds / network error / malformed response → degrade to empty.
-        return emptyFilter();
+        filter = emptyFilter();
       }
+      // GATED floor: only fires when the mapped filter is empty AND the question
+      // carries a genuine signal; otherwise returns the empty filter unchanged.
+      return applyDeterministicFloor(question, filter);
     },
   };
 }

--- a/tests/jqlFromFilter.test.ts
+++ b/tests/jqlFromFilter.test.ts
@@ -161,4 +161,58 @@ describe("empty filter degrades to status-only", () => {
     expect(jql).toBe("statusCategory != Done");
     expect(warnings).toEqual([]);
   });
+
+  it("a fixture literal that OMITS priority/recency still compiles + builds status-only", () => {
+    // `filter()` deliberately omits the optional priority/recency keys (F2).
+    const { jql } = buildJqlFromFilter(filter({ symptoms: ["crash-error"] }), VOCAB);
+    expect(jql).toContain('labels in ("mb-symptom-crash-error")');
+    expect(jql).toContain("statusCategory != Done");
+    expect(jql).not.toMatch(/priority/);
+    expect(jql).not.toMatch(/created >=/);
+  });
+});
+
+describe("#1364 — priority / recency closed-enum axes", () => {
+  it("AC1 — two filters differing only by a NEW axis build DISTINCT JQL carrying the right fragment", () => {
+    const priorityJql = buildJqlFromFilter(filter({ priority: "high" }), VOCAB).jql;
+    const recencyJql = buildJqlFromFilter(filter({ recency: "this-week" }), VOCAB).jql;
+
+    expect(priorityJql).toContain("priority in (High, Highest)");
+    expect(recencyJql).toContain("created >= startOfWeek()");
+    expect(priorityJql).not.toBe(recencyJql);
+    // Neither is the bare status query.
+    expect(priorityJql).not.toBe("statusCategory != Done");
+    expect(recencyJql).not.toBe("statusCategory != Done");
+  });
+
+  it("each known recency token emits its own audited date fragment", () => {
+    expect(buildJqlFromFilter(filter({ recency: "last-release" }), VOCAB).jql).toContain(
+      "created >= -14d",
+    );
+    expect(buildJqlFromFilter(filter({ recency: "latest" }), VOCAB).jql).toContain(
+      "created >= -7d",
+    );
+  });
+
+  it("AC5 — an unknown/hostile token is DROPPED (no clause, no raw echo) + axis-named warn", () => {
+    const hostile = '") OR labels in ("evil';
+    const { jql, warnings } = buildJqlFromFilter(filter({ priority: hostile }), VOCAB);
+    // No priority clause emitted; the hostile string never reaches the JQL.
+    expect(jql).toBe("statusCategory != Done");
+    expect(jql).not.toContain("evil");
+    expect(jql).not.toContain("priority");
+    // Axis-named warning that echoes NO raw value.
+    expect(warnings.join(" ")).toMatch(/unknown priority/i);
+    expect(warnings.join(" ")).not.toContain("evil");
+  });
+
+  it("drops a hostile recency token the same way (closed-enum, never char-stripped)", () => {
+    const { jql, warnings } = buildJqlFromFilter(
+      filter({ recency: "startOfWeek()); DROP TABLE" }),
+      VOCAB,
+    );
+    expect(jql).toBe("statusCategory != Done");
+    expect(jql).not.toContain("DROP TABLE");
+    expect(warnings.join(" ")).toMatch(/unknown recency/i);
+  });
 });

--- a/tests/nlFilterMapper.test.ts
+++ b/tests/nlFilterMapper.test.ts
@@ -4,7 +4,7 @@ import {
   emptyFilter,
   MessagesCreate,
 } from "../src/jira/nlFilterMapper";
-import { LabelVocab } from "../src/jira/jqlFromFilter";
+import { LabelVocab, buildJqlFromFilter } from "../src/jira/jqlFromFilter";
 import { DEFECT_CATEGORIES } from "../src/triage/categorizeDefect";
 
 /**
@@ -95,5 +95,88 @@ describe("MONDAY_TEST_MODE stub — deterministic, no client", () => {
     // Same input → same output.
     const g = await mapper.map("show me crashes", VOCAB);
     expect(g).toEqual(f);
+  });
+
+  it("AC2 — distinct questions build DISTINCT JQL carrying the RIGHT clause (zero network)", async () => {
+    const mapper = buildLlmFilterMapper();
+    const priorityJql = buildJqlFromFilter(await mapper.map("high priority items", VOCAB), VOCAB).jql;
+    const bugsJql = buildJqlFromFilter(await mapper.map("any open bugs", VOCAB), VOCAB).jql;
+
+    // The priority question carries the hardcoded priority fragment...
+    expect(priorityJql).toContain("priority in (High, Highest)");
+    // ...the symptom question carries a symptom-labels clause...
+    expect(bugsJql).toContain('labels in ("mb-symptom-crash-error")');
+    // ...and the two are genuinely distinct (not the same degenerate query).
+    expect(priorityJql).not.toBe(bugsJql);
+  });
+
+  it("AC3 — ≥4 example questions each build a DISTINCT, non-degenerate JQL with its axis fragment", async () => {
+    const mapper = buildLlmFilterMapper();
+    const cases: Array<{ q: string; fragment: string }> = [
+      { q: "high priority items", fragment: "priority in (High, Highest)" },
+      { q: "items from last release", fragment: "created >= -14d" },
+      { q: "the app keeps crashing", fragment: 'labels in ("mb-symptom-crash-error")' },
+      { q: "any open bugs this week", fragment: "created >= startOfWeek()" },
+    ];
+    const jqls = await Promise.all(
+      cases.map(async ({ q }) => buildJqlFromFilter(await mapper.map(q, VOCAB), VOCAB).jql),
+    );
+
+    // (a) no two identical; (b) none is the bare status query; (c) each carries its fragment.
+    expect(new Set(jqls).size).toBe(jqls.length);
+    for (let i = 0; i < cases.length; i++) {
+      expect(jqls[i]).not.toBe("statusCategory != Done");
+      expect(jqls[i]).toContain(cases[i].fragment);
+    }
+    // The symptom+recency combo carries BOTH clauses.
+    const combo = jqls[3];
+    expect(combo).toContain('labels in ("mb-symptom-crash-error")');
+    expect(combo).toContain("created >= startOfWeek()");
+  });
+});
+
+describe("AC4 — empty/error floor fires ONLY on a genuine signal", () => {
+  // The floor lives on the NON-test-mode path; make sure test mode is OFF here.
+  const prev = process.env.MONDAY_TEST_MODE;
+  beforeEach(() => {
+    delete process.env.MONDAY_TEST_MODE;
+  });
+  afterEach(() => {
+    if (prev === undefined) delete process.env.MONDAY_TEST_MODE;
+    else process.env.MONDAY_TEST_MODE = prev;
+  });
+
+  it("AC4a — a genuine-symptom question under the no-creds/error shape yields a NON-empty filter", async () => {
+    // The model returns empty/non-JSON (the no-creds/error degrade shape).
+    const mapper = buildLlmFilterMapper({ createMessage: cannedCreate("") });
+    const f = await mapper.map("the app keeps crashing", VOCAB);
+    expect(f).not.toEqual(emptyFilter());
+    expect(f.symptoms).toEqual(["crash-error"]);
+    // ...so the built JQL is NOT a bare status query.
+    const { jql } = buildJqlFromFilter(f, VOCAB);
+    expect(jql).not.toBe("statusCategory != Done");
+    expect(jql).toContain('labels in ("mb-symptom-crash-error")');
+  });
+
+  it("AC4a — the floor also rescues a priority-only question on a thrown client", async () => {
+    const mapper = buildLlmFilterMapper({
+      createMessage: async () => {
+        throw new Error("network down");
+      },
+    });
+    const f = await mapper.map("only the high priority ones please", VOCAB);
+    expect(f.priority).toBe("high");
+    expect(buildJqlFromFilter(f, VOCAB).jql).toContain("priority in (High, Highest)");
+  });
+
+  it("AC4b — a fallback-only question ('anything') does NOT fire the floor (stays emptyFilter)", async () => {
+    const malformed = buildLlmFilterMapper({ createMessage: cannedCreate("¯\\_(ツ)_/¯") });
+    expect(await malformed.map("anything", VOCAB)).toEqual(emptyFilter());
+    const thrown = buildLlmFilterMapper({
+      createMessage: async () => {
+        throw new Error("network down");
+      },
+    });
+    expect(await thrown.map("anything", VOCAB)).toEqual(emptyFilter());
   });
 });


### PR DESCRIPTION
## Summary
Generic defect questions accepted by the routing lexicon but outside the LLM mapper's symptom-slug vocabulary previously mapped to an empty filter, so the builder emitted the bare `statusCategory != Done` default and every such question produced an **identical JQL block**. This closes that vocabulary gap by adding two structured axes the mapper can populate.

- `StructuredFilter` gains optional `priority?` / `recency?` axes.
- `jqlFromFilter.ts`: `PRIORITY_FRAGMENTS` / `RECENCY_FRAGMENTS` closed-enum `Map`s + `resolveSingleAxis` helper. Emits a clause **only** for a known token; unknown/hostile tokens are dropped with an axis-named warning (no raw echo) and bypass the char-stripper + `slug()` injection surface.
- `nlFilterMapper.ts`: system prompt teaches generic synonyms + the two new axes; `parseFilterJson` parses priority/recency (keys omitted when absent). Shared `deterministicSignalFilter` helper feeds both the test-mode stub and a gated `applyDeterministicFloor` that fires only when the mapped filter is empty AND a genuine signal exists, else returns `emptyFilter()` byte-unchanged (preserves #1363 project-scoping composition and the graceful-degrade UX).
- `emptyFilter()` + empty -> `statusCategory != Done` path byte-unchanged.

## Test plan
- `npm test` -> 470/470 green (52 suites); new tests assert specific fragment text so they fail on revert.
- `npm run build` -> tsc clean (exit 0).
- AC1-AC5 covered in `tests/jqlFromFilter.test.ts` + `tests/nlFilterMapper.test.ts` (synthetic vocab only).
- Privacy: scripted denylist clean, manual home-path/identity grep over diff = 0 hits.
- 4-role chain: planner -> plan-review PASS (r2) -> executor -> execution-review PASS (independent adversarial review).

https://claude.ai/code/session_01R5rpgymipJKn4AhCTmsYpD