### PR TITLE
fix(rag): backstop false not-found (#1374) + dedup/compact citations (#1375)

### DIFF
--- a/src/llm/generate.ts
+++ b/src/llm/generate.ts
@@ -16,6 +16,7 @@ export const SYSTEM_PROMPT =
   "Passages framed as BUSINESS RULES, specs, change-logs, internal-reference notes, or backend/engineering tickets STILL count as grounding when they describe the STEPS, FLOW, or MECHANISM of what the user asked about. Do NOT refuse merely because the material is framed as internal/backend/business-rules rather than a polished end-user guide — translate the documented flow into plain user-facing steps and cite [N]. For example, if the question is how to find/do something and a passage describes the matching/selection/decision flow for exactly that, EXPLAIN that flow as the answer instead of saying there are no user-facing instructions. " +
   "This process/spec clause applies ONLY when that passage is genuinely ON-TOPIC and relevant to the exact question asked; a process or spec passage that is about a DIFFERENT topic than the question is NOT grounding for that question — do not cite it, and abstain if nothing on-topic remains. " +
   "SINGLE-PRODUCT KNOWLEDGE BASE: every passage here is about ONE product, so the ABSENCE of the product's or a feature's NAME (a brand or proper-noun) from the passages is MEANINGLESS — a missing brand word does NOT mean the topic is uncovered, and you must NEVER open with \"I couldn't find\" merely because the exact product or feature name from the question is not present verbatim in the passages. Decide grounding ONLY on whether the passages genuinely DESCRIBE THE TOPIC OR FEATURE the question asks about: if any passage describes that topic's mechanism, flow, rules, locations, or plans — even partially, even as a roadmap or backend/spec note — you MUST lead with that documented answer and cite [N], not prepend a hedge, even though the passage never names the product. The ONLY exception is the no-yes-man clamp: a passage that merely mentions or is generally about the product but does NOT address the specific topic asked is NOT grounding — only in that case do you cleanly decline with no citations. This clause removes ONLY proper-noun ABSENCE as a disqualifier; the existing genuinely ON-TOPIC precondition above still governs — it does NOT relax the requirement that the passage be on-topic to the exact question asked. " +
+  "TOPIC-COVERED vs TOPIC-ABSENT: decide whether to answer on the QUESTION'S TOPIC, never on whether a product or feature NAME string is present verbatim in the passages. GOOD (topic covered, name absent): the question names a product or feature whose NAME does NOT appear in the passages, but a passage describes that topic's mechanism, flow, rules, locations, or plans — you MUST lead with that documented answer and cite [N]; do NOT open with a refusal merely because the name is missing. BAD (topic covered, wrong opener): opening with \"I couldn't find ...\" just because the named thing is not written verbatim, while a passage describes the asked topic. ABSTAIN only when the TOPIC ITSELF is genuinely absent or off-topic — then decline cleanly with no citations. " +
   "When you abstain, your reply MUST contain NO [N] citation markers at all — never cite a loosely-related passage while saying you couldn't find the answer. " +
   "PREFER DOCS OVER TICKET STUBS: when both narrative/document sources and bare issue-tracker ticket stubs cover the same topic, build your answer from and cite the document/narrative passages, not bare ticket titles. " +
   "PHASED / PLANNED ROLLOUTS: when the relevant doc describes a PLANNED or PHASED rollout or roadmap, answer with what is LIVE now and what is NAMED-planned and cite the doc [N]; do NOT dismiss a roadmap as \"no comprehensive list.\" " +
@@ -25,6 +26,80 @@ export const SYSTEM_PROMPT =
 
 export const NO_CONTEXT_ANSWER =
   "I couldn't find any relevant information in the indexed documents to answer this question.";
+
+/**
+ * #1374b — refusal-opener backstop.
+ *
+ * Default phrase set the model tends to OPEN a refusal with. Configurable via
+ * `MONDAY_REFUSAL_OPENERS` (comma-separated; trimmed; empties dropped — mirrors
+ * `parseDefaultProjects` in `src/config/env.ts`). Per the no-magic-string rule:
+ * the phrase set is data, not an inline literal buried in the detector.
+ */
+const DEFAULT_REFUSAL_OPENERS = [
+  "I couldn't find",
+  "I could not find",
+  "I'm unable to find",
+  "I am unable to find",
+  "I don't have",
+  "I do not have",
+  "There is no relevant",
+  "No relevant information",
+];
+
+/**
+ * Firmer, CONDITIONAL retry directive appended on the bad path. It must NOT
+ * order the model to "answer anyway" — there is no relevance threshold upstream
+ * (`service.ts` passes whatever retrieval returns), so the genuine-abstain
+ * escape is preserved verbatim. The retry only corrects a proper-noun-absence
+ * over-refusal; it never manufactures an answer from off-topic chunks.
+ */
+const REGEN_DIRECTIVE =
+  "Re-examine the passages above. IF any passage describes the TOPIC of the question — its mechanism, flow, rules, locations, or plans — even though the product/feature NAME may be absent, then lead with that documented answer and cite it [N], and note any gap only afterward. IF the passages genuinely do NOT address the asked topic, abstain plainly with no citations. Never state facts that are not in the passages.";
+
+/**
+ * Normalize a string for refusal-opener comparison: fold every apostrophe
+ * variant (U+0027 `'` and U+2019 `’`) to a single ASCII apostrophe, then
+ * lower-case. The model frequently emits a typographic apostrophe
+ * (`I couldn’t`), so a naive `startsWith` against the ASCII-stored phrase set
+ * would miss it — this normalization is what makes the curly form match.
+ */
+function normalizeForOpener(s: string): string {
+  return s.replace(/['’]/g, "'").toLowerCase();
+}
+
+/**
+ * Resolve the active refusal-opener set. `MONDAY_REFUSAL_OPENERS` (when set and
+ * non-empty after parsing) fully REPLACES the defaults; otherwise the defaults
+ * apply. Side-effect-free so it can be re-read per call (env may change in
+ * tests).
+ */
+function refusalOpeners(): string[] {
+  const raw = process.env.MONDAY_REFUSAL_OPENERS;
+  if (!raw) return DEFAULT_REFUSAL_OPENERS;
+  const parsed = raw
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+  return parsed.length > 0 ? parsed : DEFAULT_REFUSAL_OPENERS;
+}
+
+/**
+ * Pure detector: true iff `answer`, after trimming leading whitespace, opens
+ * (case-insensitively, apostrophe-normalized) with any configured refusal
+ * phrase. Defensive: a non-string input is never a refusal opener.
+ */
+export function opensWithRefusal(answer: string): boolean {
+  if (typeof answer !== "string") return false;
+  const head = normalizeForOpener(answer.replace(/^\s+/, ""));
+  return refusalOpeners().some((phrase) =>
+    head.startsWith(normalizeForOpener(phrase)),
+  );
+}
+
+/** Kill-switch: `MONDAY_REFUSAL_BACKSTOP="0"` disables the regenerate step. */
+function backstopEnabled(): boolean {
+  return process.env.MONDAY_REFUSAL_BACKSTOP !== "0";
+}
 
 /**
  * Pure helper: return ONLY the citations whose `number` actually appears as an
@@ -108,10 +183,10 @@ function offlineAnswer(chunks: Chunk[]): AnswerResult {
     body.length > 0
       ? `${body} [1]`
       : NO_CONTEXT_ANSWER;
-  return {
+  return compactRenumber(
     answer,
-    citations: selectCitedCitations(answer, buildCitations(chunks)),
-  };
+    selectCitedCitations(answer, buildCitations(chunks)),
+  );
 }
 
 export interface Chunk {
@@ -134,10 +209,31 @@ export interface AnswerResult {
   citations: Citation[];
 }
 
+/**
+ * #1375 — shared source numbering. Walk chunks in order and assign the next
+ * integer (1, 2, 3 …) to each previously-unseen `source`, reusing the same
+ * number whenever that source recurs. The in-text `[N]` markers the model emits
+ * refer to THIS numbering, so `formatContext` and `buildCitations` MUST share
+ * it — numbering by source in only one of them would desync the answer text
+ * from the citation list. (Dedup key = `source`/docId.)
+ */
+function buildSourceNumbering(chunks: Chunk[]): Map<string, number> {
+  const numbering = new Map<string, number>();
+  let next = 1;
+  for (const c of chunks) {
+    if (!numbering.has(c.source)) {
+      numbering.set(c.source, next);
+      next += 1;
+    }
+  }
+  return numbering;
+}
+
 function formatContext(chunks: Chunk[]): string {
+  const numbering = buildSourceNumbering(chunks);
   return chunks
-    .map((c, i) => {
-      const n = i + 1;
+    .map((c) => {
+      const n = numbering.get(c.source);
       const meta = c.heading
         ? `(source: ${c.source}, heading: ${c.heading})`
         : `(source: ${c.source})`;
@@ -146,12 +242,73 @@ function formatContext(chunks: Chunk[]): string {
     .join("\n\n");
 }
 
-function buildCitations(chunks: Chunk[]): Citation[] {
-  return chunks.map((c, i) => {
-    const entry: Citation = { number: i + 1, source: c.source };
-    if (c.heading) entry.heading = c.heading;
-    return entry;
+/**
+ * #1375 — one citation per UNIQUE source. Uses the shared numbering so the
+ * citation list can never produce two numbers for the same source. The heading
+ * is the first NON-EMPTY heading seen for that source (omitted if none).
+ * Citations are ordered by assigned number.
+ */
+export function buildCitations(chunks: Chunk[]): Citation[] {
+  const numbering = buildSourceNumbering(chunks);
+  const bySource = new Map<string, Citation>();
+  for (const c of chunks) {
+    const number = numbering.get(c.source)!;
+    let entry = bySource.get(c.source);
+    if (!entry) {
+      entry = { number, source: c.source };
+      bySource.set(c.source, entry);
+    }
+    if (entry.heading === undefined && c.heading) {
+      entry.heading = c.heading;
+    }
+  }
+  return [...bySource.values()].sort((a, b) => a.number - b.number);
+}
+
+/**
+ * #1375 — compact, contiguous renumbering. THE single place an old#→new# map is
+ * applied, so the answer text markers and the citation list never diverge.
+ *
+ * - Defensive: non-string `answer` / non-array `citations` -> `{ answer, [] }`.
+ * - Collect old numbers that appear as `[N]` in `answer` AND exist in
+ *   `citations`; sort ascending and assign contiguous new numbers 1, 2, 3 ….
+ * - Rewrite the answer text in ONE pass via a `/\[(\d+)\]/g` replace callback so
+ *   a sequential rewrite can never double-substitute (bracket tokens match
+ *   whole, never partially — multi-digit safe).
+ * - Rewrite each citation's `number` via the same map; drop any not in the map;
+ *   sort by new number.
+ */
+export function compactRenumber(
+  answer: string,
+  citations: Citation[],
+): AnswerResult {
+  if (typeof answer !== "string" || !Array.isArray(citations)) {
+    return { answer, citations: [] };
+  }
+  const present = new Set<number>();
+  for (const c of citations) present.add(c.number);
+
+  const cited = new Set<number>();
+  for (const m of answer.matchAll(/\[(\d+)\]/g)) {
+    const n = Number(m[1]);
+    if (present.has(n)) cited.add(n);
+  }
+
+  const ordered = [...cited].sort((a, b) => a - b);
+  const remap = new Map<number, number>();
+  ordered.forEach((oldNum, i) => remap.set(oldNum, i + 1));
+
+  const newAnswer = answer.replace(/\[(\d+)\]/g, (whole, digits) => {
+    const mapped = remap.get(Number(digits));
+    return mapped === undefined ? whole : `[${mapped}]`;
   });
+
+  const newCitations = citations
+    .filter((c) => remap.has(c.number))
+    .map((c) => ({ ...c, number: remap.get(c.number)! }))
+    .sort((a, b) => a.number - b.number);
+
+  return { answer: newAnswer, citations: newCitations };
 }
 
 export async function generateAnswer(
@@ -188,34 +345,56 @@ export async function generateAnswer(
     `Context:\n${context}\n\n` +
     `Answer the question using only facts from the context. Cite each claim with [N].`;
 
-  const response = await client.messages.create({
-    model: MODEL,
-    max_tokens: MAX_TOKENS,
-    // temperature 0: the ground-vs-abstain drift on the same question was a
-    // high-temperature coin-flip (#1195). Deterministic decoding stabilizes the
-    // answer so a correct prompt grounds consistently and a wrong one fails
-    // consistently (detectable), instead of flip-flopping run-to-run.
-    temperature: 0,
-    system: SYSTEM_PROMPT,
-    messages: [{ role: "user", content: userContent }],
-  });
+  let text = await callModel(client, userContent);
 
-  const text = response.content
-    .filter((block) => block.type === "text")
-    .map((block) => (block as { type: "text"; text: string }).text)
-    .join("")
-    .trim();
+  // #1374b backstop: chunks ARE present, but the model still OPENED with a
+  // configured refusal phrase — a likely proper-noun-absence over-refusal.
+  // Regenerate ONCE at temperature 0 with the firmer CONDITIONAL directive
+  // (gated on the kill-switch). We never fabricate: a still-refusing retry is
+  // accepted as-is, and its citations end empty without invented content.
+  if (
+    text.length > 0 &&
+    chunks.length > 0 &&
+    backstopEnabled() &&
+    opensWithRefusal(text)
+  ) {
+    const harderContent = `${userContent}\n\n${REGEN_DIRECTIVE}`;
+    const retry = await callModel(client, harderContent);
+    if (retry.length > 0) text = retry;
+  }
 
   if (text.length === 0) {
-    const blockTypes = response.content.map((block) => block.type);
     console.warn(
-      `[generateAnswer] model returned non-text-only response: block_types=${JSON.stringify(blockTypes)} stop_reason=${response.stop_reason ?? "unknown"}`,
+      "[generateAnswer] model returned no text content; returning no-context answer",
     );
     return { answer: NO_CONTEXT_ANSWER, citations: [] };
   }
 
-  return stripStrayAbstainCitations(
-    text,
-    selectCitedCitations(text, buildCitations(chunks)),
-  );
+  const built = buildCitations(chunks); // dedup'd by source
+  const cited = selectCitedCitations(text, built); // only cited, may have gaps
+  const abst = stripStrayAbstainCitations(text, cited); // genuine-abstain -> []
+  return compactRenumber(abst.answer, abst.citations); // contiguous, text+list in sync
+}
+
+/**
+ * Private helper: one model call returning the trimmed concatenated text of all
+ * text blocks. Temperature stays 0 — determinism doctrine (#1195). The backstop
+ * differentiates its retry by the CHANGED directive, not by raised temperature.
+ */
+async function callModel(
+  client: ReturnType<typeof getClient>,
+  userContent: string,
+): Promise<string> {
+  const response = await client.messages.create({
+    model: MODEL,
+    max_tokens: MAX_TOKENS,
+    temperature: 0,
+    system: SYSTEM_PROMPT,
+    messages: [{ role: "user", content: userContent }],
+  });
+  return response.content
+    .filter((block) => block.type === "text")
+    .map((block) => (block as { type: "text"; text: string }).text)
+    .join("")
+    .trim();
 }

--- a/tests/__stubs__/anthropic-sdk.js
+++ b/tests/__stubs__/anthropic-sdk.js
@@ -7,6 +7,12 @@
 // generateAnswer's return value, so we surface it on the module instead).
 let __lastRequest = null;
 
+// #1374b test infra: a FIFO response queue + call counter so the backstop's
+// two-call regenerate path is testable. When the queue is empty, messages.create
+// falls back to the canonical answer below (existing tests unchanged).
+let __responseQueue = [];
+let __callCount = 0;
+
 class Anthropic {
   constructor(options) {
     this._options = options || {};
@@ -20,6 +26,7 @@ class Anthropic {
           throw new Error("Anthropic SDK stub: messages.create requires a request object");
         }
         __lastRequest = _req;
+        __callCount += 1;
         if (typeof _req.model !== "string" || _req.model.length === 0) {
           throw new Error("Anthropic SDK stub: _req.model must be a non-empty string");
         }
@@ -41,12 +48,16 @@ class Anthropic {
             throw new Error("Anthropic SDK stub: _req.messages[" + i + "].content is required");
           }
         }
-        // Canonical response the tests can assert on. [1] keeps AC-01 happy;
-        // the word count keeps AC-04 happy if a real call somehow hits the stub.
+        // #1374b: a queued response (FIFO) takes precedence so backstop tests
+        // can script the two-call regenerate path. Empty queue -> canonical
+        // answer below (existing tests unchanged). [1] keeps AC-01 happy; the
+        // word count keeps AC-04 happy if a real call somehow hits the stub.
         const text =
-          "Per the provided context, the documented procedure is to follow the " +
-          "cited source material directly [1]. The context supplies a complete, " +
-          "self-contained answer with no outside knowledge required.";
+          __responseQueue.length > 0
+            ? __responseQueue.shift()
+            : "Per the provided context, the documented procedure is to follow the " +
+              "cited source material directly [1]. The context supplies a complete, " +
+              "self-contained answer with no outside knowledge required.";
         return {
           id: "msg_stub_001",
           type: "message",
@@ -67,6 +78,22 @@ class Anthropic {
 // #1195 test introspection: the most recent messages.create request.
 Anthropic.__getLastRequest = () => __lastRequest;
 Anthropic.__resetLastRequest = () => {
+  __lastRequest = null;
+};
+
+// #1374b test infra: controllable response queue + call counter.
+Anthropic.__enqueueResponse = (text) => {
+  __responseQueue.push(text);
+};
+Anthropic.__setResponses = (texts) => {
+  __responseQueue = Array.isArray(texts) ? [...texts] : [];
+};
+Anthropic.__getCallCount = () => __callCount;
+// __reset() clears the FIFO queue, the call counter, AND __lastRequest
+// (__resetLastRequest semantics folded in) — see plan R3 leak-prevention.
+Anthropic.__reset = () => {
+  __responseQueue = [];
+  __callCount = 0;
   __lastRequest = null;
 };
 

--- a/tests/generate.prompt-integrity.test.ts
+++ b/tests/generate.prompt-integrity.test.ts
@@ -72,4 +72,12 @@ describe("SYSTEM_PROMPT integrity", () => {
     expect(SYSTEM_PROMPT).toMatch(/what is LIVE now and what is NAMED-planned/);
     expect(SYSTEM_PROMPT).toMatch(/do NOT dismiss a roadmap as/);
   });
+
+  // #1374a — strengthened anti-refusal contrast clause.
+  it("adds the TOPIC-COVERED vs TOPIC-ABSENT contrast clause with GOOD/BAD cues (#1374a)", () => {
+    expect(SYSTEM_PROMPT).toMatch(/TOPIC-COVERED vs TOPIC-ABSENT/);
+    // The clause must carry an explicit GOOD vs BAD contrast cue.
+    expect(SYSTEM_PROMPT).toMatch(/GOOD \(topic covered/);
+    expect(SYSTEM_PROMPT).toMatch(/BAD \(topic covered/);
+  });
 });

--- a/tests/generate.test.ts
+++ b/tests/generate.test.ts
@@ -16,6 +16,9 @@ import {
   generateAnswer,
   selectCitedCitations,
   stripStrayAbstainCitations,
+  opensWithRefusal,
+  compactRenumber,
+  buildCitations,
   NO_CONTEXT_ANSWER,
   Chunk,
   Citation,
@@ -132,6 +135,190 @@ describe("generateAnswer", () => {
         source: "hr-policy.txt",
         heading: "Leave",
       });
+    });
+  });
+
+  // #1374b — code backstop. Nested here so it inherits the ANTHROPIC_API_KEY
+  // beforeAll/afterAll above (R2): without a key, generateAnswer falls to the
+  // offline path and never consults the stub (0 model calls -> wrong path).
+  describe("over-refusal backstop", () => {
+    const AnthropicStub = require("@anthropic-ai/sdk");
+
+    afterEach(() => {
+      // R3 leak-prevention: clear the FIFO queue + counter + lastRequest so
+      // unconsumed responses can't corrupt the next test's call-count assertion.
+      AnthropicStub.__reset();
+    });
+
+    const synthChunks: Chunk[] = [
+      {
+        id: "c1",
+        text: "The onboarding flow is set step X then step Y.",
+        source: "mb-flow-onboarding",
+        heading: "Onboarding",
+      },
+      {
+        id: "c2",
+        text: "The widget config lives under settings.",
+        source: "mb-feature-widget",
+      },
+    ];
+
+    test("B1: chunks>0 + refusal opener -> regenerate once, returns grounded retry", async () => {
+      AnthropicStub.__reset();
+      AnthropicStub.__setResponses([
+        "I couldn't find any relevant information about that.",
+        "The documented onboarding flow is set X then Y [1].",
+      ]);
+      const result = await generateAnswer("How does onboarding work?", synthChunks);
+      expect(result.answer).toContain("documented onboarding flow");
+      expect(result.answer).not.toMatch(/^I couldn't find/);
+      expect(result.citations.length).toBeGreaterThanOrEqual(1);
+      expect(AnthropicStub.__getCallCount()).toBe(2);
+    });
+
+    test("B2: chunks===0 -> refusal, citations [], ZERO model calls", async () => {
+      AnthropicStub.__reset();
+      const result = await generateAnswer("Anything?", []);
+      expect(result.answer.toLowerCase()).toMatch(/couldn't find|no relevant/);
+      expect(result.citations).toEqual([]);
+      expect(AnthropicStub.__getCallCount()).toBe(0);
+    });
+
+    test("B3: two refusals in a row -> still abstains, no fabrication, citations []", async () => {
+      AnthropicStub.__reset();
+      // Both refusals carry NO [N] markers (N1): the 2nd uses a non-stripStray
+      // opener on purpose to prove the marker-free path also yields [].
+      AnthropicStub.__setResponses([
+        "I couldn't find anything on that topic.",
+        "I don't have information addressing that topic.",
+      ]);
+      const result = await generateAnswer("How does onboarding work?", synthChunks);
+      expect(result.answer.toLowerCase()).toMatch(/couldn't find|don't have/);
+      expect(result.answer).not.toContain("[1]");
+      expect(result.citations).toEqual([]);
+      expect(AnthropicStub.__getCallCount()).toBe(2);
+    });
+
+    test("B4: MONDAY_REFUSAL_BACKSTOP=0 suppresses the regenerate call", async () => {
+      const prev = process.env.MONDAY_REFUSAL_BACKSTOP;
+      process.env.MONDAY_REFUSAL_BACKSTOP = "0";
+      try {
+        AnthropicStub.__reset();
+        AnthropicStub.__setResponses([
+          "I couldn't find that.",
+          "grounded reply [1]",
+        ]);
+        const result = await generateAnswer("How does onboarding work?", synthChunks);
+        expect(AnthropicStub.__getCallCount()).toBe(1);
+        expect(result.answer.toLowerCase()).toMatch(/couldn't find/);
+      } finally {
+        if (prev === undefined) delete process.env.MONDAY_REFUSAL_BACKSTOP;
+        else process.env.MONDAY_REFUSAL_BACKSTOP = prev;
+      }
+    });
+
+    test("B5: opensWithRefusal detector + override + curly apostrophe", () => {
+      const prev = process.env.MONDAY_REFUSAL_OPENERS;
+      try {
+        // Default openers detected.
+        expect(opensWithRefusal("I couldn't find that.")).toBe(true);
+        expect(opensWithRefusal("I could not find that.")).toBe(true);
+        expect(opensWithRefusal("I don't have that.")).toBe(true);
+        expect(opensWithRefusal("No relevant information here.")).toBe(true);
+        // N2: typographic/curly apostrophe form matches.
+        expect(opensWithRefusal("I couldn’t find that.")).toBe(true);
+        // Leading whitespace tolerated.
+        expect(opensWithRefusal("   I couldn't find that.")).toBe(true);
+        // Content-leading answer is NOT a refusal.
+        expect(opensWithRefusal("The setup doc [1] covers that.")).toBe(false);
+        // Non-string -> false.
+        expect(opensWithRefusal(undefined as unknown as string)).toBe(false);
+
+        // Override: a custom phrase is detected AND a former default is not.
+        process.env.MONDAY_REFUSAL_OPENERS = "Regrettably, no data";
+        expect(opensWithRefusal("Regrettably, no data exists.")).toBe(true);
+        expect(opensWithRefusal("I couldn't find that.")).toBe(false);
+      } finally {
+        if (prev === undefined) delete process.env.MONDAY_REFUSAL_OPENERS;
+        else process.env.MONDAY_REFUSAL_OPENERS = prev;
+      }
+    });
+  });
+
+  // #1375 — dedup by source + compact renumber. Nested per R2 for the C2
+  // generateAnswer path; pure-function cases (C1, C3-C5) need no key.
+  describe("citation dedup + renumber", () => {
+    const AnthropicStub = require("@anthropic-ai/sdk");
+
+    afterEach(() => {
+      AnthropicStub.__reset();
+    });
+
+    test("C1: buildCitations returns ONE citation per unique source", () => {
+      const chunks: Chunk[] = [
+        { id: "a", text: "onboarding part 1", source: "mb-flow-onboarding", heading: "Onboarding" },
+        { id: "b", text: "onboarding part 2", source: "mb-flow-onboarding" },
+        { id: "c", text: "widget cfg", source: "mb-feature-widget" },
+      ];
+      const cites = buildCitations(chunks);
+      expect(cites).toEqual([
+        { number: 1, source: "mb-flow-onboarding", heading: "Onboarding" },
+        { number: 2, source: "mb-feature-widget" },
+      ]);
+    });
+
+    test("C2: one source over two cited positions -> ONE number, contiguous", async () => {
+      AnthropicStub.__reset();
+      // N3: enqueue-stub path (NOT MONDAY_TEST_MODE). Stub cites BOTH [1] and [2].
+      AnthropicStub.__setResponses([
+        "The onboarding flow is documented [1] and the widget config too [2].",
+      ]);
+      const chunks: Chunk[] = [
+        { id: "a", text: "onboarding part 1", source: "mb-flow-onboarding", heading: "Onboarding" },
+        { id: "b", text: "onboarding part 2", source: "mb-flow-onboarding" },
+        { id: "c", text: "widget cfg", source: "mb-feature-widget" },
+      ];
+      const result = await generateAnswer("How does onboarding work?", chunks);
+      const onboardingCount = result.citations.filter(
+        (c) => c.source === "mb-flow-onboarding",
+      ).length;
+      expect(onboardingCount).toBe(1);
+      const numbers = result.citations.map((c) => c.number).sort((x, y) => x - y);
+      expect(numbers).toEqual([1, 2]);
+      // Answer text markers match the citation numbers.
+      for (const c of result.citations) {
+        expect(result.answer).toContain(`[${c.number}]`);
+      }
+    });
+
+    test("C3: compactRenumber rewrites non-contiguous -> contiguous, text + list", () => {
+      const result = compactRenumber("See [2] and then [4].", [
+        { number: 2, source: "mb-feature-widget" },
+        { number: 4, source: "mb-flow-onboarding" },
+      ]);
+      expect(result.answer).toBe("See [1] and then [2].");
+      expect(result.citations).toEqual([
+        { number: 1, source: "mb-feature-widget" },
+        { number: 2, source: "mb-flow-onboarding" },
+      ]);
+    });
+
+    test("C4: compactRenumber is multi-digit safe ([1] and [10] -> [1] and [2])", () => {
+      const citations: Citation[] = [];
+      for (let i = 1; i <= 10; i++) citations.push({ number: i, source: `s${i}` });
+      const result = compactRenumber("First [1] then last [10].", citations);
+      expect(result.answer).toBe("First [1] then last [2].");
+      expect(result.citations).toEqual([
+        { number: 1, source: "s1" },
+        { number: 2, source: "s10" },
+      ]);
+    });
+
+    test("C5: compactRenumber no-op on an abstain (empty citations)", () => {
+      const result = compactRenumber("I couldn't find it.", []);
+      expect(result.answer).toBe("I couldn't find it.");
+      expect(result.citations).toEqual([]);
     });
   });
 });


### PR DESCRIPTION
## Summary
Two bundled RAG-answer fixes in `src/llm/generate.ts`, surfaced by UAT.

- **#1374 — false "I couldn't find it" over-refusal.** Strengthened the anti-refusal prompt clause AND added a code backstop: when relevant chunks were retrieved (`chunks>0`) but the answer opens with a refusal, regenerate once at temperature 0 with a **conditional** directive (answer if a passage addresses the topic; otherwise abstain plainly; never state facts not in the passages). Configurable openers (`MONDAY_REFUSAL_OPENERS`) + kill-switch (`MONDAY_REFUSAL_BACKSTOP=0`). Strict complement of the existing empty-chunks guard; regenerates at most once; a second refusal is accepted (no fabrication).
- **#1375 — citation gaps + duplicate-source numbering.** One citation number per unique source, and compact-renumber cited refs to contiguous `[1,2,3…]`, applied in a single pass to both the answer text and the citation list so they never diverge.

## Test plan
- `npm run build` exits 0; `npm test` → 54 suites / 494 tests pass.
- New tests (nested under `describe("generateAnswer")` so the model path is exercised): backstop regenerate-once / empty-chunks-still-abstains / two-refusals-no-fabrication / kill-switch / configurable-openers; citation dedup-by-source + contiguous renumber (multi-digit-safe).
- `src/slack/formatter.ts` unchanged (0-line diff). Synthetic test data only.

Claude-Session: https://claude.ai/code/session_01R5rpgymipJKn4AhCTmsYpD