### PR TITLE
feat: dual parent+child labels, partial-validation, opt-in catalog growth (#1387)

### DIFF
--- a/scripts/backfill-namespaced-labels.js
+++ b/scripts/backfill-namespaced-labels.js
@@ -69,7 +69,10 @@ const {
 } = require(path.join(DIST, "jira", "namespacedLabels"));
 const {
   buildJiraNamespacedLabelWriter,
+  GROWTH_PREFIXES,
 } = require(path.join(DIST, "jira", "namespacedLabelWriter"));
+const { resolveSnapThreshold } = require(path.join(DIST, "catalog", "catalogGrowth"));
+const { proposeChild } = require(path.join(DIST, "triage", "growthProposer"));
 
 /** Gitignored catalog path (mirrors src/catalog/cli.ts CATALOG_OUTPUT_PATH). */
 const CATALOG_OUTPUT_PATH = path.resolve(
@@ -78,6 +81,24 @@ const CATALOG_OUTPUT_PATH = path.resolve(
   ".ai-workspace",
   "catalog",
   "feature-catalog.json",
+);
+
+/** Gitignored full→lean parent map (#1387) — wires the DUAL bucket labels. */
+const FULL_TO_LEAN_MAP_PATH = path.resolve(
+  __dirname,
+  "..",
+  ".ai-workspace",
+  "catalog",
+  "full-to-lean-map.json",
+);
+
+/** Gitignored human-approval holding queue (#1387) for proposed growth. */
+const PROPOSED_ADDITIONS_PATH = path.resolve(
+  __dirname,
+  "..",
+  ".ai-workspace",
+  "catalog",
+  "proposed-additions.json",
 );
 
 /** Strip a trailing /wiki (and trailing slash) so the site root feeds Jira REST. */
@@ -110,6 +131,46 @@ function loadCatalog() {
   } catch {
     return { reviewed: false, features: [], flows: [] };
   }
+}
+
+/**
+ * Read the gitignored full→lean parent map (#1387) or an empty map if absent.
+ * Returns the `parentOf` Map (full child id → lean bucket id) plus distinct lean
+ * id lists: `featureLeanIds` (the feature-axis bucket menu / membership set) and
+ * `distinctLeanIds` (all buckets — for the JQL enumeration). The map is derived
+ * from catalog slugs (structure only), but it is gitignored and never printed.
+ */
+function loadParentMap() {
+  try {
+    const raw = JSON.parse(fs.readFileSync(FULL_TO_LEAN_MAP_PATH, "utf8"));
+    const features = raw.features && typeof raw.features === "object" ? raw.features : {};
+    const flows = raw.flows && typeof raw.flows === "object" ? raw.flows : {};
+    const parentOf = new Map([...Object.entries(features), ...Object.entries(flows)]);
+    const featureLeanIds = [...new Set(Object.values(features))];
+    const distinctLeanIds = [...new Set([...Object.values(features), ...Object.values(flows)])];
+    return { parentOf, featureLeanIds, distinctLeanIds };
+  } catch {
+    return { parentOf: new Map(), featureLeanIds: [], distinctLeanIds: [] };
+  }
+}
+
+/** Read the gitignored proposed-additions holding queue (or a fresh empty one). */
+function loadProposedAdditions() {
+  try {
+    const raw = JSON.parse(fs.readFileSync(PROPOSED_ADDITIONS_PATH, "utf8"));
+    return {
+      children: Array.isArray(raw.children) ? raw.children : [],
+      proposedParents: Array.isArray(raw.proposedParents) ? raw.proposedParents : [],
+    };
+  } catch {
+    return { children: [], proposedParents: [] };
+  }
+}
+
+/** Read-modify-write the holding queue (append-only, deduped by slug). */
+function persistProposedAdditions(state) {
+  fs.mkdirSync(path.dirname(PROPOSED_ADDITIONS_PATH), { recursive: true });
+  fs.writeFileSync(PROPOSED_ADDITIONS_PATH, JSON.stringify(state, null, 2) + "\n");
 }
 
 /**
@@ -149,15 +210,24 @@ async function main() {
   // Escape hatch: force the SYMPTOM-ONLY null classifier (the documented free
   // mode) even under --real/--apply, so debugging the deterministic axis is free.
   const symptomOnly = process.argv.includes("--symptom-only");
+  // HYBRID growth (#1387): OFF by default. Paid (extra model call) → gated like
+  // --real/--apply (assertCatalogReviewed before the proposer is constructed).
+  const grow = process.argv.includes("--grow");
+  // Graduation cleanup (#1387): peel ONLY the provisional/marker namespaces.
+  const peelProvisional = process.argv.includes("--peel-provisional");
+  // Runtime override of the PROVISIONAL dedup threshold (flag > env > default).
+  const snapThresholdFlag = argValue("--snap-threshold");
   const keys = splitList(argValue("--keys"));
   const env = process.env;
 
   const catalog = loadCatalog();
+  const parentMap = loadParentMap();
 
   if (printJql) {
     // Enumerated, sorted, quoted `labels in (...)` — NO wildcard. Safe to print:
     // the label STRINGS are derived from catalog ids (slugs), structure only.
-    console.log(buildBotLabelJql(catalog));
+    // #1387: also enumerate the PARENT bucket labels (one per distinct lean id).
+    console.log(buildBotLabelJql(catalog, undefined, parentMap.distinctLeanIds));
     return;
   }
 
@@ -185,11 +255,14 @@ async function main() {
 
   // UNSTAMP route (#1342): remove ALL the bot's labels. DRY-RUN by default; the
   // writer is constructed ONLY on --apply (mirrors the add path). Counts only.
-  if (unstamp) {
+  // #1387 --peel-provisional: peel ONLY the growth namespaces (graduation
+  // cleanup) — leaves canonical child/parent/symptom labels intact.
+  if (unstamp || peelProvisional) {
     const unstampDeps = {
       fetchOpenDefects: () => fetcher.fetchOpenDefects(projectKey),
       keys,
       apply,
+      ...(peelProvisional ? { peelPrefixes: GROWTH_PREFIXES } : {}),
     };
     if (apply) {
       unstampDeps.writer = buildJiraNamespacedLabelWriter(config, globalThis.fetch);
@@ -223,12 +296,75 @@ async function main() {
   const deps = {
     fetchOpenDefects: () => fetcher.fetchOpenDefects(projectKey),
     classifier,
-    catalog: membershipFromCatalog(catalog),
+    // #1387: wire the full→lean parent map so DUAL child+parent labels are built.
+    catalog: membershipFromCatalog(catalog, parentMap.parentOf),
     // Optional keyword extensions read from a gitignored local file (path via
     // MONDAY_KEYWORD_EXTENSIONS_FILE). Absent/malformed → {} → classify as today.
     extensions: loadKeywordExtensions(undefined, (msg) => console.error(msg)),
     apply,
   };
+
+  // HYBRID growth wiring (#1387) — OFF unless --grow. PAID (extra model call) →
+  // gated behind assertCatalogReviewed BEFORE the proposer is ever constructed,
+  // same discipline as the --real/--apply classifier. Dry-run --grow previews
+  // proposals + writes to the holding queue ONLY (no Jira write).
+  if (grow) {
+    assertCatalogReviewed(catalog, "backfill-namespaced-labels --grow");
+    const proposed = loadProposedAdditions();
+    // Dedup set: BARE canonical feature child slugs ∪ already-recorded
+    // provisional slugs (so re-runs SNAP instead of re-minting).
+    const existingChildSlugs = new Set([
+      ...catalog.features.map((e) => String(e.id).replace(/^feature-/, "")),
+      ...proposed.children.map((c) => c.slug),
+    ]);
+    const bucketIds = new Set(parentMap.featureLeanIds);
+    // Humanize a lean id into a menu label (structure only; never logged).
+    const bucketMenu = parentMap.featureLeanIds.map((id) => ({
+      id,
+      label: String(id).replace(/^feature-/, "").replace(/-/g, " "),
+    }));
+    const complete = buildProductionComplete();
+    deps.growth = {
+      grow: true,
+      existingChildSlugs,
+      bucketIds,
+      threshold: resolveSnapThreshold({
+        flag: snapThresholdFlag !== undefined ? Number(snapThresholdFlag) : undefined,
+      }),
+      propose: (issue) =>
+        proposeChild(complete, bucketMenu, {
+          summary: issue.summary,
+          descriptionText: issue.descriptionText,
+        }),
+      record: (decision) => {
+        const iso = new Date().toISOString();
+        if (decision.kind === "queue-parent") {
+          if (!proposed.proposedParents.some((p) => p.slug === decision.slug)) {
+            proposed.proposedParents.push({
+              slug: decision.slug,
+              firstSeen: iso,
+              reason: decision.reason,
+            });
+          }
+        } else {
+          // mint → provisional; queue-child → low-confidence.
+          const status = decision.kind === "mint" ? "provisional" : "low-confidence";
+          if (!proposed.children.some((c) => c.slug === decision.slug)) {
+            proposed.children.push({
+              slug: decision.slug,
+              parentLeanId: decision.parentLeanId,
+              firstSeen: iso,
+              status,
+            });
+          }
+          // Fold a minted slug into the live dedup set so this run is idempotent.
+          if (decision.kind === "mint") existingChildSlugs.add(decision.slug);
+        }
+        persistProposedAdditions(proposed);
+      },
+    };
+  }
+
   // The writer is constructed ONLY on --apply (dry-run never builds it). SAFETY
   // GATE (nit 3): a live write REFUSES to run against an unreviewed catalog.
   if (apply) {

--- a/src/catalog/catalogGrowth.ts
+++ b/src/catalog/catalogGrowth.ts
@@ -1,0 +1,196 @@
+/**
+ * Pure, I/O-free catalog-growth core (#1387).
+ *
+ * When the matcher abstains (can't confidently place a defect into the canonical
+ * catalog) AND the operator opted in (`--grow`), the proposer suggests a NEW
+ * child under an EXISTING bucket. This module is the SAFETY heart of growth:
+ *
+ *   1. PARENT-MEMBERSHIP gate (MED-4 — runs FIRST): the model's `parentLeanId`
+ *      is UNTRUSTED. Any non-member / null parent routes to a human-approval
+ *      queue and is NEVER written — code can NEVER auto-create a parent.
+ *   2. DEDUP / similarity guard: only a member parent reaches here. A candidate
+ *      that is basically the same as an existing child SNAPS to it (mints
+ *      nothing); a short slug only snaps on an EXACT match (the MIN-LENGTH
+ *      guard, MED-3); otherwise a high-confidence candidate MINTS a provisional.
+ *
+ * No fs / network / model here — unit-tested with synthetic data only.
+ */
+import { slug } from "./slug";
+
+/**
+ * The proposer's verdict for one abstaining issue. `parentLeanId` is the lean
+ * bucket id the model picked (or null); `candidateLabel` is the human-readable
+ * child label it proposes. UNTRUSTED until validated here.
+ */
+export interface GrowthProposal {
+  parentLeanId: string | null;
+  candidateLabel: string;
+  confidence: "high" | "low";
+}
+
+/**
+ * Source default snap threshold + short-slug fuzzy floor.
+ * PROVISIONAL — pending empirical calibration (MED-3). `0.85` is a starting
+ * guess, NOT a tuned value; override at runtime via `--snap-threshold` / the
+ * `MONDAY_GROWTH_SNAP_THRESHOLD` env. `GROWTH_MIN_FUZZY_LEN` stops the threshold
+ * over-snapping tiny slugs (e.g. `api` ↔ `ami`).
+ */
+export const GROWTH_SNAP_THRESHOLD = 0.85; // PROVISIONAL — pending empirical calibration.
+export const GROWTH_MIN_FUZZY_LEN = 6; // PROVISIONAL — pending empirical calibration.
+
+/** Levenshtein edit distance between two strings (iterative two-row DP). */
+function levenshtein(a: string, b: string): number {
+  const m = a.length;
+  const n = b.length;
+  if (m === 0) return n;
+  if (n === 0) return m;
+  let prev = Array.from({ length: n + 1 }, (_, j) => j);
+  let cur = new Array<number>(n + 1);
+  for (let i = 1; i <= m; i++) {
+    cur[0] = i;
+    for (let j = 1; j <= n; j++) {
+      const cost = a[i - 1] === b[j - 1] ? 0 : 1;
+      cur[j] = Math.min(prev[j] + 1, cur[j - 1] + 1, prev[j - 1] + cost);
+    }
+    [prev, cur] = [cur, prev];
+  }
+  return prev[n];
+}
+
+/**
+ * Normalized Levenshtein similarity in `[0,1]` over the two slugs (1 = identical,
+ * 0 = maximally different). The `similarity?` seam in `dedupCandidate` defaults
+ * to this — an embedding-cosine backend can swap in later without touching call
+ * sites.
+ */
+export function slugSimilarity(a: string, b: string): number {
+  const sa = slug(a);
+  const sb = slug(b);
+  if (sa === sb) return 1;
+  const maxLen = Math.max(sa.length, sb.length);
+  if (maxLen === 0) return 1;
+  return 1 - levenshtein(sa, sb) / maxLen;
+}
+
+/**
+ * PURE precedence resolver for the snap threshold (MED-3): `flag` > `env`
+ * (`MONDAY_GROWTH_SNAP_THRESHOLD`) > source default `GROWTH_SNAP_THRESHOLD`. A
+ * value is honored only if it is a finite number in `(0,1]`; an out-of-range /
+ * unparseable override is IGNORED and the next precedence level is used. Reads
+ * `process.env` only when `env` is not explicitly supplied (so unit tests stay
+ * env-free).
+ */
+export function resolveSnapThreshold(
+  opts: { flag?: number; env?: string } = {},
+): number {
+  const usable = (n: number | undefined): n is number =>
+    typeof n === "number" && Number.isFinite(n) && n > 0 && n <= 1;
+
+  if (usable(opts.flag)) return opts.flag;
+
+  const envRaw = "env" in opts ? opts.env : process.env.MONDAY_GROWTH_SNAP_THRESHOLD;
+  if (envRaw !== undefined && envRaw !== "") {
+    const envNum = Number(envRaw);
+    if (usable(envNum)) return envNum;
+  }
+  return GROWTH_SNAP_THRESHOLD;
+}
+
+export type DedupResult =
+  | { action: "snap"; childId: string }
+  | { action: "mint"; slug: string };
+
+export interface DedupOptions {
+  threshold?: number;
+  minFuzzyLen?: number;
+  similarity?: (a: string, b: string) => number;
+}
+
+/**
+ * Decide whether a candidate child SNAPS to an existing child or MINTS a new
+ * slug. EXACT slug match always snaps. Below `minFuzzyLen` (MED-3) only an exact
+ * match snaps — fuzzy is disabled so tiny slugs aren't over-snapped. Otherwise
+ * the most-similar existing child SNAPS when `sim >= threshold`; else MINT.
+ */
+export function dedupCandidate(
+  candidateLabel: string,
+  existingChildSlugs: Iterable<string>,
+  opts: DedupOptions = {},
+): DedupResult {
+  const s = slug(candidateLabel);
+  const threshold = opts.threshold ?? GROWTH_SNAP_THRESHOLD;
+  const minFuzzyLen = opts.minFuzzyLen ?? GROWTH_MIN_FUZZY_LEN;
+  const sim = opts.similarity ?? slugSimilarity;
+  const existing = [...existingChildSlugs];
+
+  // EXACT match always snaps (covers the short-slug exact case too).
+  for (const e of existing) {
+    if (slug(e) === s) return { action: "snap", childId: e };
+  }
+
+  // Short-slug MIN-LENGTH guard: below the floor, fuzzy is OFF → mint.
+  if (s.length < minFuzzyLen) return { action: "mint", slug: s };
+
+  let best: { childId: string; sim: number } = { childId: "", sim: 0 };
+  for (const e of existing) {
+    const score = sim(s, slug(e));
+    if (score > best.sim) best = { childId: e, sim: score };
+  }
+  if (best.sim >= threshold) return { action: "snap", childId: best.childId };
+  return { action: "mint", slug: s };
+}
+
+export type GrowthDecision =
+  | { kind: "snap"; childId: string }
+  | { kind: "mint"; slug: string; parentLeanId: string }
+  | { kind: "queue-child"; slug: string; parentLeanId: string }
+  | { kind: "queue-parent"; slug: string; reason: "hallucinated-parent" | "no-bucket-fit" };
+
+export interface DecideGrowthDeps {
+  existingChildSlugs: Iterable<string>;
+  bucketIds: ReadonlySet<string> | Iterable<string>;
+  threshold?: number;
+  minFuzzyLen?: number;
+  similarity?: (a: string, b: string) => number;
+}
+
+/**
+ * Top-level growth decision for ONE abstaining issue (#1387).
+ *
+ * Order is load-bearing (MED-4): VALIDATE `parentLeanId ∈ bucketIds` FIRST. A
+ * null parent → `queue-parent` (`no-bucket-fit`); a NON-member parent →
+ * `queue-parent` (`hallucinated-parent`) — both go to the human queue, NEVER
+ * written, even when the candidate child is dissimilar + high-confidence. Only a
+ * MEMBER parent proceeds to dedup: an existing child SNAPS; otherwise a
+ * high-confidence candidate MINTS, a low-confidence one → `queue-child`.
+ */
+export function decideGrowth(
+  proposal: GrowthProposal,
+  deps: DecideGrowthDeps,
+): GrowthDecision {
+  const s = slug(proposal.candidateLabel);
+
+  // 1. PARENT-MEMBERSHIP gate FIRST — code can never auto-create a parent.
+  if (proposal.parentLeanId === null) {
+    return { kind: "queue-parent", slug: s, reason: "no-bucket-fit" };
+  }
+  const bucketSet =
+    deps.bucketIds instanceof Set ? deps.bucketIds : new Set(deps.bucketIds);
+  if (!bucketSet.has(proposal.parentLeanId)) {
+    return { kind: "queue-parent", slug: s, reason: "hallucinated-parent" };
+  }
+
+  // 2. Member parent → dedup. An existing child snaps (safe regardless of conf).
+  const dedup = dedupCandidate(proposal.candidateLabel, deps.existingChildSlugs, {
+    threshold: deps.threshold,
+    minFuzzyLen: deps.minFuzzyLen,
+    similarity: deps.similarity,
+  });
+  if (dedup.action === "snap") return { kind: "snap", childId: dedup.childId };
+
+  // 3. Mint path — gate on confidence. Low confidence → queue, never mint.
+  if (proposal.confidence === "low") {
+    return { kind: "queue-child", slug: s, parentLeanId: proposal.parentLeanId };
+  }
+  return { kind: "mint", slug: s, parentLeanId: proposal.parentLeanId };
+}

--- a/src/jira/namespacedLabelWriter.ts
+++ b/src/jira/namespacedLabelWriter.ts
@@ -1,5 +1,14 @@
 import { JiraClientConfig, basicAuthHeader } from "./sync";
-import { NS_FEATURE, NS_FLOW, NS_SYMPTOM, ValidatedLabels } from "./namespacedLabels";
+import {
+  NS_FEATURE,
+  NS_FLOW,
+  NS_SYMPTOM,
+  NS_BUCKET_FEATURE,
+  NS_BUCKET_FLOW,
+  NS_PROV_FEATURE,
+  LABEL_AUTOCREATED,
+  ValidatedLabels,
+} from "./namespacedLabels";
 
 /**
  * OUTWARD-write seam for the bot's namespaced labels (#1322).
@@ -44,13 +53,33 @@ export interface JiraNamespacedLabelWriter {
    * the issue carried no bot labels (empty diff → NO PUT → idempotent re-run /
    * already-clean issue makes zero network calls).
    */
-  unstampLabels(issueKey: string, currentLabels: string[]): Promise<boolean>;
+  unstampLabels(
+    issueKey: string,
+    currentLabels: string[],
+    prefixes?: readonly string[],
+  ): Promise<boolean>;
 }
 
 type LabelOp = { add: string } | { remove: string };
 
