### PR TITLE
feat: mechanical redeploy-on-merge hook + loud startup warn when defect-scope env unset

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,6 +29,9 @@ SLACK_APP_TOKEN=replace-with-your-app-token
 # key(s). When a /jql question names NO project, the read-only search is scoped
 # to these instead of scanning the WHOLE site. A project named in the question
 # always wins. Unset → unchanged (no project fence is forced).
+# NOTE (#1372): leaving this BLANK is allowed, but the bot prints a loud startup
+# WARNING — no-project searches will scan the WHOLE site. Set it to silence the
+# warning and activate the #1363 scope fence.
 # JIRA_DEFAULT_PROJECTS=PROJA
 
 # Optional — Anthropic API key for LLM-backed answers. Without this the bot

--- a/README.md
+++ b/README.md
@@ -131,6 +131,21 @@ npm run build
 launchctl kickstart -k gui/$(id -u)/com.monday-bot   # restart with the new dist/
 ```
 
+> **Auto-redeploy after a pull (#1372).** Install the tracked git hooks once per
+> clone with `bash scripts/install-git-hooks.sh`. The `post-merge` hook then
+> restarts the launchd bot automatically after any `git pull` that advances bot
+> **source** (`src/**` or a build/dependency manifest) — the build-on-start
+> wrapper rebakes `dist/` on relaunch, so the new code actually takes effect.
+> The hook is a clean NO-OP (exit 0, nothing printed) when the launchd bot is
+> not installed — developer clones, CI, and Linux are unaffected. Docs/test-only
+> pulls do not trigger a restart. See `bash scripts/install-git-hooks.sh status`.
+
+> **Blank defect-search scope warning (#1372 / #1363).** If `JIRA_DEFAULT_PROJECTS`
+> is unset/blank, Monday prints a loud startup WARNING: defect searches that name
+> no project will scan the WHOLE Jira site. The setting is optional (the bot
+> still starts), but set it to a comma-separated list of project key(s) to scope
+> those searches and silence the warning.
+
 **Uninstall:**
 
 ```bash

--- a/scripts/git-hooks/post-merge
+++ b/scripts/git-hooks/post-merge
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+#
+# post-merge — auto-redeploy the always-on launchd bot after a SOURCE-advancing
+# pull/merge (#1372). Layer A of the redeploy-prevention pair (Layer B is the
+# blank-scope startup WARN in src/index.ts).
+#
+# WHY: the bot runs a *baked* copy of the code under launchd. A `git pull` that
+# brings in new bot source does NOT take effect until the job is restarted (the
+# build-on-start wrapper rebakes dist/ on relaunch). Doing that by hand is easy
+# to forget — that omission is exactly how the #1363/#1364 fix shipped INERT.
+# This hook makes the restart mechanical.
+#
+# CONTRACT (gates evaluated in this order):
+#   1. launchctl must exist AND the job must be LOADED — checked FIRST. On a
+#      developer clone, CI, or Linux the job is not loaded, so the hook is a
+#      clean NO-OP: exit 0, NO kickstart, NO stderr. (It must NOT call
+#      scripts/redeploy-local.sh — that script `die`s when the job is not
+#      loaded, which would break this required clean NO-OP.)
+#   2. The just-completed merge must have ADVANCED a bot-source path (src/** or a
+#      build/dependency manifest) — docs/tests/workspace-scratch-only merges
+#      NO-OP. When nothing source-y changed: exit 0, NO kickstart.
+#   3. Only when BOTH hold does the hook fire its OWN single
+#      `launchctl kickstart -k <target>`. Idempotent + re-runnable.
+#
+# Self-locates its repo via `readlink -f "$0"` so it works when invoked through
+# git's core.hooksPath (see scripts/install-git-hooks.sh). macOS bash-3.2 clean.
+#
+# Test seams (env-injected; used ONLY by the hermetic smoke — never set in prod):
+#   POST_MERGE_SERVICE_TARGET   launchd service target (default gui/<uid>/com.monday-bot)
+#   POST_MERGE_CHANGED_FILES    newline/space-separated change set to classify
+#                               (default: `git diff --name-only ORIG_HEAD HEAD`)
+#
+set -uo pipefail
+
+LABEL="com.monday-bot"
+
+# Self-locate the hook's repo (resolves a core.hooksPath / symlink invocation).
+# Exercised on the real macOS install path only; the hermetic smoke injects its
+# inputs and does not depend on this resolution.
+HOOK_PATH="$(readlink -f "$0" 2>/dev/null || echo "$0")"
+HOOK_DIR="$(cd "$(dirname "${HOOK_PATH}")" 2>/dev/null && pwd || echo ".")"
+REPO_DIR="$(git -C "${HOOK_DIR}" rev-parse --show-toplevel 2>/dev/null || echo "${HOOK_DIR}")"
+
+SERVICE_TARGET="${POST_MERGE_SERVICE_TARGET:-gui/$(id -u 2>/dev/null || echo 0)/${LABEL}}"
+
+# --- Gate 1: job must be LOADED (evaluated FIRST, before anything mutating) ----
+# A clean NO-OP on a clone/CI/Linux: no launchctl, or the job is not loaded.
+# stderr from launchctl is swallowed so the NO-OP path writes nothing to stderr.
+command -v launchctl >/dev/null 2>&1 || exit 0
+launchctl print "${SERVICE_TARGET}" >/dev/null 2>&1 || exit 0
+
+# --- Gate 2: the merge must have advanced a bot-SOURCE path -------------------
+if [ -n "${POST_MERGE_CHANGED_FILES:-}" ]; then
+  CHANGED="${POST_MERGE_CHANGED_FILES}"
+else
+  CHANGED="$(git -C "${REPO_DIR}" diff --name-only ORIG_HEAD HEAD 2>/dev/null || true)"
+fi
+
+advanced_source=0
+while IFS= read -r changed_path; do
+  [ -n "${changed_path}" ] || continue
+  case "${changed_path}" in
+    src/* | package.json | package-lock.json | tsconfig.json)
+      advanced_source=1
+      break
+      ;;
+  esac
+done <<EOF
+${CHANGED}
+EOF
+
+[ "${advanced_source}" -eq 1 ] || exit 0
+
+# --- Both gates passed: our OWN single restart (rebakes dist/ on relaunch) -----
+launchctl kickstart -k "${SERVICE_TARGET}" >/dev/null 2>&1 || true
+exit 0

--- a/scripts/install-git-hooks.sh
+++ b/scripts/install-git-hooks.sh
@@ -31,14 +31,24 @@ HOOKS_DIR_ABS="${REPO_DIR}/${HOOKS_DIR_REL}"
 
 die() { echo "ERROR: $*" >&2; exit 1; }
 
+# Tracked hooks this installer validates + arms. core.hooksPath auto-discovers
+# any file in the dir, but each is still validated + chmod'd so a fresh clone is
+# fully armed by ONE command.
+HOOK_FILES="pre-commit post-merge"
+
 cmd_install() {
   [ -d "${HOOKS_DIR_ABS}" ] || die "tracked hooks dir not found: ${HOOKS_DIR_REL}"
-  [ -f "${HOOKS_DIR_ABS}/pre-commit" ] || die "pre-commit not found in ${HOOKS_DIR_REL}"
-  chmod +x "${HOOKS_DIR_ABS}/pre-commit" 2>/dev/null || true
+  for hook in ${HOOK_FILES}; do
+    [ -f "${HOOKS_DIR_ABS}/${hook}" ] || die "${hook} not found in ${HOOKS_DIR_REL}"
+    chmod +x "${HOOKS_DIR_ABS}/${hook}" 2>/dev/null || true
+  done
   git -C "${REPO_DIR}" config core.hooksPath "${HOOKS_DIR_REL}"
   echo "Installed: core.hooksPath -> ${HOOKS_DIR_REL}"
   echo "The pre-commit privacy hook is now live for THIS clone."
   echo "Local scope = home-path leaks only; the internal-identifier denylist is a CI backstop."
+  echo "The post-merge redeploy hook is also live: after a pull that advances bot"
+  echo "source it restarts the launchd bot (#1372). It NO-OPs cleanly when the bot"
+  echo "is not installed (developer clones / CI / Linux)."
   echo "Bypass once (discouraged): git commit --no-verify"
 }
 
@@ -47,8 +57,10 @@ cmd_status() {
   cur="$(git -C "${REPO_DIR}" config --get core.hooksPath || true)"
   if [ -n "${cur}" ]; then
     echo "core.hooksPath = ${cur}"
+    echo "Tracked hooks armed: pre-commit (privacy scan), post-merge (#1372 redeploy)."
   else
-    echo "core.hooksPath is NOT set — hook not installed. Run: bash scripts/install-git-hooks.sh"
+    echo "core.hooksPath is NOT set — hooks not installed. Run: bash scripts/install-git-hooks.sh"
+    echo "Tracked hooks that would arm: pre-commit (privacy scan), post-merge (#1372 redeploy)."
   fi
 }
 
@@ -59,14 +71,18 @@ cmd_uninstall() {
 
 usage() {
   cat <<EOF
-install-git-hooks.sh — wire the local pre-commit privacy hook (monday-bot).
+install-git-hooks.sh — wire the local tracked git hooks (monday-bot).
 
-  (no args)    Install: set core.hooksPath -> ${HOOKS_DIR_REL}.
-  status       Show the current core.hooksPath.
+  (no args)    Install: set core.hooksPath -> ${HOOKS_DIR_REL}, validate + chmod the hooks.
+  status       Show the current core.hooksPath + which hooks are armed.
   uninstall    Unset core.hooksPath (tracked files remain).
   --help, -h   This help.
 
-Local scope is HOME-PATH leaks only; the internal-identifier denylist is enforced by CI.
+Tracked hooks armed by install:
+  pre-commit   Local STAGED privacy scan (home-path leaks; denylist is a CI backstop).
+  post-merge   #1372 redeploy — after a pull that advances bot source, restart the
+               launchd bot so it rebakes dist/. NO-OPs cleanly when the bot is not
+               installed (developer clones / CI / Linux).
 EOF
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { App } from "@slack/bolt";
-import { MissingEnvVarError, validateEnv, AppEnv } from "./config/env";
+import { MissingEnvVarError, validateEnv, AppEnv, parseDefaultProjects } from "./config/env";
 import { loadConfig, AppConfig } from "./config/config";
 import { KnowledgeService } from "./knowledge/service";
 import {
@@ -154,6 +154,35 @@ function warnIfStaleBuild(): void {
   } catch {
     /* observability only — never break startup */
   }
