### PR TITLE
fix(catalog): batch corpus for distillation to scale past model context

### DIFF
--- a/scripts/build-catalog.js
+++ b/scripts/build-catalog.js
@@ -19,6 +19,10 @@
  * Env: CONFLUENCE_URL (or CONFLUENCE_BASE_URL), CONFLUENCE_EMAIL,
  *      CONFLUENCE_API_TOKEN, CONFLUENCE_SPACES (comma-separated; the FIRST entry
  *      is cataloged). Optional ANTHROPIC_MODEL overrides the distiller model.
+ *      Optional CATALOG_BATCH_TOKEN_BUDGET overrides the per-batch token budget
+ *      (#1378 map-reduce split; default is DEFAULT_BATCH_TOKEN_BUDGET in
+ *      dist/catalog/distill). Optional CATALOG_CHARS_PER_TOKEN overrides the
+ *      chars-per-token size estimate. Both are ignored if unset or non-numeric.
  */
 "use strict";
 
@@ -45,6 +49,13 @@ function splitList(raw) {
     .split(",")
     .map((s) => s.trim())
     .filter(Boolean);
+}
+
+/** Parse an optional positive-number env knob; return undefined if unset/NaN/<=0. */
+function parsePositiveNumberEnv(raw) {
+  if (raw === undefined || raw === null || String(raw).trim() === "") return undefined;
+  const n = Number(raw);
+  return Number.isFinite(n) && n > 0 ? n : undefined;
 }
 
 /**
@@ -119,11 +130,17 @@ async function main() {
     fs.writeFileSync(target, `${JSON.stringify(catalog, null, 2)}\n`, "utf-8");
   };
 
+  // Optional map-reduce knobs (#1378) — ignored if unset/non-numeric.
+  const batchTokenBudget = parsePositiveNumberEnv(env.CATALOG_BATCH_TOKEN_BUDGET);
+  const charsPerToken = parsePositiveNumberEnv(env.CATALOG_CHARS_PER_TOKEN);
+
   const result = await run({
     fetchPages: (key) => fetcher.fetchPages(key),
     distiller: buildLlmDistiller(),
     writeCatalog,
     spaceKey,
+    batchTokenBudget,
+    charsPerToken,
   });
 
   // Counts/structure ONLY — never a label, body, id, space key, host, or email.

--- a/src/catalog/cli.ts
+++ b/src/catalog/cli.ts
@@ -28,6 +28,14 @@ export interface CatalogRunDeps {
   now?: () => number;
   /** Counts/structure-only logger sink; defaults to `console.log`. */
   log?: (msg: string) => void;
