### PR TITLE
fix: clamp /ask abstain so on-topic how-to questions get answered (#1380)

### DIFF
--- a/src/llm/generate.ts
+++ b/src/llm/generate.ts
@@ -17,6 +17,7 @@ export const SYSTEM_PROMPT =
   "This process/spec clause applies ONLY when that passage is genuinely ON-TOPIC and relevant to the exact question asked; a process or spec passage that is about a DIFFERENT topic than the question is NOT grounding for that question — do not cite it, and abstain if nothing on-topic remains. " +
   "SINGLE-PRODUCT KNOWLEDGE BASE: every passage here is about ONE product, so the ABSENCE of the product's or a feature's NAME (a brand or proper-noun) from the passages is MEANINGLESS — a missing brand word does NOT mean the topic is uncovered, and you must NEVER open with \"I couldn't find\" merely because the exact product or feature name from the question is not present verbatim in the passages. Decide grounding ONLY on whether the passages genuinely DESCRIBE THE TOPIC OR FEATURE the question asks about: if any passage describes that topic's mechanism, flow, rules, locations, or plans — even partially, even as a roadmap or backend/spec note — you MUST lead with that documented answer and cite [N], not prepend a hedge, even though the passage never names the product. The ONLY exception is the no-yes-man clamp: a passage that merely mentions or is generally about the product but does NOT address the specific topic asked is NOT grounding — only in that case do you cleanly decline with no citations. This clause removes ONLY proper-noun ABSENCE as a disqualifier; the existing genuinely ON-TOPIC precondition above still governs — it does NOT relax the requirement that the passage be on-topic to the exact question asked. " +
   "TOPIC-COVERED vs TOPIC-ABSENT: decide whether to answer on the QUESTION'S TOPIC, never on whether a product or feature NAME string is present verbatim in the passages. GOOD (topic covered, name absent): the question names a product or feature whose NAME does NOT appear in the passages, but a passage describes that topic's mechanism, flow, rules, locations, or plans — you MUST lead with that documented answer and cite [N]; do NOT open with a refusal merely because the name is missing. BAD (topic covered, wrong opener): opening with \"I couldn't find ...\" just because the named thing is not written verbatim, while a passage describes the asked topic. ABSTAIN only when the TOPIC ITSELF is genuinely absent or off-topic — then decline cleanly with no citations. " +
+  "HOW-TO SYNTHESIS: when the question is phrased as how to / how do I / where do I do or find something, and a passage describes that topic's flow, mechanism, rules, or decision/matching logic — even when framed as a backend/internal/engineering spec rather than a polished tap-by-tap UI tutorial — you MUST translate that documented flow into plain user-facing steps and cite [N]. GOOD (how-to, spec-framed): leading with the synthesized steps drawn from the documented flow [N], noting only afterward that this is the documented process rather than a tap-by-tap walkthrough. BAD (how-to, spec-framed): declining with \"these describe backend/internal specs, not user-facing steps\" (or equivalent) while a passage DOES describe the asked flow. This clause removes ONLY \"framed as internal spec / not a step-by-step tutorial\" as a disqualifier; it does NOT relax the on-topic gate — abstain cleanly with no citations when the topic itself is genuinely absent or off-topic. " +
   "When you abstain, your reply MUST contain NO [N] citation markers at all — never cite a loosely-related passage while saying you couldn't find the answer. " +
   "PREFER DOCS OVER TICKET STUBS: when both narrative/document sources and bare issue-tracker ticket stubs cover the same topic, build your answer from and cite the document/narrative passages, not bare ticket titles. " +
   "PHASED / PLANNED ROLLOUTS: when the relevant doc describes a PLANNED or PHASED rollout or roadmap, answer with what is LIVE now and what is NAMED-planned and cite the doc [N]; do NOT dismiss a roadmap as \"no comprehensive list.\" " +
@@ -55,6 +56,50 @@ const DEFAULT_REFUSAL_OPENERS = [
  */
 const REGEN_DIRECTIVE =
   "Re-examine the passages above. IF any passage describes the TOPIC of the question — its mechanism, flow, rules, locations, or plans — even though the product/feature NAME may be absent, then lead with that documented answer and cite it [N], and note any gap only afterward. IF the passages genuinely do NOT address the asked topic, abstain plainly with no citations. Never state facts that are not in the passages.";
+
+/**
+ * #1380 — how-to over-refusal backstop (SECOND refusal class).
+ *
+ * The #1374 backstop catches the START-ANCHORED not-found opener. This class is
+ * the BODY-POSITION how-to hedge: the model leads with content, then declines in
+ * the body ("…these are backend/internal specs, not user-facing steps"). That is
+ * NOT start-anchored, so `opensWithRefusal` misses it.
+ *
+ * Default phrase set the model tends to hedge with (generic + name-free).
+ * Configurable via `MONDAY_HOWTO_HEDGE_PHRASES` (comma-separated; trimmed;
+ * empties dropped; a non-empty parse REPLACES the defaults — identical semantics
+ * to `refusalOpeners()`). Per the no-magic-string rule: data, not inline literals.
+ */
+const DEFAULT_HOWTO_HEDGE_PHRASES = [
+  "not user-facing steps",
+  "not user-facing instructions",
+  "backend/internal specs",
+  "internal spec",
+  "no step-by-step",
+  "not a step-by-step",
+  "don't include step-by-step",
+  "no user-facing",
+];
+
+/**
+ * #1380 — coverage-floor default. DERIVED from the Step-0 retrieval probe on the
+ * real corpus (NOT a guess): the on-topic symptom passage scored cosine 0.5679
+ * in final topK, while a genuinely off-topic control query's best chunk scored
+ * 0.1989. 0.35 sits comfortably between them (margin 0.15 above the off-topic
+ * control, 0.22 below the on-topic passage) — it separates "retrieved genuinely
+ * on-topic material" from "retrieved nothing relevant," it does NOT re-rank.
+ * Override via `MONDAY_HOWTO_COVERAGE_MIN_SCORE`.
+ */
+const DEFAULT_HOWTO_COVERAGE_MIN_SCORE = 0.35;
+
+/**
+ * Firmer, CONDITIONAL retry directive for the how-to hedge class. Like
+ * `REGEN_DIRECTIVE` it must NOT order the model to "answer anyway": if the
+ * passages genuinely do not address the topic it abstains plainly. It only
+ * corrects the "framed as an internal spec, so I can't give steps" brush-off.
+ */
+const HOWTO_REGEN_DIRECTIVE =
+  "Re-examine the passages. IF any passage describes how the asked thing works — its flow, mechanism, rules, or decision/matching logic — even if it reads as an internal/engineering spec rather than a tap-by-tap tutorial, then SYNTHESIZE the user-facing steps from that documented flow and cite [N]; do not refuse merely because it is framed as an internal spec. IF the passages genuinely do NOT address the asked topic, abstain plainly with no citations. Never state steps that are not supported by the passages.";
 
 /**
  * Normalize a string for refusal-opener comparison: fold every apostrophe
@@ -99,6 +144,84 @@ export function opensWithRefusal(answer: string): boolean {
 /** Kill-switch: `MONDAY_REFUSAL_BACKSTOP="0"` disables the regenerate step. */
 function backstopEnabled(): boolean {
   return process.env.MONDAY_REFUSAL_BACKSTOP !== "0";
+}
+
+/**
+ * #1380 granular kill-switch: `MONDAY_HOWTO_BACKSTOP="0"` disables ONLY the
+ * how-to hedge class, leaving the #1374 opener class intact. Default ON.
+ */
+function howToBackstopEnabled(): boolean {
+  return process.env.MONDAY_HOWTO_BACKSTOP !== "0";
+}
+
+/**
+ * #1380 — resolve the active how-to-hedge phrase set. `MONDAY_HOWTO_HEDGE_PHRASES`
+ * (when set and non-empty after parsing) fully REPLACES the defaults; otherwise
+ * the defaults apply. Side-effect-free so it can be re-read per call.
+ */
+function howToHedgePhrases(): string[] {
+  const raw = process.env.MONDAY_HOWTO_HEDGE_PHRASES;
+  if (!raw) return DEFAULT_HOWTO_HEDGE_PHRASES;
+  const parsed = raw
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+  return parsed.length > 0 ? parsed : DEFAULT_HOWTO_HEDGE_PHRASES;
+}
+
+/**
+ * #1380 — resolve the coverage-floor score. Reads
+ * `MONDAY_HOWTO_COVERAGE_MIN_SCORE`; a finite-number override wins, anything
+ * non-finite (unset / NaN / empty) falls back to the measured baked default.
+ */
+function coverageMinScore(): number {
+  const raw = process.env.MONDAY_HOWTO_COVERAGE_MIN_SCORE;
+  if (raw === undefined) return DEFAULT_HOWTO_COVERAGE_MIN_SCORE;
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) ? parsed : DEFAULT_HOWTO_COVERAGE_MIN_SCORE;
+}
+
+/**
+ * #1380 — retrieval-coverage SIGNAL. True iff the retrieval surfaced genuinely
+ * on-topic material, used to GATE the how-to regenerate so a TRUE off-topic
+ * abstain can never be silently loosened.
+ *
+ * - true iff at least one chunk carries a numeric `score >= coverageMinScore()`.
+ * - `score` is the cosine similarity threaded by `service.ts → toLlmChunk`
+ *   (stays cosine even with rerank/docPrior — those reorder, never overwrite it).
+ * - Score-absent fallback (back-compat): if NO chunk carries a numeric `score`
+ *   at all (e.g. score-less unit chunks or a future caller), return `true` —
+ *   coverage is "unknown, not blocked," so the conditional directive remains the
+ *   guard. Production always carries scores, so the gate is real where it matters.
+ */
+export function hasOnTopicCoverage(chunks: Chunk[]): boolean {
+  if (!Array.isArray(chunks) || chunks.length === 0) return false;
+  const floor = coverageMinScore();
+  let sawScore = false;
+  for (const c of chunks) {
+    if (typeof c?.score === "number" && Number.isFinite(c.score)) {
+      sawScore = true;
+      if (c.score >= floor) return true;
+    }
+  }
+  // No numeric score anywhere -> "unknown, not blocked".
+  return sawScore ? false : true;
+}
+
+/**
+ * #1380 — how-to NON-STEP refusal detector. True iff `text` (a) contains
+ * (case-insensitive, substring) any configured how-to-hedge phrase, AND (b)
+ * carries NO `[N]` citation marker. The "no `[N]`" condition is load-bearing: it
+ * distinguishes the BAD uncited brush-off ("…not user-facing steps", no citation)
+ * from the GOOD grounded answer the prompt ENCOURAGES ("the documented process
+ * [1] … rather than a tap-by-tap walkthrough", which IS cited) — so an
+ * already-grounded answer never trips an extra regenerate.
+ */
+export function isHowToHedge(text: string): boolean {
+  if (typeof text !== "string" || text.length === 0) return false;
+  if (/\[\d+\]/.test(text)) return false; // cited -> already grounded, not a hedge
+  const lower = text.toLowerCase();
+  return howToHedgePhrases().some((p) => lower.includes(p.toLowerCase()));
 }
 
 /**
@@ -347,18 +470,29 @@ export async function generateAnswer(
 
   let text = await callModel(client, userContent);
 
-  // #1374b backstop: chunks ARE present, but the model still OPENED with a
-  // configured refusal phrase — a likely proper-noun-absence over-refusal.
-  // Regenerate ONCE at temperature 0 with the firmer CONDITIONAL directive
-  // (gated on the kill-switch). We never fabricate: a still-refusing retry is
-  // accepted as-is, and its citations end empty without invented content.
+  // Two-class regenerate backstop. Class 1 (#1374b): chunks present, but the
+  // model OPENED with a configured refusal phrase — a likely proper-noun-absence
+  // over-refusal. Class 2 (#1380): chunks present AND retrieval has on-topic
+  // coverage (score gate) AND the model led with content but hedged in the body
+  // ("…internal specs, not user-facing steps") WITHOUT citing — the how-to
+  // non-step brush-off. `refusalClass` takes PRECEDENCE: an answer that BOTH
+  // opens with a refusal AND carries a how-to hedge routes through the #1374
+  // directive (the `howToClass` term is `!refusalClass && …`), keeping the #1374
+  // path byte-identical. The coverage gate is what makes loosening safe: a
+  // genuinely off-topic (low-score) retrieval has no coverage, so the how-to
+  // class never fires and the model's refusal stands. Regenerate ONCE at
+  // temperature 0 with the matching CONDITIONAL directive; never fabricate.
+  const refusalClass = opensWithRefusal(text);
+  const howToClass =
+    !refusalClass && hasOnTopicCoverage(chunks) && isHowToHedge(text);
   if (
     text.length > 0 &&
     chunks.length > 0 &&
     backstopEnabled() &&
-    opensWithRefusal(text)
+    (refusalClass || (howToClass && howToBackstopEnabled()))
   ) {
-    const harderContent = `${userContent}\n\n${REGEN_DIRECTIVE}`;
+    const directive = howToClass ? HOWTO_REGEN_DIRECTIVE : REGEN_DIRECTIVE;
+    const harderContent = `${userContent}\n\n${directive}`;
     const retry = await callModel(client, harderContent);
     if (retry.length > 0) text = retry;
   }

--- a/tests/fixtures/recall-eval/golden-private.example.json
+++ b/tests/fixtures/recall-eval/golden-private.example.json
@@ -48,6 +48,20 @@
       "groundTruthSource": null,
       "expect": "clean-non-doc-reply",
       "_note": "#1195 BORDERLINE abstain control: a plausible-sounding how-to question that retrieves a tangentially-related process/spec passage but is NOT actually answerable from the corpus. The bot must still cleanly decline (0 citations). This is the over-grounding case the process-doc grounding clause could regress, so it joins the clean-decline control gate."
+    },
+    {
+      "id": "Q8",
+      "question": "synthetic how-to placeholder question with a spec-framed answer doc",
+      "groundTruthSource": "confluence:example-flow-overview",
+      "expect": "grounded",
+      "_note": "#1380 HOW-TO POSITIVE: a how-to-phrased question whose pinned source is a flow/spec doc framed as an internal spec rather than a tap-by-tap tutorial. The bot must SYNTHESIZE user-facing steps from the documented flow and cite the doc (grounded, not abstain). This is the case the how-to backstop now answers."
+    },
+    {
+      "id": "Q9",
+      "question": "synthetic how-to placeholder question with nothing on-topic in the corpus",
+      "groundTruthSource": null,
+      "expect": "clean-non-doc-reply",
+      "_note": "#1380 HOW-TO NEGATIVE / true-abstain control: a how-to-phrased question that retrieves nothing on-topic (all chunks below the coverage floor). The coverage gate must keep the how-to backstop from firing, so the bot still cleanly declines (0 citations)."
     }
   ]
 }

--- a/tests/generate.prompt-integrity.test.ts
+++ b/tests/generate.prompt-integrity.test.ts
@@ -80,4 +80,14 @@ describe("SYSTEM_PROMPT integrity", () => {
     expect(SYSTEM_PROMPT).toMatch(/GOOD \(topic covered/);
     expect(SYSTEM_PROMPT).toMatch(/BAD \(topic covered/);
   });
+
+  // #1380 — how-to synthesis clause (SECONDARY reinforcement for the body-position
+  // how-to hedge class). Marker + GOOD cue + BAD cue must survive a reword.
+  it("adds the HOW-TO SYNTHESIS clause with GOOD/BAD cues (#1380)", () => {
+    expect(SYSTEM_PROMPT).toMatch(/HOW-TO SYNTHESIS/);
+    expect(SYSTEM_PROMPT).toMatch(/GOOD \(how-to, spec-framed\)/);
+    expect(SYSTEM_PROMPT).toMatch(/BAD \(how-to, spec-framed\)/);
+    // It must NOT relax the on-topic gate.
+    expect(SYSTEM_PROMPT).toMatch(/does NOT relax the on-topic gate/);
+  });
 });

--- a/tests/generate.test.ts
+++ b/tests/generate.test.ts
@@ -17,6 +17,8 @@ import {
   selectCitedCitations,
   stripStrayAbstainCitations,
   opensWithRefusal,
+  hasOnTopicCoverage,
+  isHowToHedge,
   compactRenumber,
   buildCitations,
   NO_CONTEXT_ANSWER,
@@ -243,6 +245,159 @@ describe("generateAnswer", () => {
         if (prev === undefined) delete process.env.MONDAY_REFUSAL_OPENERS;
         else process.env.MONDAY_REFUSAL_OPENERS = prev;
       }
+    });
+  });
+
+  // #1380 — how-to over-refusal backstop (SECOND refusal class, coverage-gated).
+  // Nested here so it inherits the ANTHROPIC_API_KEY beforeAll/afterAll (without
+  // a key generateAnswer falls to the offline path and never consults the stub).
+  describe("how-to over-refusal backstop", () => {
+    const AnthropicStub = require("@anthropic-ai/sdk");
+
+    afterEach(() => {
+      AnthropicStub.__reset();
+    });
+
+    // High-score on-topic chunks: best chunk >= the 0.35 measured floor, so
+    // hasOnTopicCoverage is TRUE (coverage present).
+    const onTopicChunks: Chunk[] = [
+      {
+        id: "c1",
+        text: "The matching flow selects the nearest available slot then confirms.",
+        source: "mb-flow-overview",
+        heading: "Flow Overview",
+        score: 0.57,
+      },
+      {
+        id: "c2",
+        text: "The selection rules describe how a candidate is chosen.",
+        source: "mb-flow-overview",
+        score: 0.41,
+      },
+    ];
+
+    // All scores BELOW the floor: hasOnTopicCoverage is FALSE (no coverage).
+    const offTopicChunks: Chunk[] = [
+      { id: "d1", text: "Unrelated note about billing exports.", source: "mb-misc", score: 0.2 },
+      { id: "d2", text: "Another off-topic stub.", source: "mb-misc-2", score: 0.18 },
+    ];
+
+    const HEDGE =
+      "Here is what the docs cover, but these describe internal specs, not user-facing steps.";
+
+    test("H1 (POSITIVE): coverage + uncited how-to hedge -> regenerate once, grounded steps", async () => {
+      AnthropicStub.__reset();
+      AnthropicStub.__setResponses([
+        HEDGE,
+        "Step 1: open the finder. Step 2: pick the nearest slot. Step 3: confirm [1].",
+      ]);
+      const result = await generateAnswer("How do I find an available slot?", onTopicChunks);
+      expect(result.answer).toContain("Step 1");
+      expect(result.answer).not.toContain("not user-facing steps");
+      expect(result.citations.length).toBeGreaterThanOrEqual(1);
+      expect(AnthropicStub.__getCallCount()).toBe(2);
+    });
+
+    test("H2 (NEGATIVE, coverage gate): low-score chunks + hedge -> still abstains, ZERO regenerate", async () => {
+      AnthropicStub.__reset();
+      AnthropicStub.__setResponses([HEDGE]);
+      const result = await generateAnswer("How do I find an available slot?", offTopicChunks);
+      // hasOnTopicCoverage is false -> howToClass never fires -> no 2nd call.
+      expect(AnthropicStub.__getCallCount()).toBe(1);
+      expect(result.citations).toEqual([]);
+      expect(result.answer).toContain("not user-facing steps");
+    });
+
+    test("H3 (NEGATIVE, second hedge -> no fabrication): both responses hedge", async () => {
+      AnthropicStub.__reset();
+      AnthropicStub.__setResponses([
+        HEDGE,
+        "Still just backend/internal specs here, no user-facing walkthrough.",
+      ]);
+      const result = await generateAnswer("How do I find an available slot?", onTopicChunks);
+      expect(AnthropicStub.__getCallCount()).toBe(2);
+      expect(result.answer).not.toMatch(/\[\d+\]/);
+      expect(result.citations).toEqual([]);
+    });
+
+    test("H4 (no false regenerate on a GROUNDED answer): cited hedge phrase is not a hedge", async () => {
+      AnthropicStub.__reset();
+      AnthropicStub.__setResponses([
+        "The documented process [1] is to pick the nearest slot, rather than a tap-by-tap walkthrough.",
+      ]);
+      const result = await generateAnswer("How do I find an available slot?", onTopicChunks);
+      expect(AnthropicStub.__getCallCount()).toBe(1);
+      expect(result.answer).toContain("[1]");
+      expect(result.citations.length).toBeGreaterThanOrEqual(1);
+    });
+
+    test("H5 (kill-switch): MONDAY_HOWTO_BACKSTOP=0 suppresses the how-to regenerate", async () => {
+      const prev = process.env.MONDAY_HOWTO_BACKSTOP;
+      process.env.MONDAY_HOWTO_BACKSTOP = "0";
+      try {
+        AnthropicStub.__reset();
+        AnthropicStub.__setResponses([HEDGE, "grounded steps [1]"]);
+        const result = await generateAnswer("How do I find an available slot?", onTopicChunks);
+        expect(AnthropicStub.__getCallCount()).toBe(1);
+        expect(result.answer).toContain("not user-facing steps");
+      } finally {
+        if (prev === undefined) delete process.env.MONDAY_HOWTO_BACKSTOP;
+        else process.env.MONDAY_HOWTO_BACKSTOP = prev;
+      }
+    });
+
+    test("H6 (detector units): hasOnTopicCoverage + isHowToHedge with overrides", () => {
+      // hasOnTopicCoverage — true when a score >= floor, false when all below.
+      expect(hasOnTopicCoverage(onTopicChunks)).toBe(true);
+      expect(hasOnTopicCoverage(offTopicChunks)).toBe(false);
+      // Back-compat: no numeric scores at all -> "unknown, not blocked" -> true.
+      expect(
+        hasOnTopicCoverage([{ id: "x", text: "t", source: "s" }]),
+      ).toBe(true);
+      // Honors the coverage-floor override.
+      const prevFloor = process.env.MONDAY_HOWTO_COVERAGE_MIN_SCORE;
+      try {
+        process.env.MONDAY_HOWTO_COVERAGE_MIN_SCORE = "0.9";
+        expect(hasOnTopicCoverage(onTopicChunks)).toBe(false); // 0.57 < 0.9
+        process.env.MONDAY_HOWTO_COVERAGE_MIN_SCORE = "0.1";
+        expect(hasOnTopicCoverage(offTopicChunks)).toBe(true); // 0.2 >= 0.1
+      } finally {
+        if (prevFloor === undefined) delete process.env.MONDAY_HOWTO_COVERAGE_MIN_SCORE;
+        else process.env.MONDAY_HOWTO_COVERAGE_MIN_SCORE = prevFloor;
+      }
+
+      // isHowToHedge — true on uncited hedge, false when same phrase is cited,
+      // false on a clean grounded answer.
+      expect(isHowToHedge("these are internal specs, not user-facing steps")).toBe(true);
+      expect(isHowToHedge("the documented flow [1] is not user-facing steps")).toBe(false);
+      expect(isHowToHedge("Step 1: open the finder. Step 2: confirm.")).toBe(false);
+      // Honors the hedge-phrase override (custom detected, a former default not).
+      const prevPhrases = process.env.MONDAY_HOWTO_HEDGE_PHRASES;
+      try {
+        process.env.MONDAY_HOWTO_HEDGE_PHRASES = "regrettably no walkthrough";
+        expect(isHowToHedge("Regrettably no walkthrough exists.")).toBe(true);
+        expect(isHowToHedge("these are not user-facing steps")).toBe(false);
+      } finally {
+        if (prevPhrases === undefined) delete process.env.MONDAY_HOWTO_HEDGE_PHRASES;
+        else process.env.MONDAY_HOWTO_HEDGE_PHRASES = prevPhrases;
+      }
+    });
+
+    test("H7 (CLASS PRECEDENCE): opener AND hedge co-occur -> #1374 directive wins", async () => {
+      AnthropicStub.__reset();
+      AnthropicStub.__setResponses([
+        "I couldn't find a step-by-step guide; the docs are backend/internal specs, not user-facing steps.",
+        "The documented flow [1] is to pick the nearest slot.",
+      ]);
+      const result = await generateAnswer("How do I find an available slot?", onTopicChunks);
+      expect(AnthropicStub.__getCallCount()).toBe(2);
+      // The 2nd (regenerate) call must carry the #1374 REGEN_DIRECTIVE, NOT the
+      // how-to directive — refusalClass takes precedence.
+      const req = AnthropicStub.__getLastRequest();
+      const sent: string = req.messages[0].content;
+      expect(sent).toContain("even though the product/feature NAME may be absent");
+      expect(sent).not.toContain("SYNTHESIZE the user-facing steps");
+      expect(result.answer).toContain("[1]");
     });
   });
 


### PR DESCRIPTION
## Summary

`/ask` over-refused on how-to phrasing even when retrieval surfaced on-topic coverage. When the best retrieved chunk scores at/above a configurable floor (`MONDAY_HOWTO_COVERAGE_MIN_SCORE`, default 0.35 — measured separation: on-topic ~0.57 vs off-topic ~0.20) and the model emits an uncited body-position how-to hedge, the answer generator now regenerates exactly once with a directive to answer the documented topic.

Key safety properties:
- **True-abstain preserved.** Genuinely low-score retrieval still refuses with zero regenerate — the loosening cannot silently disable abstain.
- **Cited answers skipped** (citation-marker check).
- **Refusal precedence.** A co-occurring #1374-style refusal opener routes through the prior fix (two-class trigger with `refusalClass` precedence). The #1374 path is byte-identical.
- **Kill-switch** `MONDAY_HOWTO_BACKSTOP` disables only the new class.
- **F1 retrieval-probe gate PASSED** on the real corpus: the on-topic passage reaches final topK, so this is a genuine abstain-clamp defect, not a recall miss.

## Test plan

- Full suite: 512 passed / 54 suites (added H1–H7 coverage cases, P1 prompt-integrity, G1 fixture-shape; #1374 B1–B5 still green).
- Build + typecheck clean.
- Coverage floor is configurable (finite-number guard); placeholder value absent from shipped code.
- Fixtures synthetic + name-free.
- Privacy denylist scan clean.
- 4-role chain all PASS; execution-review independently re-verified build/tests/typecheck/privacy and #1374 byte-identity.

---
https://claude.ai/code/session_01R5rpgymipJKn4AhCTmsYpD