+}
+
+/**
+ * #1372 Part B — loud startup WARN when the defect-search scope env is unset.
+ *
+ * The #1363 default-scope feature only fences a no-project /jql search to
+ * `JIRA_DEFAULT_PROJECTS`. When that env is blank the feature is INERT: searches
+ * silently scan the WHOLE site (slow + noisy) with no signal that it's happening
+ * — the exact silent-unset-default trap that left the #1363/#1364 fix invisible.
+ *
+ * The setting is genuinely OPTIONAL (.env.example), so this WARNS only — it
+ * never throws. Pure + injectable: the `log` sink lets the unit test assert the
+ * message without capturing global console. Mirrors logBuildStamp /
+ * warnIfStaleBuild in shape + placement.
+ */
+export function warnIfDefectScopeUnset(
+  env: NodeJS.ProcessEnv = process.env,
+  log: (message: string) => void = console.warn,
+): void {
+  if (parseDefaultProjects(env.JIRA_DEFAULT_PROJECTS).length > 0) {
+    return; // scope is set — stay silent on the happy path
+  }
+  log(
+    "WARNING: JIRA_DEFAULT_PROJECTS is not set — defect searches that name no " +
+      "project will scan the WHOLE Jira site (slow + noisy, and easy to miss). " +
+      "Set JIRA_DEFAULT_PROJECTS to a comma-separated list of project key(s) to " +
+      "scope them (see .env.example). This makes the #1363 default-scope feature " +
+      "active; leaving it blank keeps the pre-#1363 whole-site behavior.",
+  );
 }
 
 export async function runMonday(opts: RunMondayOptions = {}): Promise<RunMondayHandle> {
@@ -313,6 +342,9 @@ if (require.main === module) {
   } catch {
     /* no .env file — rely on shell-exported env vars */
   }
+  // Layer B (#1372): WARN loudly (never throw) if the optional defect-search
+  // scope env is blank, so the silent whole-site fallback can't go unnoticed.
+  warnIfDefectScopeUnset();
   runMonday().catch((err) => {
     const message = err instanceof Error ? err.message : String(err);
     console.error(`Monday: unhandled error during startup: ${message}`);

--- a/tests/defect-scope-warn.test.ts
+++ b/tests/defect-scope-warn.test.ts
@@ -1,0 +1,55 @@
+/**
+ * #1372 Part B — unit test for the blank-scope startup WARN seam
+ * (warnIfDefectScopeUnset). Cross-platform, no launchctl, no subprocess. Uses an
+ * injected sink so the message is asserted without capturing global console.
+ *
+ * Synthetic project keys ONLY — this is a PUBLIC repo and no real Jira project
+ * key may appear in a committed test.
+ */
+
+import { warnIfDefectScopeUnset } from "../src/index";
+
+function collect(env: NodeJS.ProcessEnv): string[] {
+  const sink: string[] = [];
+  warnIfDefectScopeUnset(env, (m) => sink.push(m));
+  return sink;
+}
+
+describe("warnIfDefectScopeUnset (#1372 Part B / #1363)", () => {
+  it("WARNS when JIRA_DEFAULT_PROJECTS is unset (AC-B1)", () => {
+    expect(collect({})).toHaveLength(1);
+  });
+
+  it("WARNS when JIRA_DEFAULT_PROJECTS is blank or all-commas (AC-B1)", () => {
+    expect(collect({ JIRA_DEFAULT_PROJECTS: "" })).toHaveLength(1);
+    expect(collect({ JIRA_DEFAULT_PROJECTS: "   " })).toHaveLength(1);
+    expect(collect({ JIRA_DEFAULT_PROJECTS: ", ,," })).toHaveLength(1);
+  });
+
+  it("is SILENT when set to a synthetic project key (AC-B2)", () => {
+    expect(collect({ JIRA_DEFAULT_PROJECTS: "SAMPLEKEY" })).toHaveLength(0);
+    expect(collect({ JIRA_DEFAULT_PROJECTS: "ALPHA,BETA" })).toHaveLength(0);
+    expect(collect({ JIRA_DEFAULT_PROJECTS: " SOLO " })).toHaveLength(0);
+  });
+
+  it("the message carries the env-var name + #1363 but no project-key token (AC-B3)", () => {
+    const msg = collect({})[0];
+    expect(msg).toContain("JIRA_DEFAULT_PROJECTS");
+    expect(msg).toContain("#1363");
+    // No real/synthetic project key (e.g. ABC-123 / PROJ42) leaks into the text.
+    expect(msg).not.toMatch(/\b[A-Z][A-Z0-9]+-\d+\b/);
+    expect(msg).not.toMatch(/\bPROJ[A-Z]?\d*\b/);
+  });
+
+  it("does NOT throw when the env is unset (AC-B4 — no-throw contract)", () => {
+    expect(() => warnIfDefectScopeUnset({}, () => undefined)).not.toThrow();
+    // Also exercise the real default sink path (console.warn) without crashing.
+    const original = console.warn;
+    console.warn = () => undefined;
+    try {
+      expect(() => warnIfDefectScopeUnset({})).not.toThrow();
+    } finally {
+      console.warn = original;
+    }
+  });
+});

--- a/tests/fixtures/launchctl-shim/launchctl
+++ b/tests/fixtures/launchctl-shim/launchctl
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+#
+# launchctl — HERMETIC SHIM for the post-merge hook smoke (#1372). This is NOT a
+# real launchctl; it lives on PATH for the bash smoke ONLY (tests/post-merge-hook
+# .test.ts prepends this dir). Behavior is driven by env the smoke sets per case:
+#   SHIM_JOB_LOADED=1  -> `launchctl print <target>` exits 0 (job "loaded")
+#                         (anything else -> exit 1, i.e. NOT loaded)
+#   SHIM_CALL_LOG=<f>  -> each `launchctl kickstart ...` appends a line to <f>
+# Any other subcommand is a benign exit 0.
+#
+set -u
+case "${1:-}" in
+  print)
+    [ "${SHIM_JOB_LOADED:-0}" = "1" ] && exit 0
+    exit 1
+    ;;
+  kickstart)
+    [ -n "${SHIM_CALL_LOG:-}" ] && echo "kickstart" >>"${SHIM_CALL_LOG}"
+    exit 0
+    ;;
+  *)
+    exit 0
+    ;;
+esac

