### PR TITLE
fix(jira): canonicalize feature/flow ids in buildDesiredLabels (#1381)

### DIFF
--- a/src/jira/namespacedLabels.ts
+++ b/src/jira/namespacedLabels.ts
@@ -99,6 +99,32 @@ export class LabelValidationError extends Error {
 }
 
 /**
+ * Idempotently, membership-AWARE, resolve a feature/flow value to its canonical
+ * catalog id. The value may arrive EITHER as a bare slug (`widget`) OR as an
+ * already kind-prefixed catalog id (`feature-widget`) — the matcher
+ * (`featureFlowMatcher.ts`) returns the latter, legacy callers/tests pass the
+ * former. Both MUST resolve to the SAME id, validated against the catalog set
+ * exactly once.
+ *
+ * Rule: slug the value to `s`. If `s` is ALREADY a member of the catalog set,
+ * that IS the canonical id (the value was a canonical id all along — e.g.
+ * `feature-feature-flags` whose label legitimately starts with the kind word).
+ * Otherwise treat it as bare and prefix it (`<kind>-<s>`). Return the chosen id
+ * only if it is in the set; otherwise `undefined` (caller fails loud). This does
+ * NOT weaken the guard: a value that is neither `s` nor `<kind>-<s>` in the set
+ * yields `undefined` and is still rejected.
+ */
+function resolveCatalogId(
+  value: string,
+  kind: "feature" | "flow",
+  ids: ReadonlySet<string>,
+): string | undefined {
+  const s = slug(value);
+  const id = ids.has(s) ? s : `${kind}-${s}`;
+  return ids.has(id) ? id : undefined;
+}
+
+/**
  * Canonicalise + VALIDATE an assignment, then construct the bot labels.
  *
  * Validation happens BEFORE any label is returned and BEFORE the writer is ever
@@ -114,8 +140,8 @@ export function buildDesiredLabels(
 ): ValidatedLabels {
   let featureLabel: string | undefined;
   if (assignment.feature !== undefined && assignment.feature !== "") {
-    const id = `feature-${slug(assignment.feature)}`;
-    if (!catalog.featureIds.has(id)) {
+    const id = resolveCatalogId(assignment.feature, "feature", catalog.featureIds);
+    if (id === undefined) {
       log("namespaced-label: REJECTED unknown feature (validation failed BEFORE write)");
       throw new LabelValidationError("feature", assignment.feature);
     }
@@ -124,8 +150,8 @@ export function buildDesiredLabels(
 
   const flowLabels: string[] = [];
   for (const flow of assignment.flows ?? []) {
-    const id = `flow-${slug(flow)}`;
-    if (!catalog.flowIds.has(id)) {
+    const id = resolveCatalogId(flow, "flow", catalog.flowIds);
+    if (id === undefined) {
       log("namespaced-label: REJECTED unknown flow (validation failed BEFORE write)");
       throw new LabelValidationError("flow", flow);
     }

--- a/tests/jira.namespacedLabels.test.ts
+++ b/tests/jira.namespacedLabels.test.ts
@@ -138,6 +138,95 @@ describe("AC-5 (model) — catalog validation refuses unknown, fail-loud", () =>
   });
 });
 
+describe("#1381 — buildDesiredLabels accepts CANONICAL ids (matcher output), no double-prefix", () => {
+  // The matcher (featureFlowMatcher) returns canonical catalog ids
+  // (`feature-<slug>` / `flow-<slug>`), NOT bare names. The old code re-prefixed
+  // them to `feature-feature-<slug>` and rejected EVERY real pick. These cases
+  // feed the canonical INPUT shape the matcher really sends.
+  it("a canonical feature-<slug> id validates → mb-feature-<slug> (no double prefix)", () => {
+    const catalog: LabelCatalog = {
+      featureIds: new Set(["feature-widget"]),
+      flowIds: new Set(),
+    };
+    const v = buildDesiredLabels(
+      { feature: "feature-widget", flows: [], symptom: "crash-error" },
+      catalog,
+    );
+    expect(v.feature).toBe("mb-feature-widget");
+    expect(v.feature).not.toContain("feature-feature");
+  });
+
+  it("a canonical flow-<slug> id validates → mb-flow-<slug> (no double prefix)", () => {
+    const catalog: LabelCatalog = {
+      featureIds: new Set(),
+      flowIds: new Set(["flow-onboarding"]),
+    };
+    const v = buildDesiredLabels(
+      { flows: ["flow-onboarding"], symptom: "crash-error" },
+      catalog,
+    );
+    expect(v.flows).toEqual(["mb-flow-onboarding"]);
+    expect(v.flows.join("")).not.toContain("flow-flow");
+  });
+
+  it("a bare name STILL validates → mb-feature-<slug> (legacy contract preserved)", () => {
+    const catalog: LabelCatalog = {
+      featureIds: new Set(["feature-x"]),
+      flowIds: new Set(),
+    };
+    const v = buildDesiredLabels(
+      { feature: "x", flows: [], symptom: "crash-error" },
+      catalog,
+    );
+    expect(v.feature).toBe("mb-feature-x");
+  });
+
+  it("a catalog id whose label starts with the kind word resolves for BOTH bare + canonical input", () => {
+    // Catalog entry id is `feature-feature-flags` (its label legitimately begins
+    // with the kind word). Bare `feature-flags` → prefix once. Canonical
+    // `feature-feature-flags` → already a member, used as-is. Both balance.
+    const catalog: LabelCatalog = {
+      featureIds: new Set(["feature-feature-flags"]),
+      flowIds: new Set(),
+    };
+    const fromBare = buildDesiredLabels(
+      { feature: "feature-flags", flows: [], symptom: "crash-error" },
+      catalog,
+    );
+    const fromCanonical = buildDesiredLabels(
+      { feature: "feature-feature-flags", flows: [], symptom: "crash-error" },
+      catalog,
+    );
+    expect(fromBare.feature).toBe("mb-feature-feature-flags");
+    expect(fromCanonical.feature).toBe("mb-feature-feature-flags");
+  });
+
+  it("AC6 — an UNKNOWN id is STILL rejected on BOTH axes (guard not weakened)", () => {
+    const catalog: LabelCatalog = {
+      featureIds: new Set(["feature-widget"]),
+      flowIds: new Set(["flow-onboarding"]),
+    };
+    // Unknown on the feature axis — neither `nope` nor `feature-nope` is a member.
+    expect(() =>
+      buildDesiredLabels(
+        { feature: "feature-nope", flows: [], symptom: "crash-error" },
+        catalog,
+        undefined,
+        () => {},
+      ),
+    ).toThrow(LabelValidationError);
+    // Unknown on the flow axis — neither `nope` nor `flow-nope` is a member.
+    expect(() =>
+      buildDesiredLabels(
+        { flows: ["flow-nope"], symptom: "crash-error" },
+        catalog,
+        undefined,
+        () => {},
+      ),
+    ).toThrow(LabelValidationError);
+  });
+});
+
 describe("AC-6 — label-set PUT body shape (clean issue)", () => {
   it("issues exactly ONE PUT with the expected headers + label-add set", async () => {
     const fetchImpl = okFetchSpy();

--- a/tests/triage.backfill.test.ts
+++ b/tests/triage.backfill.test.ts
@@ -143,6 +143,33 @@ describe("AC-5 (backfill) — unknown value → rejected + ZERO fetch", () => {
   });
 });
 
+describe("#1381 — classifier returns CANONICAL ids (matcher shape) → validated, not rejected", () => {
+  it("a classifier returning feature-<slug> / flow-<slug> ids validates with ZERO rejects", async () => {
+    const fetchImpl = okFetchSpy();
+    const writer = buildJiraNamespacedLabelWriter(CONFIG, fetchImpl as unknown as typeof fetch);
+    // The real matcher returns canonical catalog ids, not bare names. Before the
+    // #1381 fix this re-prefixed to feature-feature-* and rejected EVERY issue.
+    const canonicalClassifier: IssueFeatureFlowClassifier = {
+      async classify() {
+        return { feature: "feature-checkout", flows: ["flow-signin"] };
+      },
+    };
+    const result = await run({
+      fetchOpenDefects: async () => [
+        { key: "X-1", summary: "the app crashed on launch", descriptionText: "", commentTexts: [] },
+        { key: "X-2", summary: "the app crashed on launch", descriptionText: "", commentTexts: [] },
+      ],
+      classifier: canonicalClassifier,
+      catalog: MEMBERSHIP,
+      writer,
+      apply: true,
+      log: () => undefined,
+    });
+    expect(result.validated).toBeGreaterThan(0);
+    expect(result.rejected).toBe(0);
+  });
+});
+
 describe("AC-7 (#1343) — feature/flow pass is ADDITIVE: mb-symptom-* untouched", () => {
   it("adds mb-feature-* and leaves the pre-existing mb-symptom-* label in place", async () => {
     // Capture the PUT body so we can prove the symptom label is never removed.


### PR DESCRIPTION
## Summary

`buildDesiredLabels` re-derived the catalog id from the incoming feature/flow value as `<kind>-${slug(value)}`. But the feature/flow matcher returns **already kind-prefixed canonical catalog ids** (copied verbatim from the in-prompt menu, e.g. `feature-widget`). Re-prefixing produced a double-prefix (`feature-feature-widget`), which is never a catalog member, so `LabelValidationError` was thrown before any write — rejecting **100% of exact classifier picks**. The bug was latent on both the feature and flow axes; the feature check threw first, masking the flow side. Unit tests never caught it because they only fed bare names (`"x"` with a catalog holding `feature-x`), so the two halves of the seam were never integration-tested against the matcher's real output.

The fix adds `resolveCatalogId()` — a membership-aware, idempotent canonicalization applied on **both** axes: slug the incoming value; if the slugged value is already a catalog member, that IS the canonical id; otherwise prefix it (`<kind>-<slug>`) and check membership; reject (same axis-only fail-loud log + `LabelValidationError`) only if neither form is a member. The membership guard is **not** weakened — an unknown id still rejects on both axes. The `feature-feature-flags` edge (a catalog id whose label legitimately starts with the kind word) resolves correctly via the member-check-first precedence.

## Test plan

- `npm run build` exit 0; `npm test` exit 0 — 54 suites / 504 tests green.
- New regression tests (would have FAILED pre-fix):
  - canonical-id input on both axes → exact `mb-feature-...` / `mb-flow-...` output
  - bare-name legacy input still validates (regression guard)
  - `feature-feature-flags` edge for both bare-label and canonical-id input shapes
  - unknown id still rejected on **both** axes (proves the guard isn't weakened)
  - backfill end-to-end with a classifier returning canonical ids → `validated > 0`, `rejected === 0`

4-role chain all PASS (plan-review PASS r2 after AC tightening; execution-review PASS — guard-not-weakened confirmed, tests proven non-vacuous, privacy clean).