### PR TITLE
fix: /ask how-to intent classifier tolerates hyphen/glued spelling (#1393)

### DIFF
--- a/src/knowledge/queryExpansion.ts
+++ b/src/knowledge/queryExpansion.ts
@@ -139,8 +139,10 @@ export function hasHowToActionIntent(question: string): boolean {
   if (typeof question !== "string") return false;
   const s = question.toLowerCase();
   // Exclude the greeting / state-of-being "how are/is/was…" (chit-chat control).
-  if (/\bhow\s+(are|is|was|were|'?s)\b/.test(s)) return false;
-  if (/\bhow\s+to\b/.test(s)) return true; //                "how to X"
-  if (/\bhow\s+(do|can|does|could|should)\b/.test(s)) return true; // "how do I X"
+  // Hyphen-tolerant separator, plus an optional "to" bridge so a hyphenated or
+  // spaced "how[- ]to are/is/was…" reads as small-talk, NOT how-to-action.
+  if (/\bhow[-\s]+(to[-\s]+)?(are|is|was|were|'?s)\b/.test(s)) return false;
+  if (/\bhow[-\s]*to\b/.test(s)) return true; //             "how to / how-to / howto X"
+  if (/\bhow[-\s]+(do|can|does|could|should)\b/.test(s)) return true; // "how[- ]do I X"
   return false;
 }

--- a/tests/recall-docprior.test.ts
+++ b/tests/recall-docprior.test.ts
@@ -41,14 +41,23 @@ describe("hasHowToActionIntent — tightened classifier (correction #2)", () => 
     expect(hasHowToActionIntent("how does the matching feature work")).toBe(true);
   });
 
+  it("FIRES on the hyphenated / solid spelling of how-to", () => {
+    expect(hasHowToActionIntent("how-to reserve a slot")).toBe(true); // hyphen compound
+    expect(hasHowToActionIntent("howto find a spot")).toBe(true); //     solid compound
+    expect(hasHowToActionIntent("how-do I book a desk")).toBe(true); //  hyphenated verb clause
+  });
+
   it("does NOT fire on the greeting control", () => {
     expect(hasHowToActionIntent("how are you today")).toBe(false);
+    expect(hasHowToActionIntent("how-are you")).toBe(false); //  hyphenated greeting
+    expect(hasHowToActionIntent("how-to are you")).toBe(false); // to-bridge in the exclusion
   });
 
   it("does NOT fire on capacity / frequency / pricing 'how' questions (dropped loose clause)", () => {
     // These false-fired under the plan's anywhere-in-sentence clause 3, which was
     // DROPPED — their answers may live in a ticket, so the doc boost must NOT run.
     expect(hasHowToActionIntent("how many people can I add to a team")).toBe(false);
+    expect(hasHowToActionIntent("how-many people can I add")).toBe(false); // hyphenated quantity
     expect(hasHowToActionIntent("how often do I get billed")).toBe(false);
     expect(hasHowToActionIntent("how much does it cost to book")).toBe(false);
   });


### PR DESCRIPTION
## Summary
`hasHowToActionIntent` required whitespace in its how-to regexes (`/\bhow\s+to\b/`), so a hyphenated "how-to" returned false. That left the doc-prior retrieval lever ungated, backend tickets dominated top-K, and `/ask` over-refused on a documented topic. The space-spelled "how to" worked; the hyphenated/glued form did not.

This widens the three intent regexes to tolerate hyphen and glued spelling while keeping the greeting exclusion first and hyphen-tolerant. No retrieval-path normalization (which would wrongly split sign-in / e-mail / dates) and no new env.

## Test plan
- New synthetic cases in the existing `hasHowToActionIntent — tightened classifier` describe block.
- Full jest: 57/57 suites, 544/544 tests pass; build + typecheck clean.
- Privacy grep over the diff: count 0.

https://claude.ai/code/session_01R5rpgymipJKn4AhCTmsYpD