--- a/tests/post-merge-hook-smoke.sh
+++ b/tests/post-merge-hook-smoke.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+#
+# post-merge-hook-smoke.sh — hermetic behavioral smoke for
+# scripts/git-hooks/post-merge (#1372). Driven by the win32-skipped jest wrapper
+# tests/post-merge-hook.test.ts, which prepends the launchctl SHIM dir
+# (tests/fixtures/launchctl-shim) to PATH — so `launchctl` here is the shim, NOT
+# the system binary. There is ZERO launchctl logic in any TS file; the wrapper
+# only shells out and asserts this script's exit code.
+#
+# It drives the hook with env-injected inputs (service target + change set) so
+# every assertion is observable from OUTSIDE the implementation, and proves the
+# three contract cases:
+#   1. job ABSENT + source changed   -> NO-OP: exit 0, no kickstart, no stderr.
+#   2. job LOADED + non-source only   -> NO-OP: exit 0, no kickstart.
+#   3. job LOADED + source advanced   -> EXACTLY ONE kickstart, exit 0.
+#
+# `readlink -f "$0"` self-location is NOT exercised here (env-injected inputs);
+# it is the macOS-install-path concern noted in the hook header.
+#
+set -uo pipefail
+
+SMOKE_PATH="$(readlink -f "$0" 2>/dev/null || echo "$0")"
+SMOKE_DIR="$(cd "$(dirname "${SMOKE_PATH}")" && pwd)"
+REPO_DIR="$(cd "${SMOKE_DIR}/.." && pwd)"
+HOOK="${REPO_DIR}/scripts/git-hooks/post-merge"
+
+fail() { echo "post-merge smoke: $*" >&2; }
+
+[ -f "${HOOK}" ] || { fail "FAIL — hook not found at ${HOOK}"; exit 1; }
+
+# The launchctl on PATH MUST be the shim (the wrapper guarantees this); if the
+# real binary were resolved, a not-loaded job would falsely look the same — but
+# a kickstart would hit the real launchctl. Guard against a mis-wired PATH.
+command -v launchctl >/dev/null 2>&1 || { fail "FAIL — no launchctl shim on PATH"; exit 1; }
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "${WORK}"' EXIT
+CALL_LOG="${WORK}/calls.log"
+ERR_LOG="${WORK}/stderr.log"
+TARGET="gui/0/com.monday-bot.test"
+
+# run_hook <job-loaded 0|1> <changed-files newline-sep> -> prints the hook exit code
+run_hook() {
+  : >"${CALL_LOG}"
+  : >"${ERR_LOG}"
+  SHIM_JOB_LOADED="$1" \
+  SHIM_CALL_LOG="${CALL_LOG}" \
+  POST_MERGE_SERVICE_TARGET="${TARGET}" \
+  POST_MERGE_CHANGED_FILES="$2" \
+    bash "${HOOK}" 1 >/dev/null 2>"${ERR_LOG}"
+  echo "$?"
+}
+
+kick_count() { grep -c '^kickstart' "${CALL_LOG}" 2>/dev/null || true; }
+
+fails=0
+
+# --- Case 1: job ABSENT + source changed -> clean NO-OP (no stderr) -----------
+rc="$(run_hook 0 "src/index.ts")"
+[ "${rc}" = "0" ] || { fail "Case1 FAIL — exit ${rc} != 0"; fails=1; }
+[ "$(kick_count)" = "0" ] || { fail "Case1 FAIL — kickstart fired while job ABSENT"; fails=1; }
+[ -s "${ERR_LOG}" ] && { fail "Case1 FAIL — wrote to stderr while job ABSENT"; fails=1; }
+
+# --- Case 2: job LOADED + only non-source changed -> NO-OP --------------------
+rc="$(run_hook 1 "README.md
+tests/foo.test.ts
+.ai-workspace/notes.md")"
+[ "${rc}" = "0" ] || { fail "Case2 FAIL — exit ${rc} != 0"; fails=1; }
+[ "$(kick_count)" = "0" ] || { fail "Case2 FAIL — kickstart fired for non-source change"; fails=1; }
+
+# --- Case 3: job LOADED + source advanced -> exactly ONE kickstart ------------
+rc="$(run_hook 1 "README.md
+src/index.ts")"
+[ "${rc}" = "0" ] || { fail "Case3 FAIL — exit ${rc} != 0"; fails=1; }
+[ "$(kick_count)" = "1" ] || { fail "Case3 FAIL — expected 1 kickstart, got $(kick_count)"; fails=1; }
+
+if [ "${fails}" -ne 0 ]; then
+  fail "FAIL"
+  exit 1
+fi
+echo "post-merge smoke: PASS (3/3 cases)"
+exit 0