-/** The bot's three private namespaces. */
-const NS_PREFIXES = [NS_FEATURE, NS_FLOW, NS_SYMPTOM];
+/**
+ * Every bot-owned namespace the unstamp/peel must cover: the three children, the
+ * two parent buckets (#1387), the provisional-child namespace + the flat
+ * `mb-autocreated` marker (peeled by exact prefix). Human/other labels never
+ * match.
+ */
+const NS_PREFIXES = [
+  NS_FEATURE,
+  NS_FLOW,
+  NS_SYMPTOM,
+  NS_BUCKET_FEATURE,
+  NS_BUCKET_FLOW,
+  NS_PROV_FEATURE,
+  LABEL_AUTOCREATED,
+];
+
+/** ONLY the growth namespaces (#1387) — used by `--peel-provisional`. */
+export const GROWTH_PREFIXES = [NS_PROV_FEATURE, LABEL_AUTOCREATED];
 
 /**
  * Compute the diff-driven REMOVE op list for an UNSTAMP: a `{ remove }` op for
@@ -61,11 +90,14 @@ const NS_PREFIXES = [NS_FEATURE, NS_FLOW, NS_SYMPTOM];
  * op list. Empty result when the issue carries no bot labels (the idempotency
  * short-circuit consumed by the writer → no PUT).
  */