+  /**
+   * Optional per-batch token budget for the distill map-reduce (#1378). When
+   * set, threaded into `distillCatalog`; otherwise the module default applies.
+   * The shell derives this from `CATALOG_BATCH_TOKEN_BUDGET`.
+   */
+  batchTokenBudget?: number;
+  /** Optional chars-per-token estimate override (from `CATALOG_CHARS_PER_TOKEN`). */
+  charsPerToken?: number;
 }
 
 export interface CatalogRunResult {
@@ -75,8 +83,15 @@ export async function run(deps: CatalogRunDeps): Promise<CatalogRunResult> {
   const pages = await deps.fetchPages(deps.spaceKey);
   log(`Ingested ${pages.length} pages.`);
 
-  // 2. Distill (the single LLM call lives inside the injected distiller).
-  const catalog = await distillCatalog(pages, { distiller: deps.distiller, now: deps.now });
+  // 2. Distill (the per-batch LLM calls live inside the injected distiller).
+  //    The batch-count + truncation warnings reach the counts-only sink.
+  const catalog = await distillCatalog(pages, {
+    distiller: deps.distiller,
+    now: deps.now,
+    log,
+    batchTokenBudget: deps.batchTokenBudget,
+    charsPerToken: deps.charsPerToken,
+  });
 
   // 3. Write the gitignored catalog via the injected sink.
   await deps.writeCatalog(catalog);

--- a/src/catalog/distill.ts
+++ b/src/catalog/distill.ts
@@ -20,6 +20,81 @@ export interface DistillDeps {
   distiller: CatalogDistiller;
   /** Injectable clock for deterministic `generatedAt` in tests. */
   now?: () => number;
+  /**
+   * Per-batch token budget for the map-reduce split (#1378). Defaults to
+   * `DEFAULT_BATCH_TOKEN_BUDGET`. The production shell threads the
+   * `CATALOG_BATCH_TOKEN_BUDGET` env override through here; tests inject a TINY
+   * budget to force multi-batch splits without huge fixtures.
+   */
+  batchTokenBudget?: number;
+  /** Chars-per-token estimate divisor. Defaults to `DEFAULT_CHARS_PER_TOKEN`. */
+  charsPerToken?: number;
+  /**
+   * Counts/structure-only logger. Defaults to a no-op when undefined (never
+   * crash on a missing logger). NEVER receives a label / title / body / id.
+   */
+  log?: (msg: string) => void;
+}
+
+/**
+ * Default per-batch token budget (#1378). Safely under the model's 200k hard
+ * input limit, leaving margin for the instructions prompt + the `max_tokens`
+ * output reservation. CONFIGURABLE — overridable via `deps.batchTokenBudget`
+ * and, in the production shell, the `CATALOG_BATCH_TOKEN_BUDGET` env var
+ * (parsed + threaded in `scripts/build-catalog.js`; the pure module never reads
+ * `process.env`). This named const — NOT a bare literal — is the sole source of
+ * the default value (MEMORY: feedback_configurable_parameters_not_hardcoded).
+ */
+export const DEFAULT_BATCH_TOKEN_BUDGET = 150000;
+
+/** Default chars-per-token divisor for the deterministic size estimate. */
+export const DEFAULT_CHARS_PER_TOKEN = 4;
+
+/**
+ * Fixed per-page serialization overhead (chars) — the `### PAGE id=… title=…`
+ * wrapper + separators the production distiller adds around each page body.
+ * Folded into the size estimate so packing matches the real serialized cost.
+ */
+export const PER_PAGE_OVERHEAD_CHARS = 32;
+
+/**
+ * Deterministic, tokenizer-free size estimate for one page: the way the
+ * production distiller serializes it (`### PAGE id=… title=…\n<body>`),
+ * approximated as chars/charsPerToken. Fully deterministic (re-run stability is
+ * an AC).
+ */
+function estTokens(page: CatalogPage, charsPerToken: number): number {
+  const chars = page.id.length + page.title.length + page.body.length + PER_PAGE_OVERHEAD_CHARS;
+  return Math.ceil(chars / charsPerToken);
+}
+
+/**
+ * Greedy bin-pack pages IN INPUT ORDER under `budget` (estimated tokens).
+ * Page order is never reordered (determinism). A page whose own estimate
+ * exceeds the budget has already been truncated upstream to fit, so it lands in
+ * its own batch here.
+ */
+function packBatches(
+  pages: CatalogPage[],
+  budget: number,
+  charsPerToken: number,
+): CatalogPage[][] {
+  const batches: CatalogPage[][] = [];
+  let current: CatalogPage[] = [];
+  let currentTokens = 0;
+  for (const page of pages) {
+    const est = estTokens(page, charsPerToken);
+    // Starting a new batch when adding this page would overflow a non-empty one.
+    if (current.length > 0 && currentTokens + est > budget) {
+      batches.push(current);
+      current = [];
+      currentTokens = 0;
+    }
+    current.push(page);
+    currentTokens += est;
+  }
+  if (current.length > 0) batches.push(current);
+  return batches;
 }
 
 /**
@@ -111,11 +186,58 @@ export async function distillCatalog(
   if (!deps || !deps.distiller || typeof deps.distiller.distill !== "function") {
     throw new TypeError("distillCatalog: deps.distiller with a distill() method is required");
   }
+  // Default a no-op logger so a missing sink never crashes the pure module.
+  const log = deps.log ?? (() => undefined);
+  const budget =
+    typeof deps.batchTokenBudget === "number" && deps.batchTokenBudget > 0
+      ? deps.batchTokenBudget
+      : DEFAULT_BATCH_TOKEN_BUDGET;
+  const charsPerToken =
+    typeof deps.charsPerToken === "number" && deps.charsPerToken > 0
+      ? deps.charsPerToken
+      : DEFAULT_CHARS_PER_TOKEN;
+
+  // corpusIds is built from the FULL ORIGINAL corpus so post-distill provenance
+  // validation in buildEntries() is unaffected by any truncation below.
   const corpusIds = new Set(pages.map((p) => p.id));
 
-  const raw = await deps.distiller.distill(pages);
-  const rawFeatures = Array.isArray(raw?.features) ? raw.features : [];
-  const rawFlows = Array.isArray(raw?.flows) ? raw.flows : [];
+  // A page whose own estimate exceeds the budget cannot fit in any batch.
+  // TRUNCATE its body on a COPY (never mutate input, never silently drop): keep
+  // the head up to a budget-DERIVED char cap so the page still participates
+  // (its id, head content, and provenance survive). Count only — no label /
+  // title / body / id is ever logged (privacy: the catalog carries internal
+  // product names).
+  let truncatedCount = 0;
+  const processed: CatalogPage[] = pages.map((page) => {
+    if (estTokens(page, charsPerToken) <= budget) return page;
+    truncatedCount += 1;
+    const maxBodyChars = Math.max(
+      0,
+      budget * charsPerToken - PER_PAGE_OVERHEAD_CHARS - page.id.length - page.title.length,
+    );
+    return { ...page, body: page.body.slice(0, maxBodyChars) };
+  });
+
+  const batches = packBatches(processed, budget, charsPerToken);
+  log(`Distilling corpus in ${batches.length} batch(es).`);
+  if (truncatedCount > 0) {
+    log(
+      `WARN: ${truncatedCount} page(s) exceeded the per-batch token budget and were ` +
+        `truncated (content preserved up to the budget; nothing dropped from the catalog).`,
+    );
+  }
+
+  // Map: one distiller call PER BATCH. Reduce: concatenate the per-batch raw
+  // arrays IN BATCH ORDER, then hand the concatenation to the existing
+  // buildEntries() (which dedups-by-id, unions provenance first-wins-label, and
+  // validates against the full corpus — unchanged).
+  const rawFeatures: RawCatalogEntry[] = [];
+  const rawFlows: RawCatalogEntry[] = [];
+  for (const batch of batches) {
+    const raw = await deps.distiller.distill(batch);
+    if (Array.isArray(raw?.features)) rawFeatures.push(...raw.features);
+    if (Array.isArray(raw?.flows)) rawFlows.push(...raw.flows);
+  }
 
   const features = buildEntries(rawFeatures, "feature", corpusIds);
   const flows = buildEntries(rawFlows, "flow", corpusIds);

--- a/tests/catalog.test.ts
+++ b/tests/catalog.test.ts
@@ -2,7 +2,7 @@ import { execFileSync } from "node:child_process";
 import { readFileSync, readdirSync } from "node:fs";
 import { join } from "node:path";
 
-import { distillCatalog } from "../src/catalog/distill";
+import { distillCatalog, PER_PAGE_OVERHEAD_CHARS } from "../src/catalog/distill";
 import {
   run,
   chooseWritePath,
@@ -340,6 +340,180 @@ describe("AC-REUSE-FETCHER — reuses src/confluence/sync, no re-implemented pag
       const src = readFileSync(join(dir, file), "utf-8");
       expect(offenders.test(src)).toBe(false);
     }
+  });
+});
+
+describe("AC-BATCH-MULTI — a multi-batch corpus drives >1 distiller call; merge dedups + unions provenance", () => {
+  it("calls the fake per batch and unions same-slug provenance across batches", async () => {
+    // Tiny budget + charsPerToken=1 so each synthetic page lands in its OWN batch.
+    const SPLIT_PAGES: CatalogPage[] = [
+      { id: "p1", title: "T1", body: "alpha body one" },
+      { id: "p2", title: "T2", body: "beta body two" },
+      { id: "p3", title: "T3", body: "gamma body three" },
+    ];
+    let calls = 0;
+    // ARGUMENT-AWARE: provenance + the per-batch-unique label are derived from
+    // the pages each call actually receives (a vacuous arg-ignoring fake would
+    // make the merge assertion meaningless).
+    const distiller: CatalogDistiller = {
+      async distill(pages) {
+        calls += 1;
+        const ids = pages.map((p) => p.id);
+        return {
+          features: [
+            // Same slug in EVERY batch -> must merge to one entry, provenance unioned.
+            { label: "Shared Feature", provenancePageIds: ids },
+            // Distinct per batch -> proves the calls really saw different pages.
+            { label: `Unique ${ids.join("-")}`, provenancePageIds: ids },
+          ],
+          flows: [],
+        };
+      },
+    };
+
+    const catalog = await distillCatalog(SPLIT_PAGES, {
+      distiller,
+      now: FROZEN_NOW,
+      batchTokenBudget: 60,
+      charsPerToken: 1,
+    });
+
+    // >1 batch -> >1 fake-distiller call.
+    expect(calls).toBeGreaterThan(1);
+
+    const shared = catalog.features.find((f) => f.id === "feature-shared-feature");
+    expect(shared).toBeDefined();
+    // Provenance is the insertion-ordered UNION across all batches.
+    expect(shared!.provenancePageIds).toEqual(["p1", "p2", "p3"]);
+
+    // Per-batch-unique features survived distinctly (one per batch).
+    expect(catalog.features.filter((f) => f.id.startsWith("feature-unique"))).toHaveLength(3);
+
+    // Every provenance id stays within the corpus.
+    const corpusIds = new Set(SPLIT_PAGES.map((p) => p.id));
+    for (const entry of [...catalog.features, ...catalog.flows]) {
+      for (const pid of entry.provenancePageIds) {
+        expect(corpusIds.has(pid)).toBe(true);
+      }
+    }
+  });
+});
+
+describe("AC-BATCH-CONFLICT — same id across batches: first-wins label + unioned provenance", () => {
+  it("keeps the first-seen label and unions provenance on a real slug collision", async () => {
+    const CONFLICT_PAGES: CatalogPage[] = [
+      { id: "p1", title: "T1", body: "first batch body content" },
+      { id: "p2", title: "T2", body: "second batch body content" },
+    ];
+    // ARGUMENT-AWARE: returns a DIFFERENT label per batch keyed on the pages it
+    // receives. "Sign In" (p1's batch) and "sign-in" (p2's batch) both slug to
+    // "sign-in" -> a genuine same-id-across-batches conflict.
+    const distiller: CatalogDistiller = {
+      async distill(pages) {
+        const ids = pages.map((p) => p.id);
+        if (ids.includes("p1")) {
+          return { features: [{ label: "Sign In", provenancePageIds: ["p1"] }], flows: [] };
+        }
+        if (ids.includes("p2")) {
+          return { features: [{ label: "sign-in", provenancePageIds: ["p2"] }], flows: [] };
+        }
+        return { features: [], flows: [] };
+      },
+    };
+
+    const catalog = await distillCatalog(CONFLICT_PAGES, {
+      distiller,
+      now: FROZEN_NOW,
+      batchTokenBudget: 60,
+      charsPerToken: 1,
+    });
+
+    // Exactly one merged entry; FIRST-seen label (batch order = page order) wins.
+    expect(catalog.features).toHaveLength(1);
+    expect(catalog.features[0].id).toBe("feature-sign-in");
+    expect(catalog.features[0].label).toBe("Sign In");
+    expect(catalog.features[0].provenancePageIds).toEqual(["p1", "p2"]);
+  });
+});
+
+describe("AC-BATCH-OVERSIZED — a single over-budget page is TRUNCATED (not dropped) + warning logged", () => {
+  it("truncates the body on a copy, logs a counts-only warning, keeps the entry", async () => {
+    const budget = 100;
+    const charsPerToken = 1;
+    const TITLE = "ZBIGTITLE";
+    const BODY_MARKER = "ZBODYSECRET";
+    const oversizedBody = `${BODY_MARKER}${"x".repeat(500)}`;
+    const OVERSIZED_PAGES: CatalogPage[] = [{ id: "p1", title: TITLE, body: oversizedBody }];
+
+    const received: Array<{ id: string; title: string; body: string }> = [];
+    const distiller: CatalogDistiller = {
+      async distill(pages) {
+        received.push(...pages.map((p) => ({ id: p.id, title: p.title, body: p.body })));
+        return {
+          features: [{ label: "Oversized Feature", provenancePageIds: pages.map((p) => p.id) }],
+          flows: [],
+        };
+      },
+    };
+
+    const logs: string[] = [];
+    const catalog = await distillCatalog(OVERSIZED_PAGES, {
+      distiller,
+      now: FROZEN_NOW,
+      batchTokenBudget: budget,
+      charsPerToken,
+      log: (m) => logs.push(m),
+    });
+
+    // The page still PARTICIPATED (its id reached the distiller) — never dropped.
+    expect(received).toHaveLength(1);
+    expect(received[0].id).toBe("p1");
+
+    // The body was truncated to the budget-DERIVED cap (a copy — input untouched).
+    const cap = budget * charsPerToken - PER_PAGE_OVERHEAD_CHARS - "p1".length - TITLE.length;
+    expect(received[0].body.length).toBeLessThanOrEqual(cap);
+    expect(received[0].body.length).toBeLessThan(oversizedBody.length);
+    // Input page was NOT mutated.
+    expect(OVERSIZED_PAGES[0].body).toBe(oversizedBody);
+
+    // The catalog still contains the entry, with that page's id in provenance.
+    const entry = catalog.features.find((f) => f.provenancePageIds.includes("p1"));
+    expect(entry).toBeDefined();
+
+    // A LOUD truncation warning was logged.
+    const stdout = logs.join("\n");
+    expect(stdout).toMatch(/WARN/);
+    expect(stdout).toMatch(/truncated/);
+    // The warning carries NO label / title / body / id — counts/structure only.
+    expect(stdout).not.toContain(TITLE);
+    expect(stdout).not.toContain(BODY_MARKER);
+    expect(stdout).not.toContain("p1");
+    expect(stdout).not.toContain("Oversized Feature");
+  });
+});
+
+describe("AC-BATCH-SINGLE-UNCHANGED — a sub-budget corpus stays single-batch (one call)", () => {
+  it("makes exactly one distiller call and the same counts/ids as today", async () => {
+    let calls = 0;
+    const counting: CatalogDistiller = {
+      async distill() {
+        calls += 1;
+        return {
+          features: [
+            { label: "Sign In", provenancePageIds: ["p1"] },
+            { label: "Reporting Dashboard", provenancePageIds: ["p3"] },
+          ],
+          flows: [{ label: "Checkout Flow", provenancePageIds: ["p2"] }],
+        };
+      },
+    };
+    // DEFAULT budget (no override) -> the 3-page PAGES fixture stays one batch.
+    const catalog = await distillCatalog(PAGES, { distiller: counting, now: FROZEN_NOW });
+    expect(calls).toBe(1);
+    expect(catalog.features).toHaveLength(2);
+    expect(catalog.flows).toHaveLength(1);
+    expect(catalog.features.map((f) => f.id)).toContain("feature-sign-in");
+    expect(catalog.flows.map((f) => f.id)).toContain("flow-checkout-flow");
   });
 });
 


### PR DESCRIPTION
## Summary
The catalog distiller joined the entire Confluence corpus into one LLM message. The real corpus (201729 tokens) exceeded the model's 200k context and the build failed with a 400 \"prompt is too long\". This blocks rebuilding the feature/flow catalog needed for the Slack query UAT.

`distillCatalog` now greedily bin-packs pages under a configurable token budget (`DEFAULT_BATCH_TOKEN_BUDGET=150000`, env `CATALOG_BATCH_TOKEN_BUDGET`), distills each batch via the injected distiller, then concatenates the raw per-batch entries and reuses the existing `buildEntries` (dedup-by-id + union provenance + full-corpus validation — unchanged). A single page that alone exceeds the budget is truncated on a copy with a counts-only warning; the input is never mutated and nothing is silently dropped.

Map-reduce lives entirely in the pure `distillCatalog`, so the injected-fake test seam stays zero-network.

## Test plan
- `npm run build` (tsc) — exit 0
- `npm test` (jest) — all suites green; 4 new tests: AC-BATCH-MULTI (multi-batch → distiller called >1×), AC-BATCH-CONFLICT (\"Sign In\" vs \"sign-in\" slug collision dedups correctly across batches), AC-BATCH-OVERSIZED (single oversized page truncated + warned, not dropped), AC-BATCH-SINGLE-UNCHANGED (small corpus = one batch, behaviour identical)
- Reviewer empirically proved non-vacuity: reverting batching makes AC-BATCH-MULTI fail at `expect(calls).toBeGreaterThan(1)`

Reviewed by the 4-role ship chain (planner → plan-review → executor → execution-review), all independent background subagents; execution-review verdict PASS.

https://claude.ai/code/session_01R5rpgymipJKn4AhCTmsYpD