--- a/tests/post-merge-hook.test.ts
+++ b/tests/post-merge-hook.test.ts
@@ -1,0 +1,38 @@
+/**
+ * #1372 Part A — jest wrapper that BINDS the hermetic post-merge hook smoke into
+ * `npm test` (so the ubuntu CI leg provably runs it; AC-A6). It mirrors
+ * tests/install-launchd.test.ts: the ONLY subprocess shells out to bash, and is
+ * win32-skipped (bash + the launchctl shim aren't guaranteed on Windows CI).
+ *
+ * There is ZERO launchctl logic in this file. All gating is in the bash hook
+ * (scripts/git-hooks/post-merge); all simulation is in the bash smoke
+ * (tests/post-merge-hook-smoke.sh) + the PATH-shimmed launchctl
+ * (tests/fixtures/launchctl-shim/launchctl). This wrapper only puts the shim on
+ * PATH, runs the smoke, and asserts its exit code.
+ */
+
+import { execFileSync } from "node:child_process";
+import { join } from "node:path";
+
+const REPO_ROOT = join(__dirname, "..");
+const SMOKE = join(REPO_ROOT, "tests", "post-merge-hook-smoke.sh");
+const SHIM_DIR = join(REPO_ROOT, "tests", "fixtures", "launchctl-shim");
+
+describe("post-merge redeploy hook (#1372 Part A — hermetic launchctl-shim smoke)", () => {
+  // bash + the shim aren't guaranteed on the Windows runner; skip there only —
+  // on the ubuntu CI leg this RUNS (passes, not skipped), so the smoke cannot
+  // silently go unrun (AC-A6).
+  const maybe = process.platform === "win32" ? it.skip : it;
+
+  maybe(
+    "kickstarts exactly once when LOADED + source advanced; clean NO-OP when ABSENT or non-source",
+    () => {
+      expect(() =>
+        execFileSync("bash", [SMOKE], {
+          stdio: "pipe",
+          env: { ...process.env, PATH: `${SHIM_DIR}:${process.env.PATH ?? ""}` },
+        }),
+      ).not.toThrow();
+    },
+  );
+});