-export function computeUnstampOps(currentLabels: string[]): LabelOp[] {
+export function computeUnstampOps(
+  currentLabels: string[],
+  prefixes: readonly string[] = NS_PREFIXES,
+): LabelOp[] {
   const current = currentLabels ?? [];
   const ops: LabelOp[] = [];
   for (const label of current) {
-    if (NS_PREFIXES.some((prefix) => label.startsWith(prefix))) {
+    if (prefixes.some((prefix) => label.startsWith(prefix))) {
       ops.push({ remove: label });
     }
   }
@@ -78,10 +110,12 @@ export function computeLabelOps(currentLabels: string[], target: ValidatedLabels
   const present = new Set(current);
   const ops: LabelOp[] = [];
 
-  // SINGLE-value namespaces: remove ALL stale, then add target if absent.
+  // SINGLE-value namespaces: remove ALL stale, then add target if absent. The
+  // feature-bucket (#1387) is single-value like the feature child.
   const single: Array<[string, string | undefined]> = [
     [NS_FEATURE, target.feature],
     [NS_SYMPTOM, target.symptom],
+    [NS_BUCKET_FEATURE, target.featureBucket],
   ];
   for (const [prefix, targetLabel] of single) {
     if (!targetLabel) continue;
@@ -93,9 +127,16 @@ export function computeLabelOps(currentLabels: string[], target: ValidatedLabels
     if (!present.has(targetLabel)) ops.push({ add: targetLabel });
   }
 
-  // MULTI-value namespace: add only desired flows not already present.
-  for (const flow of target.flows) {
-    if (!present.has(flow)) ops.push({ add: flow });
+  // MULTI-value namespaces (additive): desired flows, flow-buckets (#1387), and
+  // the TYPED provisional adds (#1387, MED-1: a minted provisional child + its
+  // bucket + the `mb-autocreated` marker — without this loop they would be
+  // computed in `desired` but NEVER written to Jira).
+  const additive = [...target.flows, ...(target.flowBuckets ?? []), ...(target.provisionalAdds ?? [])];
+  for (const label of additive) {
+    if (!present.has(label)) {
+      ops.push({ add: label });
+      present.add(label); // guard against an intra-list duplicate double-add.
+    }
   }
 
   return ops;
@@ -144,11 +185,11 @@ export function buildJiraNamespacedLabelWriter(
       return putLabelOps(issueKey, computeLabelOps(currentLabels, target));
     },
 
-    async unstampLabels(issueKey, currentLabels): Promise<boolean> {
+    async unstampLabels(issueKey, currentLabels, prefixes): Promise<boolean> {
       if (typeof issueKey !== "string" || issueKey.length === 0) {
         throw new TypeError("unstampLabels: issueKey must be a non-empty string");
       }
-      return putLabelOps(issueKey, computeUnstampOps(currentLabels));
+      return putLabelOps(issueKey, computeUnstampOps(currentLabels, prefixes));
     },
   };
 }

--- a/src/jira/namespacedLabels.ts
+++ b/src/jira/namespacedLabels.ts
@@ -24,6 +24,24 @@ export const NS_FLOW = "mb-flow-";
 export const NS_SYMPTOM = "mb-symptom-";
 
 /**
+ * PARENT (bucket) namespaces (#1387) — a coarse "family" label derived from a
+ * child id via the full→lean map. ONE umbrella prefix `mb-bucket-` (so unstamp
+ * peels every parent with one rule); the embedded axis word lets the writer
+ * apply single-vs-multi semantics mirroring the children.
+ */
+export const NS_BUCKET_FEATURE = "mb-bucket-feature-";
+export const NS_BUCKET_FLOW = "mb-bucket-flow-";
+
+/**
+ * GROWTH markers (#1387) — a PROVISIONAL (auto-created, unreviewed) child kept in
+ * its OWN namespace so it can never be mistaken for a canonical `mb-feature-*` id
+ * and is trivially peeled at graduation. `LABEL_AUTOCREATED` is a flat audit
+ * marker so ONE JQL term surfaces every auto-labeled defect for human review.
+ */
+export const NS_PROV_FEATURE = "mb-prov-feature-";
+export const LABEL_AUTOCREATED = "mb-autocreated";
+
+/**
  * Per-issue assignment the backfill produces: a symptom (always, from the
  * deterministic categorizer) plus an optional feature and zero-or-more flows
  * (from the injected classifier seam). The raw string values are slugged +
@@ -47,6 +65,13 @@ export interface LabelAssignment {
 export interface LabelCatalog {
   featureIds: ReadonlySet<string>;
   flowIds: ReadonlySet<string>;
+  /**
+   * Optional parent map (#1387): full catalog id (`feature-<slug>` / `flow-<slug>`)
+   * → its lean BUCKET id (also `feature-<slug>` / `flow-<slug>`). Wired from the
+   * gitignored `full-to-lean-map.json`. ABSENT → no parent labels are emitted
+   * (backward-compatible: a catalog without `parentOf` yields child+symptom only).
+   */
+  parentOf?: ReadonlyMap<string, string>;
 }
 
 /** Minimal catalog shape (the gitignored `FeatureCatalog`) for set derivation. */
@@ -55,12 +80,34 @@ export interface CatalogIdSource {
   flows: ReadonlyArray<{ id: string }>;
 }
 
-/** Derive the injected membership sets from a (synthetic or real) catalog. */
-export function membershipFromCatalog(catalog: CatalogIdSource): LabelCatalog {
+/**
+ * Derive the injected membership sets from a (synthetic or real) catalog. The
+ * optional `parentOf` map (#1387, full child id → lean bucket id) is threaded
+ * through unchanged so the shell can wire the gitignored full→lean map.
+ */
+export function membershipFromCatalog(
+  catalog: CatalogIdSource,
+  parentOf?: ReadonlyMap<string, string>,
+): LabelCatalog {
   return {
     featureIds: new Set(catalog.features.map((e) => e.id)),
     flowIds: new Set(catalog.flows.map((e) => e.id)),
+    ...(parentOf ? { parentOf } : {}),
   };
+}
+
+/**
+ * Pure helper (#1387): derive the PARENT bucket label for a child catalog id.
+ * The lean id already carries its axis word (`feature-…` / `flow-…`), so the
+ * parent label is simply `"mb-bucket-" + leanId`. A child with no map entry →
+ * `undefined` (caller omits the parent — never throws).
+ */
+export function parentBucketLabel(
+  childId: string,
+  parentOf?: ReadonlyMap<string, string>,
+): string | undefined {
+  const leanId = parentOf?.get(childId);
+  return leanId ? `mb-bucket-${leanId}` : undefined;
 }
 
 /**
@@ -75,6 +122,19 @@ export interface ValidatedLabels {
   flows: string[];
   /** Full `mb-symptom-<cat>` label. */
   symptom: string;
+  /** PARENT bucket label for the feature child (#1387), if mapped. */
+  featureBucket?: string;
+  /** De-duped PARENT bucket labels for the flow children (#1387). */
+  flowBuckets: string[];
+  /**
+   * TYPED additive growth labels (#1387, MED-1): a minted provisional child +
+   * its bucket + the `mb-autocreated` marker. The writer reads this field
+   * directly — a label present ONLY in `desired` would be computed but NEVER
+   * written. Default `[]`.
+   */
+  provisionalAdds: string[];
+  /** How many supplied feature/flow members were DROPPED as invalid (#1387). */
+  droppedCount: number;
   /** Every desired bot label (the writer's diff target). */
   desired: string[];
 }
@@ -127,10 +187,17 @@ function resolveCatalogId(
 /**
  * Canonicalise + VALIDATE an assignment, then construct the bot labels.
  *
- * Validation happens BEFORE any label is returned and BEFORE the writer is ever
- * called: an unknown feature/flow/symptom emits a fail-loud (axis-only) log line
- * and THROWS `LabelValidationError`. A valid assignment yields the full
- * `ValidatedLabels` (feature? + flows + symptom) plus the `desired` set.
+ * PARTIAL validation (#1387): on the feature/flow axes, a value that fails
+ * `resolveCatalogId` is DROPPED (axis-only log), not fatal — the valid members
+ * are kept. The loud `LabelValidationError` is thrown ONLY when something was
+ * supplied but NOTHING valid remains (`supplied > 0 && valid === 0`) — the
+ * all-invalid loud guard is NOT weakened. A symptom-only assignment (no feature,
+ * empty flows: `supplied === 0`) never trips the feature/flow guard. The symptom
+ * axis keeps its own independent throw.
+ *
+ * DUAL labels (#1387): each valid child also contributes a PARENT bucket label
+ * derived via `catalog.parentOf`; a child with no map entry logs axis-only and
+ * simply omits its parent. Child + parent + symptom all land in `desired`.
  */
 export function buildDesiredLabels(
   assignment: LabelAssignment,
@@ -138,24 +205,62 @@ export function buildDesiredLabels(
   symptoms: ReadonlySet<string> = new Set(DEFECT_CATEGORIES),
   log: (msg: string) => void = (m) => console.error(m),
 ): ValidatedLabels {
+  let supplied = 0;
+  let valid = 0;
+  let droppedCount = 0;
+
+  // FEATURE axis (single-value) — collect-then-decide (partial validation).
   let featureLabel: string | undefined;
+  let featureBucket: string | undefined;
   if (assignment.feature !== undefined && assignment.feature !== "") {
+    supplied++;
     const id = resolveCatalogId(assignment.feature, "feature", catalog.featureIds);
     if (id === undefined) {
-      log("namespaced-label: REJECTED unknown feature (validation failed BEFORE write)");
-      throw new LabelValidationError("feature", assignment.feature);
+      log("namespaced-label: dropped invalid feature (kept rest; axis only)");
+      droppedCount++;
+    } else {
+      valid++;
+      featureLabel = `mb-${id}`;
+      featureBucket = parentBucketLabel(id, catalog.parentOf);
+      if (featureBucket === undefined) {
+        log("namespaced-label: child has no parent-bucket mapping (axis only)");
+      }
     }
-    featureLabel = `mb-${id}`;
   }
 
+  // FLOW axis (multi-value) — drop only the invalid members, keep the rest.
   const flowLabels: string[] = [];
+  const flowBucketSet = new Set<string>();
   for (const flow of assignment.flows ?? []) {
+    supplied++;
     const id = resolveCatalogId(flow, "flow", catalog.flowIds);
     if (id === undefined) {
-      log("namespaced-label: REJECTED unknown flow (validation failed BEFORE write)");
-      throw new LabelValidationError("flow", flow);
+      log("namespaced-label: dropped invalid flow (kept rest; axis only)");
+      droppedCount++;
+      continue;
     }
+    valid++;
     flowLabels.push(`mb-${id}`);
+    const bucket = parentBucketLabel(id, catalog.parentOf);
+    if (bucket === undefined) {
+      log("namespaced-label: child has no parent-bucket mapping (axis only)");
+    } else {
+      flowBucketSet.add(bucket);
+    }
+  }
+
+  // ALL-INVALID loud guard (NOT weakened): something was supplied on the
+  // feature/flow axes but nothing valid remained → fail loud + throw. The loud
+  // line names ONLY the axis (PUBLIC repo); the error value stays a SUPPLIED
+  // value, never an internal-name-derived string.
+  if (supplied > 0 && valid === 0) {
+    const featureSupplied = assignment.feature !== undefined && assignment.feature !== "";
+    const axis: LabelKind = featureSupplied ? "feature" : "flow";
+    log(`namespaced-label: REJECTED unknown ${axis} (validation failed BEFORE write)`);
+    const value = featureSupplied
+      ? (assignment.feature as string)
+      : ((assignment.flows ?? [])[0] ?? "");
+    throw new LabelValidationError(axis, value);
   }
 
   const symptomSlug = slug(assignment.symptom ?? "");
@@ -165,12 +270,49 @@ export function buildDesiredLabels(
   }
   const symptomLabel = `${NS_SYMPTOM}${symptomSlug}`;
 
+  const flowBuckets = [...flowBucketSet];
   const desired = [
     ...(featureLabel ? [featureLabel] : []),
     ...flowLabels,
+    ...(featureBucket ? [featureBucket] : []),
+    ...flowBuckets,
     symptomLabel,
   ];
-  return { feature: featureLabel, flows: flowLabels, symptom: symptomLabel, desired };
+  return {
+    feature: featureLabel,
+    flows: flowLabels,
+    symptom: symptomLabel,
+    featureBucket,
+    flowBuckets,
+    provisionalAdds: [],
+    droppedCount,
+    desired,
+  };
+}
+
+/**
+ * Attach a MINTED provisional child to a validated label set (#1387, growth).
+ * Pushes `mb-prov-feature-<slug>`, the parent bucket `mb-bucket-<parentLeanId>`,
+ * and the `mb-autocreated` marker into BOTH `provisionalAdds` (so the writer
+ * actually emits them — MED-1) AND `desired` (for JQL / diff parity). Pure.
+ */
+export function withProvisionalChild(
+  base: ValidatedLabels,
+  candidateSlug: string,
+  parentLeanId: string,
+): ValidatedLabels {
+  const adds = [
+    `${NS_PROV_FEATURE}${candidateSlug}`,
+    `mb-bucket-${parentLeanId}`,
+    LABEL_AUTOCREATED,
+  ];
+  const provisionalAdds = [...base.provisionalAdds];
+  const desired = [...base.desired];
+  for (const a of adds) {
+    if (!provisionalAdds.includes(a)) provisionalAdds.push(a);
+    if (!desired.includes(a)) desired.push(a);
+  }
+  return { ...base, provisionalAdds, desired };
 }
 
 /**
@@ -196,11 +338,15 @@ export function labelsInClause(labels: readonly string[]): string {
 export function buildBotLabelJql(
   catalog: CatalogIdSource,
   symptoms: readonly string[] = DEFECT_CATEGORIES,
+  leanBuckets: readonly string[] = [],
 ): string {
   const labels = [
     ...catalog.features.map((e) => `mb-${e.id}`),
     ...catalog.flows.map((e) => `mb-${e.id}`),
     ...symptoms.map((s) => `${NS_SYMPTOM}${s}`),
+    // PARENT bucket labels (#1387): one `mb-bucket-<leanId>` per distinct lean
+    // id present in the full→lean map (the shell supplies the distinct list).
+    ...leanBuckets.map((lean) => `mb-bucket-${lean}`),
   ];
   return labelsInClause(labels);
 }

--- a/src/triage/backfill.ts
+++ b/src/triage/backfill.ts
@@ -10,7 +10,13 @@ import {
   LabelCatalog,
   LabelValidationError,
   buildDesiredLabels,
+  withProvisionalChild,
 } from "../jira/namespacedLabels";
+import {
+  decideGrowth,
+  type GrowthProposal,
+  type GrowthDecision,
+} from "../catalog/catalogGrowth";
 
 /**
  * Injectable backfill core (#1322) — mirrors `src/triage/cli.ts`.
@@ -44,6 +50,30 @@ export interface BackfillRunDeps {
    * gitignored local file). When absent, classification is identical to today.
    */
   extensions?: CategoryExtensions;
+  /**
+   * Optional HYBRID growth dep (#1387). Fires ONLY when an issue ABSTAINS on the
+   * feature axis (`feature === undefined`) AND `grow` is true. Absent / `grow`
+   * false → the non-grow path is byte-identical to today (no proposer call, no
+   * `proposed-additions` write). The proposer + file I/O live in the shell.
+   */
+  growth?: GrowthDeps;
+}
+
+/**
+ * Injected growth dep (#1387). `propose` is the paid model seam (a fake in
+ * tests); `existingChildSlugs` is the dedup set (canonical ∪ recorded
+ * provisional, MUTATED by `record` so re-runs snap); `bucketIds` is the distinct
+ * lean-id set the parent-membership gate validates against; `record` persists a
+ * decision to the holding queue. All COUNTS/AXIS-only — never log the candidate.
+ */
+export interface GrowthDeps {
+  propose: (issue: JiraIssue) => Promise<GrowthProposal>;
+  existingChildSlugs: Set<string>;
+  bucketIds: ReadonlySet<string>;
+  threshold?: number;
+  minFuzzyLen?: number;
+  record: (decision: GrowthDecision, proposal: GrowthProposal) => void;
+  grow: boolean;
 }
 
 export interface BackfillRunResult {
@@ -51,10 +81,20 @@ export interface BackfillRunResult {
   total: number;
   /** Issues whose assignment passed validation. */
   validated: number;
-  /** Issues rejected by validation (unknown feature/flow/symptom). */
+  /** Issues rejected by validation (all-invalid feature/flow, or bad symptom). */
   rejected: number;
   /** Issues that actually received a mutating PUT (0 in dry-run / on re-run). */
   applied: number;
+  /** Issues that validated but had ≥1 member DROPPED (partial validation, #1387). */
+  partial: number;
+  /** Total feature/flow members dropped as invalid across all issues (#1387). */
+  dropped: number;
+  /** Provisional children MINTED on the abstain+grow path (#1387). */
+  minted: number;
+  /** Abstain+grow proposals that SNAPPED to an existing child (#1387). */
+  snapped: number;
+  /** Abstain+grow proposals routed to the human-approval queue (#1387). */
+  proposed: number;
 }
 
 export async function run(deps: BackfillRunDeps): Promise<BackfillRunResult> {
@@ -65,6 +105,11 @@ export async function run(deps: BackfillRunDeps): Promise<BackfillRunResult> {
   let validated = 0;
   let rejected = 0;
   let applied = 0;
+  let partial = 0;
+  let dropped = 0;
+  let minted = 0;
+  let snapped = 0;
+  let proposed = 0;
 
   for (const issue of issues) {
     const { category } = categorizeDefect(
@@ -96,6 +141,47 @@ export async function run(deps: BackfillRunDeps): Promise<BackfillRunResult> {
       throw err;
     }
     validated++;
+    if (target.droppedCount > 0) {
+      partial++;
+      dropped += target.droppedCount;
+    }
+
+    // HYBRID growth (#1387): ONLY on a feature-axis abstain AND opt-in `grow`.
+    // Fires in dry-run too (previews + records to the holding queue; no Jira
+    // write unless `apply`). Default path (no growth dep / grow false) is inert.
+    if (deps.growth?.grow && ff.feature === undefined) {
+      const proposal = await deps.growth.propose(issue);
+      const decision = decideGrowth(proposal, {
+        existingChildSlugs: deps.growth.existingChildSlugs,
+        bucketIds: deps.growth.bucketIds,
+        threshold: deps.growth.threshold,
+        minFuzzyLen: deps.growth.minFuzzyLen,
+      });
+      switch (decision.kind) {
+        case "mint":
+          // MED-1: ride the typed `provisionalAdds` so the writer emits them.
+          target = withProvisionalChild(target, decision.slug, decision.parentLeanId);
+          minted++;
+          log("growth: minted 1 provisional child");
+          deps.growth.record(decision, proposal);
+          break;
+        case "snap":
+          // Reuse the existing child; mint NOTHING, write NOTHING new.
+          snapped++;
+          log("growth: snapped 1 candidate to an existing child");
+          break;
+        case "queue-parent":
+          proposed++;
+          log("growth: 1 hallucinated/no-fit parent proposal queued for human review");
+          deps.growth.record(decision, proposal);
+          break;
+        case "queue-child":
+          proposed++;
+          log("growth: 1 low-confidence child proposal queued for human review");
+          deps.growth.record(decision, proposal);
+          break;
+      }
+    }
 
     if (apply && deps.writer && issue.key) {
       const didPut = await deps.writer.applyLabels(issue.key, issue.labels ?? [], target);
@@ -105,10 +191,22 @@ export async function run(deps: BackfillRunDeps): Promise<BackfillRunResult> {
 
   log(
     `backfill: total=${issues.length} validated=${validated} rejected=${rejected} ` +
-      `applied=${applied} (${apply ? "APPLY" : "dry-run"})`,
+      `applied=${applied} partial=${partial} dropped=${dropped} ` +
+      `minted=${minted} snapped=${snapped} proposed=${proposed} ` +
+      `(${apply ? "APPLY" : "dry-run"})`,
   );
 
-  return { total: issues.length, validated, rejected, applied };
+  return {
+    total: issues.length,
+    validated,
+    rejected,
+    applied,
+    partial,
+    dropped,
+    minted,
+    snapped,
+    proposed,
+  };
 }
 
 /**
@@ -142,6 +240,12 @@ export interface UnstampRunDeps {
    * `UnmatchedUnstampKeysError` (S1 fail-loud). Empty / undefined → full sweep.
    */
   keys?: string[];
+  /**
+   * Optional restricted peel set (#1387, `--peel-provisional`): peel ONLY these
+   * namespace prefixes instead of every bot namespace. Absent → full bot-label
+   * peel (default `NS_PREFIXES`).
+   */
+  peelPrefixes?: readonly string[];
   /** Logger sink; defaults to `console.log`. */
   log?: (msg: string) => void;
 }
@@ -192,11 +296,15 @@ export async function runUnstamp(deps: UnstampRunDeps): Promise<UnstampRunResult
   let removable = 0;
   let removed = 0;
   for (const issue of scoped) {
-    const ops = computeUnstampOps(issue.labels ?? []);
-    if (ops.length === 0) continue; // no bot labels — nothing to peel.
+    const ops = computeUnstampOps(issue.labels ?? [], deps.peelPrefixes);
+    if (ops.length === 0) continue; // no matching bot labels — nothing to peel.
     removable++;
     if (apply && deps.writer && issue.key) {
-      const didPut = await deps.writer.unstampLabels(issue.key, issue.labels ?? []);
+      const didPut = await deps.writer.unstampLabels(
+        issue.key,
+        issue.labels ?? [],
+        deps.peelPrefixes,
+      );
       if (didPut) removed++;
     }
   }

--- a/src/triage/growthProposer.ts
+++ b/src/triage/growthProposer.ts
@@ -1,0 +1,90 @@
+/**
+ * Catalog-growth PROPOSER seam + adapter (#1387).
+ *
+ * Mirrors `featureFlowMatcher`: a thin INJECTED `complete(prompt) → text`
+ * boundary, `temperature: 0` upstream, strict-JSON-from-text parse, counts-only
+ * logging. Given an abstaining issue + the EXISTING bucket menu, the model
+ * (a) picks the best-fitting EXISTING parent bucket (or null) and (b) proposes a
+ * human-readable child label. The pick is UNTRUSTED — `decideGrowth`
+ * (`catalogGrowth.ts`) validates the parent against the real bucket set before
+ * anything is written.
+ *
+ * Privacy: the bucket menu carries internal names → IN-PROMPT ONLY, never
+ * logged. No fs / network here — tests inject a fake `complete`.
+ */
+import type { CompleteFn, MatcherIssue } from "./featureFlowMatcher";
+import type { GrowthProposal } from "../catalog/catalogGrowth";
+
+/** One bucket the model may pick from (lean id + human label). */
+export interface BucketMenuEntry {
+  id: string;
+  label: string;
+}
+
+/**
+ * Build the proposer prompt: list every EXISTING bucket id + label, then demand
+ * the model pick ONE existing id (or null) + propose a child label, as STRICT
+ * JSON. It must NEVER invent a bucket id.
+ */
+export function buildProposerPrompt(
+  bucketMenu: readonly BucketMenuEntry[],
+  issue: MatcherIssue,
+): string {
+  const menu = bucketMenu.map((e) => `  - ${e.id}: ${e.label}`).join("\n");
+  const description = (issue.descriptionText ?? "").trim();
+  return [
+    "A software defect did NOT fit any existing catalog feature. Propose a NEW",
+    "child feature for it under ONE of the EXISTING parent buckets below.",
+    "",
+    "PARENT BUCKETS (pick the single best-fitting id, or null if none fits):",
+    menu || "  (none)",
+    "",
+    "Rules:",
+    "- Use ONLY a bucket id from the menu above. NEVER invent a bucket id.",
+    "- If no bucket clearly fits, set \"parentLeanId\":null (a human will review).",
+    "- Propose a SHORT human-readable child label for the new feature.",
+    '- If you are not confident, set "confidence":"low" rather than guessing.',
+    '- Respond with STRICT JSON ONLY: {"parentLeanId":"<id|null>","candidateLabel":"<label>","confidence":"high|low"}',
+    "",
+    "DEFECT:",
+    `summary: ${issue.summary}`,
+    description ? `description: ${description}` : "description: (none)",
+  ].join("\n");
+}
+
+/** Parse the model's strict-JSON reply into a `GrowthProposal`. */
+export function parseProposerReply(text: string): GrowthProposal {
+  const start = text.indexOf("{");
+  const end = text.lastIndexOf("}");
+  if (start === -1 || end === -1 || end <= start) {
+    throw new Error("growth proposer: model reply contained no JSON object");
+  }
+  const parsed = JSON.parse(text.slice(start, end + 1)) as {
+    parentLeanId?: unknown;
+    candidateLabel?: unknown;
+    confidence?: unknown;
+  };
+  const parentLeanId =
+    typeof parsed.parentLeanId === "string" && parsed.parentLeanId !== ""
+      ? parsed.parentLeanId
+      : null;
+  const candidateLabel =
+    typeof parsed.candidateLabel === "string" ? parsed.candidateLabel : "";
+  const confidence = parsed.confidence === "high" ? "high" : "low";
+  return { parentLeanId, candidateLabel, confidence };
+}
+
+/**
+ * Propose a NEW child for one abstaining issue via the injected `complete` seam.
+ * The returned proposal is UNTRUSTED — `decideGrowth` gates it. ZERO network in
+ * tests (fake `complete`).
+ */
+export async function proposeChild(
+  complete: CompleteFn,
+  bucketMenu: readonly BucketMenuEntry[],
+  issue: MatcherIssue,
+): Promise<GrowthProposal> {
+  const prompt = buildProposerPrompt(bucketMenu, issue);
+  const text = await complete(prompt);
+  return parseProposerReply(text);
+}

--- a/tests/catalog.catalogGrowth.test.ts
+++ b/tests/catalog.catalogGrowth.test.ts
@@ -1,0 +1,117 @@
+import {
+  slugSimilarity,
+  resolveSnapThreshold,
+  dedupCandidate,
+  decideGrowth,
+  GROWTH_SNAP_THRESHOLD,
+  GROWTH_MIN_FUZZY_LEN,
+  type GrowthProposal,
+} from "../src/catalog/catalogGrowth";
+
+/**
+ * #1387 — catalog-growth safety core. Pure, ZERO network. SYNTHETIC fixtures.
+ */
+
+const BUCKETS = new Set(["feature-tools", "feature-account"]);
+
+function proposal(p: Partial<GrowthProposal>): GrowthProposal {
+  return { parentLeanId: "feature-tools", candidateLabel: "something", confidence: "high", ...p };
+}
+
+describe("#1387 — slugSimilarity + resolveSnapThreshold", () => {
+  it("identical slugs → 1; totally different → low", () => {
+    expect(slugSimilarity("dark-mode", "dark-mode")).toBe(1);
+    expect(slugSimilarity("dark-mode", "billing-export")).toBeLessThan(0.5);
+  });
+
+  it("#21 resolveSnapThreshold honors flag > env > source default", () => {
+    expect(resolveSnapThreshold({ flag: 0.95 })).toBe(0.95);
+    expect(resolveSnapThreshold({ env: "0.9" })).toBe(0.9);
+    expect(resolveSnapThreshold({ flag: 0.95, env: "0.5" })).toBe(0.95); // flag wins
+    expect(resolveSnapThreshold({ env: undefined })).toBe(GROWTH_SNAP_THRESHOLD);
+    // Out-of-range override is ignored → next precedence.
+    expect(resolveSnapThreshold({ flag: 2, env: "0.7" })).toBe(0.7);
+    expect(resolveSnapThreshold({ flag: 0, env: "" })).toBe(GROWTH_SNAP_THRESHOLD);
+  });
+});
+
+describe("#1387 #16 GOLDEN Snap — long candidate within threshold of an existing child", () => {
+  it("snaps to the existing child and mints nothing", () => {
+    // "darkmode" vs "dark-mode" → slugs "darkmode" vs "dark-mode": 1 edit / 9 = 0.889 ≥ 0.85.
+    const res = dedupCandidate("dark mode", ["dark-modes"]); // 1 edit / 10 = 0.9
+    expect(res.action).toBe("snap");
+    if (res.action === "snap") expect(res.childId).toBe("dark-modes");
+  });
+});
+
+describe("#1387 #17 GOLDEN Mint — dissimilar candidate, member bucket, high confidence", () => {
+  it("decideGrowth returns mint with the candidate slug + parent", () => {
+    const d = decideGrowth(
+      proposal({ candidateLabel: "Billing Export", parentLeanId: "feature-tools" }),
+      { existingChildSlugs: ["dark-mode", "search"], bucketIds: BUCKETS },
+    );
+    expect(d.kind).toBe("mint");
+    if (d.kind === "mint") {
+      expect(d.slug).toBe("billing-export");
+      expect(d.parentLeanId).toBe("feature-tools");
+    }
+  });
+});
+
+describe("#1387 #18 GOLDEN Queue parent — null parent", () => {
+  it("a null parentLeanId → queue-parent, never mints", () => {
+    const d = decideGrowth(
+      proposal({ parentLeanId: null, candidateLabel: "Billing Export" }),
+      { existingChildSlugs: [], bucketIds: BUCKETS },
+    );
+    expect(d.kind).toBe("queue-parent");
+    if (d.kind === "queue-parent") expect(d.reason).toBe("no-bucket-fit");
+  });
+});
+
+describe("#1387 #19 GOLDEN Hallucinated parent NON-MEMBER (MED-4)", () => {
+  it("a non-member parent → queue-parent, NEVER mint — even dissimilar + high confidence", () => {
+    const d = decideGrowth(
+      proposal({
+        parentLeanId: "feature-hallucinated", // NOT in BUCKETS
+        candidateLabel: "Totally New Thing",
+        confidence: "high",
+      }),
+      { existingChildSlugs: ["dark-mode"], bucketIds: BUCKETS },
+    );
+    expect(d.kind).toBe("queue-parent");
+    if (d.kind === "queue-parent") expect(d.reason).toBe("hallucinated-parent");
+    // The never-auto-create-a-parent invariant: it is NEVER a mint.
+    expect(d.kind).not.toBe("mint");
+  });
+});
+
+describe("#1387 #20 — short-slug MIN-LENGTH guard (MED-3)", () => {
+  it("two short slugs a low threshold WOULD fuzzy-snap are NOT snapped (fuzzy disabled)", () => {
+    // sim("api","ami") = 1 - 1/3 = 0.667. At threshold 0.6 a LONG pair snaps...
+    expect(GROWTH_MIN_FUZZY_LEN).toBe(6);
+    const short = dedupCandidate("api", ["ami"], { threshold: 0.6 });
+    expect(short.action).toBe("mint"); // short-slug guard forces mint.
+
+    // ...proving it is the guard (not the threshold): a 7-char pair at the same
+    // similarity DOES snap at the same threshold.
+    const longPair = dedupCandidate("abcdefg", ["abcdefh"], { threshold: 0.6 }); // 1/7 → 0.857
+    expect(longPair.action).toBe("snap");
+  });
+
+  it("an EXACT short-slug match still snaps", () => {
+    const res = dedupCandidate("api", ["api", "ami"], { threshold: 0.6 });
+    expect(res.action).toBe("snap");
+    if (res.action === "snap") expect(res.childId).toBe("api");
+  });
+});
+
+describe("#1387 #21 — runtime threshold override changes snap behavior", () => {
+  it("a pair that snaps at 0.85 does NOT snap at 0.95", () => {
+    // slugs "dark-mode" vs "dark-mude": 1 edit / 9 = 0.889.
+    const atDefault = dedupCandidate("dark mode", ["dark-mude"], { threshold: 0.85 });
+    expect(atDefault.action).toBe("snap");
+    const atStrict = dedupCandidate("dark mode", ["dark-mude"], { threshold: 0.95 });
+    expect(atStrict.action).toBe("mint");
+  });
+});

--- a/tests/jira.namespacedLabelWriter.test.ts
+++ b/tests/jira.namespacedLabelWriter.test.ts
@@ -1,0 +1,120 @@
+import {
+  computeLabelOps,
+  computeUnstampOps,
+  buildJiraNamespacedLabelWriter,
+} from "../src/jira/namespacedLabelWriter";
+import {
+  buildDesiredLabels,
+  withProvisionalChild,
+  type LabelCatalog,
+  type ValidatedLabels,
+} from "../src/jira/namespacedLabels";
+
+/**
+ * #1387 — writer ops for the DUAL parent buckets + the TYPED provisional adds.
+ *
+ * SYNTHETIC fixtures ONLY; the write path is driven by a spied fake `fetchImpl`
+ * with ZERO live mutation.
+ */
+const CONFIG = { baseUrl: "https://example.atlassian.net", email: "a@b.c", apiToken: "tok" };
+
+function okFetchSpy(): jest.Mock {
+  return jest.fn(async () => ({
+    ok: true,
+    status: 204,
+    statusText: "No Content",
+    async json() {
+      return {};
+    },
+  }));
+}
+
+const DUAL_CATALOG: LabelCatalog = {
+  featureIds: new Set(["feature-widget"]),
+  flowIds: new Set(["flow-onboarding"]),
+  parentOf: new Map([
+    ["feature-widget", "feature-tools"],
+    ["flow-onboarding", "flow-account"],
+  ]),
+};
+
+describe("#1387 #9 — feature-bucket is single-value (remove stale, add new)", () => {
+  it("removes a stale mb-bucket-feature-* and adds the target bucket", () => {
+    const target = buildDesiredLabels(
+      { feature: "feature-widget", flows: [], symptom: "crash-error" },
+      DUAL_CATALOG,
+      undefined,
+      () => {},
+    );
+    const ops = computeLabelOps(["mb-bucket-feature-old", "keep-me"], target);
+    expect(ops).toContainEqual({ remove: "mb-bucket-feature-old" });
+    expect(ops).toContainEqual({ add: "mb-bucket-feature-tools" });
+    expect(JSON.stringify(ops)).not.toContain("keep-me");
+  });
+});
+
+describe("#1387 #10 — flow-buckets are additive (add desired, remove none)", () => {
+  it("adds the desired flow bucket and removes no flow bucket", () => {
+    const target = buildDesiredLabels(
+      { flows: ["flow-onboarding"], symptom: "crash-error" },
+      DUAL_CATALOG,
+      undefined,
+      () => {},
+    );
+    const ops = computeLabelOps(["mb-bucket-flow-existing"], target);
+    expect(ops).toContainEqual({ add: "mb-bucket-flow-account" });
+    // Additive: a different existing flow bucket is NOT removed.
+    expect(ops.some((o) => "remove" in o)).toBe(false);
+  });
+});
+
+describe("#1387 #11 — unstamp peels parents + provisional + marker, human untouched", () => {
+  it("removes every bot label across all namespaces, leaves a human label", () => {
+    const ops = computeUnstampOps([
+      "mb-feature-x",
+      "mb-bucket-feature-x",
+      "mb-bucket-flow-y",
+      "mb-prov-feature-z",
+      "mb-autocreated",
+      "keep-me",
+    ]);
+    const removed = new Set(ops.map((o) => ("remove" in o ? o.remove : "")));
+    expect(removed).toEqual(
+      new Set([
+        "mb-feature-x",
+        "mb-bucket-feature-x",
+        "mb-bucket-flow-y",
+        "mb-prov-feature-z",
+        "mb-autocreated",
+      ]),
+    );
+    expect(JSON.stringify(ops)).not.toContain("keep-me");
+  });
+});
+
+describe("#1387 #12 GOLDEN — provisional adds land in the WRITE BODY (MED-2)", () => {
+  it("a minted provisional child + bucket + marker appear as real add ops in the PUT", async () => {
+    const fetchImpl = okFetchSpy();
+    const writer = buildJiraNamespacedLabelWriter(CONFIG, fetchImpl as unknown as typeof fetch);
+
+    // Symptom-only base (the abstain shape), then a minted provisional child.
+    const base: ValidatedLabels = buildDesiredLabels(
+      { flows: [], symptom: "crash-error" },
+      DUAL_CATALOG,
+      undefined,
+      () => {},
+    );
+    const target = withProvisionalChild(base, "dark-mode", "feature-tools");
+
+    const didPut = await writer.applyLabels("DEMO-1", [], target);
+    expect(didPut).toBe(true);
+
+    const init = fetchImpl.mock.calls[0][1] as { body: string };
+    const ops = JSON.parse(init.body).update.labels as Array<{ add?: string; remove?: string }>;
+    // The mint is WRITTEN, not merely computed in `desired` (a `desired`-only
+    // implementation would FAIL these three assertions).
+    expect(ops).toContainEqual({ add: "mb-prov-feature-dark-mode" });
+    expect(ops).toContainEqual({ add: "mb-bucket-feature-tools" });
+    expect(ops).toContainEqual({ add: "mb-autocreated" });
+  });
+});

--- a/tests/jira.namespacedLabels.test.ts
+++ b/tests/jira.namespacedLabels.test.ts
@@ -9,6 +9,169 @@ import {
 import { buildJiraNamespacedLabelWriter } from "../src/jira/namespacedLabelWriter";
 import { DEFECT_CATEGORIES } from "../src/triage/categorizeDefect";
 
+/** #1387 — DUAL labels (child + parent bucket) + PARTIAL validation. */
+describe("#1387 — DUAL child+parent bucket labels", () => {
+  const PARENT_OF = new Map<string, string>([
+    ["feature-widget", "feature-tools"],
+    ["flow-onboarding", "flow-account"],
+  ]);
+  const CATALOG: LabelCatalog = {
+    featureIds: new Set(["feature-widget"]),
+    flowIds: new Set(["flow-onboarding"]),
+    parentOf: PARENT_OF,
+  };
+
+  it("#1 happy path: child + parent bucket on BOTH axes + symptom", () => {
+    const v = buildDesiredLabels(
+      { feature: "feature-widget", flows: ["flow-onboarding"], symptom: "crash-error" },
+      CATALOG,
+      undefined,
+      () => {},
+    );
+    expect(v.desired).toEqual(
+      expect.arrayContaining([
+        "mb-feature-widget",
+        "mb-bucket-feature-tools",
+        "mb-flow-onboarding",
+        "mb-bucket-flow-account",
+        "mb-symptom-crash-error",
+      ]),
+    );
+    expect(v.featureBucket).toBe("mb-bucket-feature-tools");
+    expect(v.flowBuckets).toEqual(["mb-bucket-flow-account"]);
+  });
+
+  it("#2 child with no map entry → child present, NO bucket, no throw, axis-only log", () => {
+    const logs: string[] = [];
+    const catalog: LabelCatalog = {
+      featureIds: new Set(["feature-orphan"]),
+      flowIds: new Set(),
+      parentOf: new Map(), // feature-orphan absent from the map.
+    };
+    const v = buildDesiredLabels(
+      { feature: "feature-orphan", flows: [], symptom: "crash-error" },
+      catalog,
+      undefined,
+      (m) => logs.push(m),
+    );
+    expect(v.feature).toBe("mb-feature-orphan");
+    expect(v.featureBucket).toBeUndefined();
+    expect(v.desired.some((l) => l.startsWith("mb-bucket-"))).toBe(false);
+    expect(logs.some((l) => l.includes("no parent-bucket mapping"))).toBe(true);
+    expect(logs.join("\n")).not.toContain("orphan");
+  });
+
+  it("#3 two flows → same bucket de-duped to exactly one", () => {
+    const catalog: LabelCatalog = {
+      featureIds: new Set(),
+      flowIds: new Set(["flow-a", "flow-b"]),
+      parentOf: new Map([
+        ["flow-a", "flow-shared"],
+        ["flow-b", "flow-shared"],
+      ]),
+    };
+    const v = buildDesiredLabels(
+      { flows: ["flow-a", "flow-b"], symptom: "crash-error" },
+      catalog,
+      undefined,
+      () => {},
+    );
+    const buckets = v.desired.filter((l) => l === "mb-bucket-flow-shared");
+    expect(buckets).toEqual(["mb-bucket-flow-shared"]);
+    expect(v.flowBuckets).toEqual(["mb-bucket-flow-shared"]);
+  });
+
+  it("#7 backward-compat: NO parentOf → child + symptom only (no bucket)", () => {
+    const catalog: LabelCatalog = {
+      featureIds: new Set(["feature-widget"]),
+      flowIds: new Set(["flow-onboarding"]),
+    };
+    const v = buildDesiredLabels(
+      { feature: "feature-widget", flows: ["flow-onboarding"], symptom: "crash-error" },
+      catalog,
+      undefined,
+      () => {},
+    );
+    expect(v.desired.some((l) => l.startsWith("mb-bucket-"))).toBe(false);
+    expect(v.featureBucket).toBeUndefined();
+    expect(v.flowBuckets).toEqual([]);
+  });
+});
+
+describe("#1387 — PARTIAL validation (keep valid, drop invalid; all-invalid still throws)", () => {
+  const CATALOG: LabelCatalog = {
+    featureIds: new Set(["feature-widget"]),
+    flowIds: new Set(["flow-onboarding"]),
+  };
+
+  it("#4 GOLDEN partial-keep: bad feature dropped, valid flow kept, no throw", () => {
+    const logs: string[] = [];
+    const v = buildDesiredLabels(
+      { feature: "feature-nope", flows: ["flow-onboarding"], symptom: "crash-error" },
+      CATALOG,
+      undefined,
+      (m) => logs.push(m),
+    );
+    expect(v.feature).toBeUndefined();
+    expect(v.flows).toEqual(["mb-flow-onboarding"]);
+    expect(v.droppedCount).toBe(1);
+    expect(v.desired).toContain("mb-symptom-crash-error");
+    // Log names only the axis, never the supplied value.
+    expect(logs.some((l) => l.includes("dropped invalid feature"))).toBe(true);
+    expect(logs.join("\n")).not.toContain("nope");
+  });
+
+  it("#5 GOLDEN all-invalid: every supplied member invalid → throws (guard NOT weakened)", () => {
+    const logs: string[] = [];
+    expect(() =>
+      buildDesiredLabels(
+        { feature: "feature-nope", flows: ["flow-nope"], symptom: "crash-error" },
+        CATALOG,
+        undefined,
+        (m) => logs.push(m),
+      ),
+    ).toThrow(LabelValidationError);
+    expect(logs.join("\n")).not.toContain("nope");
+  });
+
+  it("#6 symptom-only (no feature, empty flows): no throw, symptom-only desired", () => {
+    const v = buildDesiredLabels(
+      { flows: [], symptom: "crash-error" },
+      CATALOG,
+      undefined,
+      () => {},
+    );
+    expect(v.feature).toBeUndefined();
+    expect(v.flows).toEqual([]);
+    expect(v.droppedCount).toBe(0);
+    expect(v.desired).toEqual(["mb-symptom-crash-error"]);
+  });
+
+  it("partial-keep on the FLOW axis: one bad flow dropped, valid flow kept", () => {
+    const v = buildDesiredLabels(
+      { flows: ["flow-onboarding", "flow-nope"], symptom: "crash-error" },
+      CATALOG,
+      undefined,
+      () => {},
+    );
+    expect(v.flows).toEqual(["mb-flow-onboarding"]);
+    expect(v.droppedCount).toBe(1);
+  });
+});
+
+describe("#1387 — buildBotLabelJql enumerates parent buckets too", () => {
+  it("#8 includes mb-bucket-* for each supplied lean id, sorted, quoted, no wildcard", () => {
+    const catalog = {
+      features: [{ id: "feature-widget" }],
+      flows: [{ id: "flow-onboarding" }],
+    };
+    const jql = buildBotLabelJql(catalog, undefined, ["feature-tools", "flow-account"]);
+    expect(jql).not.toContain("*");
+    expect(jql).toContain('"mb-bucket-feature-tools"');
+    expect(jql).toContain('"mb-bucket-flow-account"');
+  });
+});
+
 /**
  * #1322 — bot-namespaced Jira labels (mb-feature / mb-flow / mb-symptom).
  *

--- a/tests/triage.backfill.test.ts
+++ b/tests/triage.backfill.test.ts
@@ -1,7 +1,8 @@
-import { run } from "../src/triage/backfill";
+import { run, type GrowthDeps } from "../src/triage/backfill";
 import { buildJiraNamespacedLabelWriter } from "../src/jira/namespacedLabelWriter";
 import { buildDesiredLabels, membershipFromCatalog } from "../src/jira/namespacedLabels";
 import type { IssueFeatureFlowClassifier } from "../src/triage/classifier";
+import type { GrowthProposal, GrowthDecision } from "../src/catalog/catalogGrowth";
 import type { JiraIssue } from "../src/jira/sync";
 
 /**
@@ -221,5 +222,178 @@ describe("AC-7 (#1343) — feature/flow pass is ADDITIVE: mb-symptom-* untouched
     expect(desired.desired).toContain("mb-feature-checkout");
     expect(desired.desired).toContain("mb-symptom-crash-error");
     expect(desired.symptom).toBe("mb-symptom-crash-error");
+  });
+});
+
+describe("#1387 — partial validation + dual labels in the backfill", () => {
+  it("#13 partial run: one bad flow dropped, issue still validates + writes", async () => {
+    const fetchImpl = okFetchSpy();
+    const writer = buildJiraNamespacedLabelWriter(CONFIG, fetchImpl as unknown as typeof fetch);
+    const mixedClassifier: IssueFeatureFlowClassifier = {
+      async classify() {
+        return { feature: "checkout", flows: ["signin", "not-a-flow"] };
+      },
+    };
+    const result = await run({
+      fetchOpenDefects: async () => [
+        { key: "X-1", summary: "the app crashed", descriptionText: "", commentTexts: [] },
+      ],
+      classifier: mixedClassifier,
+      catalog: MEMBERSHIP,
+      writer,
+      apply: true,
+      log: () => undefined,
+    });
+    expect(result.validated).toBe(1);
+    expect(result.rejected).toBe(0);
+    expect(result.partial).toBe(1);
+    expect(result.dropped).toBe(1);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it("#14 all-invalid still rejected: ZERO fetch (existing guard preserved)", async () => {
+    const fetchImpl = okFetchSpy();
+    const writer = buildJiraNamespacedLabelWriter(CONFIG, fetchImpl as unknown as typeof fetch);
+    const allBad: IssueFeatureFlowClassifier = {
+      async classify() {
+        return { feature: "nope", flows: ["also-nope"] };
+      },
+    };
+    const result = await run({
+      fetchOpenDefects: async () => [
+        { key: "X-9", summary: "the app crashed", descriptionText: "", commentTexts: [] },
+      ],
+      classifier: allBad,
+      catalog: MEMBERSHIP,
+      writer,
+      apply: true,
+      log: () => undefined,
+    });
+    expect(result.rejected).toBe(1);
+    expect(result.validated).toBe(0);
+    expect(result.partial).toBe(0);
+    expect(fetchImpl).toHaveBeenCalledTimes(0);
+  });
+
+  it("#15 dual labels: child + parent bucket adds land together in ONE PUT", async () => {
+    const calls: Array<{ ops: unknown[] }> = [];
+    const fetchImpl = jest.fn(async (_url: string, init: { body: string }) => {
+      calls.push({ ops: JSON.parse(init.body).update.labels });
+      return { ok: true, status: 204, statusText: "No Content", async json() {return {};} };
+    });
+    const writer = buildJiraNamespacedLabelWriter(CONFIG, fetchImpl as unknown as typeof fetch);
+    const dualCatalog = membershipFromCatalog(
+      { features: [{ id: "feature-checkout" }], flows: [{ id: "flow-signin" }] },
+      new Map([
+        ["feature-checkout", "feature-tools"],
+        ["flow-signin", "flow-account"],
+      ]),
+    );
+    const canonical: IssueFeatureFlowClassifier = {
+      async classify() {
+        return { feature: "feature-checkout", flows: ["flow-signin"] };
+      },
+    };
+    const result = await run({
+      fetchOpenDefects: async () => [
+        { key: "X-1", summary: "the app crashed", descriptionText: "", commentTexts: [] },
+      ],
+      classifier: canonical,
+      catalog: dualCatalog,
+      writer,
+      apply: true,
+      log: () => undefined,
+    });
+    expect(result.applied).toBe(1);
+    expect(calls).toHaveLength(1);
+    const ops = calls[0].ops as Array<{ add?: string }>;
+    const adds = new Set(ops.filter((o) => o.add).map((o) => o.add));
+    expect(adds).toEqual(
+      new Set([
+        "mb-feature-checkout",
+        "mb-bucket-feature-tools",
+        "mb-flow-signin",
+        "mb-bucket-flow-account",
+        "mb-symptom-crash-error",
+      ]),
+    );
+  });
+});
+
+describe("#1387 — HYBRID growth integration", () => {
+  const ABSTAIN: IssueFeatureFlowClassifier = {
+    async classify() {
+      return { feature: undefined, flows: [] };
+    },
+  };
+  const ISSUE: JiraIssue = {
+    key: "X-1",
+    summary: "the app crashed",
+    descriptionText: "",
+    commentTexts: [],
+  };
+
+  it("#24 growth GATED: no growth dep → abstain issue gets symptom-only, NO proposer call", async () => {
+    let proposeCalls = 0;
+    const result = await run({
+      fetchOpenDefects: async () => [ISSUE],
+      classifier: ABSTAIN,
+      catalog: MEMBERSHIP,
+      apply: false,
+      log: () => undefined,
+      growth: {
+        grow: false, // default OFF
+        existingChildSlugs: new Set(),
+        bucketIds: new Set(["feature-tools"]),
+        async propose() {
+          proposeCalls++;
+          return { parentLeanId: "feature-tools", candidateLabel: "x", confidence: "high" };
+        },
+        record: () => undefined,
+      } as GrowthDeps,
+    });
+    expect(proposeCalls).toBe(0);
+    expect(result.minted).toBe(0);
+    expect(result.proposed).toBe(0);
+  });
+
+  it("#25 GOLDEN growth mint idempotent: mints once, snaps on run #2", async () => {
+    const existingChildSlugs = new Set<string>();
+    const recorded: Array<{ decision: GrowthDecision; proposal: GrowthProposal }> = [];
+    const growth = (): GrowthDeps => ({
+      grow: true,
+      existingChildSlugs,
+      bucketIds: new Set(["feature-tools"]),
+      async propose() {
+        return { parentLeanId: "feature-tools", candidateLabel: "Dark Mode", confidence: "high" };
+      },
+      record: (decision, proposal) => {
+        recorded.push({ decision, proposal });
+        if (decision.kind === "mint") existingChildSlugs.add(decision.slug);
+      },
+    });
+
+    const run1 = await run({
+      fetchOpenDefects: async () => [ISSUE],
+      classifier: ABSTAIN,
+      catalog: MEMBERSHIP,
+      apply: false,
+      log: () => undefined,
+      growth: growth(),
+    });
+    expect(run1.minted).toBe(1);
+    expect(run1.snapped).toBe(0);
+    expect(existingChildSlugs.has("dark-mode")).toBe(true);
+
+    const run2 = await run({
+      fetchOpenDefects: async () => [ISSUE],
+      classifier: ABSTAIN,
+      catalog: MEMBERSHIP,
+      apply: false,
+      log: () => undefined,
+      growth: growth(),
+    });
+    expect(run2.minted).toBe(0);
+    expect(run2.snapped).toBe(1);
   });
 });

--- a/tests/triage.growthProposer.test.ts
+++ b/tests/triage.growthProposer.test.ts
@@ -1,0 +1,66 @@
+import {
+  buildProposerPrompt,
+  parseProposerReply,
+  proposeChild,
+  type BucketMenuEntry,
+} from "../src/triage/growthProposer";
+import { decideGrowth } from "../src/catalog/catalogGrowth";
+import type { CompleteFn } from "../src/triage/featureFlowMatcher";
+
+/**
+ * #1387 — growth proposer seam. SYNTHETIC fixtures; the model boundary is an
+ * INJECTED fake `complete`, so ZERO network / model / cred calls.
+ */
+const BUCKET_MENU: BucketMenuEntry[] = [
+  { id: "feature-tools", label: "Tools" },
+  { id: "feature-account", label: "Account" },
+];
+const ISSUE = { summary: "cannot toggle the new widget", descriptionText: "broken" };
+
+function fakeComplete(canned: string): CompleteFn {
+  return async () => canned;
+}
+
+describe("#1387 #22 — buildProposerPrompt lists buckets, demands strict JSON, never invents", () => {
+  it("includes every bucket id + label and the strict-JSON contract", () => {
+    const prompt = buildProposerPrompt(BUCKET_MENU, ISSUE);
+    expect(prompt).toContain("feature-tools");
+    expect(prompt).toContain("Tools");
+    expect(prompt).toContain("feature-account");
+    expect(prompt).toContain("STRICT JSON");
+    expect(prompt).toContain("NEVER invent a bucket id");
+    expect(prompt).toContain("cannot toggle the new widget");
+  });
+});
+
+describe("#1387 #23 — parse + abstain (fake complete, zero network)", () => {
+  it("parses a high-confidence reply to a usable proposal", async () => {
+    const complete = fakeComplete(
+      '{"parentLeanId":"feature-tools","candidateLabel":"Dark Mode","confidence":"high"}',
+    );
+    const p = await proposeChild(complete, BUCKET_MENU, ISSUE);
+    expect(p).toEqual({
+      parentLeanId: "feature-tools",
+      candidateLabel: "Dark Mode",
+      confidence: "high",
+    });
+  });
+
+  it("a null-parent / low-confidence reply parses to a queue decision", async () => {
+    const complete = fakeComplete(
+      'Sure:\n{"parentLeanId":null,"candidateLabel":"Mystery","confidence":"low"}\nDone.',
+    );
+    const p = await proposeChild(complete, BUCKET_MENU, ISSUE);
+    expect(p.parentLeanId).toBeNull();
+    expect(p.confidence).toBe("low");
+    const d = decideGrowth(p, {
+      existingChildSlugs: [],
+      bucketIds: new Set(["feature-tools", "feature-account"]),
+    });
+    expect(d.kind).toBe("queue-parent");
+  });
+
+  it("throws a structured error when the reply carries no JSON object", () => {
+    expect(() => parseProposerReply("I cannot answer that.")).toThrow(/no JSON object/);
+  });
+});


### PR DESCRIPTION
## Summary

Three coupled upgrades to the defect-labeling pipeline, landed before the one-time backfill apply (#1377).

1. **Dual labels** — each defect gets BOTH its child feature/flow label (`mb-<id>`) and its lean parent bucket label (`mb-bucket-<leanId>`), plus the symptom, in a **single Jira PUT**. Reviewers see granular + rolled-up tags for transparency.
2. **Partial-validation** — collect-then-decide: drop only the invalid member, keep the valid feature/flow, instead of rejecting a defect's whole label set over one model-invented id. Throw only when something was supplied and nothing valid remains. Prior all-invalid reject behavior unchanged.
3. **Hybrid catalog growth** (opt-in, default OFF behind `--grow`) — when a defect fits no bucket, optionally mint a NEW CHILD under an existing parent (`mb-prov-feature-*` + `mb-autocreated`), guarded by a configurable similarity snap (`--snap-threshold`, flag>env>0.85) and a short-slug floor (`GROWTH_MIN_FUZZY_LEN`). A new **PARENT is NEVER auto-created** — a non-member/null parent routes to a gitignored human-approval holding queue (`proposed-additions.json`), never written outward.

## Test plan

- Build clean (exit 0) + typecheck clean.
- Full suite: **535 passed / 57 suites** (~26 new cases incl. 9 golden write-body assertions that parse the real Jira PUT body).
- Non-grow path **byte-identical** — all prior backfill/writer tests green unchanged.
- Catalog / full↔lean map / proposed-additions queue all confirmed gitignored.
- Fixtures synthetic + name-free; privacy grep 0.
- 4-role chain all PASS; execution-review independently re-verified build, tests, growth-safety invariants, and non-grow byte-identity.

---
https://claude.ai/code/session_01R5rpgymipJKn4AhCTmsYpD