### PR DESCRIPTION
## Summary

Prevention for the double-fault where a merged fix to the always-on launchd bot stayed **inert**:
1. **Stale deploy** — nothing restarted the bot after merge, so it kept serving compiled `dist/` built before the merge.
2. **Silent unset config** — the activating scope env was never set in the live config, and its unset-default silently matched the old buggy behavior (no warning).

### Part A — mechanical redeploy-on-merge
A gated `post-merge` git hook (installed via `scripts/install-git-hooks.sh`) restarts the launchd service when a pull advances tracked **source**. It:
- evaluates the service-loaded gate **first** → clean exit-0 no-op with **no stderr** when the service isn't loaded (dev clones / CI),
- fires its **own single** restart only when loaded AND source advanced (doc-only / test-only changes don't trigger),
- never calls the heavy redeploy path,
- self-locates via `readlink -f "$0"`.

### Part B — loud startup warning
A pure `warnIfDefectScopeUnset(env, log)` seam called right after env load emits a prominent startup warning (**no throw**) when the defect-scope env is unset — so a silently-absent activating config can't mask a regression again.

## Test plan
- Part A: hermetic launchctl-shim smoke (no-op when service absent; no restart on non-source-only change; exactly one restart when loaded + source advanced) run through a **win32-skipped jest wrapper**, so it's provably executed by `npm test` (cannot silently go unrun).
- Part B: unit test — warns when env unset/blank, silent when set, message carries the env-var name + the originating issue ref but no project key, no throw.
- Full local gate green: `npm run build`, `npm test` (54 suites / 483 tests), `scripts/privacy-denylist-check.sh`.
- All launchctl logic lives only in the bash hook/shim — zero launchctl logic in any TypeScript file.

## Docs
`.env.example` + `README.md` document both the redeploy hook and the scope-unset startup warning.

https://claude.ai/code/session_01R5rpgymipJKn4AhCTmsYpD