### PR TITLE
fix: /jql cross-axis child-stem union + full/lean vocab (#1392, #1385)

### DIFF
--- a/src/jira/answerJql.ts
+++ b/src/jira/answerJql.ts
@@ -34,12 +34,14 @@ import { JqlReply } from "../slack/commands";
  *   seam). Production passes none → a real `buildJqlSearchFetcher` is built.
  * - `fetchImpl` — override the global fetch passed to the real fetcher (tests).
  * - `catalogPath` — override the gitignored catalog path (tests).
+ * - `mapPath` — override the gitignored full→lean map path (#1385, tests).
  */
 export interface BuildAnswerJqlDeps {
   env: NodeJS.ProcessEnv;
   search?: JqlSearchFetcher;
   fetchImpl?: typeof fetch;
   catalogPath?: string;
+  mapPath?: string;
 }
 
 /**
@@ -82,6 +84,45 @@ function loadCatalog(catalogPath?: string): CatalogIdSource {
 }
 
 /**
+ * Read the gitignored full→lean map (#1385) into a flat `parentOf` map
+ * (`fullChildId → leanBucketId`) merged across the `features` + `flows` sections.
+ * Resolved from `process.cwd()` like `loadCatalog`. NEVER throws: an absent or
+ * malformed map yields an EMPTY map, so the lean-vocab feature is a genuine no-op
+ * when the map has not landed (behaviour identical to pre-#1385). Exported for
+ * the zero-I/O unit test seam (the real map is gitignored + runtime-only).
+ */
+export function loadFullToLeanMap(mapPath?: string): Map<string, string> {
+  const resolved =
+    mapPath ?? path.resolve(process.cwd(), ".ai-workspace", "catalog", "full-to-lean-map.json");
+  const out = new Map<string, string>();
+  try {
+    const raw = JSON.parse(fs.readFileSync(resolved, "utf8"));
+    for (const axis of ["features", "flows"] as const) {
+      const section = raw?.[axis];
+      if (section && typeof section === "object") {
+        for (const [childId, leanId] of Object.entries(section)) {
+          if (typeof leanId === "string" && leanId.length > 0) out.set(childId, leanId);
+        }
+      }
+    }
+  } catch {
+    // absent / malformed → empty map (behaviour unchanged). NEVER throws.
+  }
+  return out;
+}
+
+/**
+ * Read an env flag that defaults ON (#1385/#1392 knobs). Any value except `"0"`
+ * / `"false"` (case-insensitive, trimmed) keeps the feature ON; an UNSET flag is
+ * ON. `=0`/`=false` is the explicit kill-switch.
+ */
+function envFlagOn(raw: string | undefined): boolean {
+  if (raw === undefined) return true;
+  const v = raw.trim().toLowerCase();
+  return v !== "0" && v !== "false";
+}
+
+/**
  * Build the production `answerJql(question)` method for the Slack `adminService`.
  *
  * Returns a function that maps an English defect question to JQL and runs ONE
@@ -102,8 +143,16 @@ export function buildAnswerJql(deps: BuildAnswerJqlDeps): (question: string) => 
     // Step 2 — load the gitignored catalog (empty fallback on any error).
     const catalog = loadCatalog(deps.catalogPath);
 
+    // #1385 — full↔lean vocab knob (default ON, genuinely data-gated: no/empty
+    // map ⇒ no buckets ⇒ behaviour identical to today). When OFF, pass NO
+    // parentOf so buckets are neither offered to the LLM nor accepted.
+    const acceptLeanVocab = envFlagOn(deps.env.JQL_ACCEPT_LEAN_VOCAB);
+    const parentOf = acceptLeanVocab ? loadFullToLeanMap(deps.mapPath) : undefined;
+    // #1392 — cross-axis union knob (default ON).
+    const crossAxisUnion = envFlagOn(deps.env.JQL_CROSS_AXIS_UNION);
+
     // Step 3 — compose the seams (engine unchanged).
-    const vocab = buildVocab(catalog);
+    const vocab = buildVocab(catalog, undefined, parentOf);
     const mapper = buildLlmFilterMapper();
     const search =
       deps.search ??
@@ -122,6 +171,7 @@ export function buildAnswerJql(deps: BuildAnswerJqlDeps): (question: string) => 
       search,
       run: true,
       defaultProjects,
+      crossAxisUnion,
     });
 
     // Step 5 — map to the Slack `JqlReply` (drops the debug-only `filter`).

--- a/src/jira/jqlFromFilter.ts
+++ b/src/jira/jqlFromFilter.ts
@@ -22,7 +22,14 @@
  * rejected raw value (mirrors `LabelValidationError` log discipline — PUBLIC repo).
  */
 import { slug } from "../catalog/slug";
-import { labelsInClause, NS_FEATURE, NS_FLOW, NS_SYMPTOM } from "./namespacedLabels";
+import {
+  labelsInClause,
+  NS_BUCKET_FEATURE,
+  NS_BUCKET_FLOW,
+  NS_FEATURE,
+  NS_FLOW,
+  NS_SYMPTOM,
+} from "./namespacedLabels";
 
 /**
  * The structured query the LLM maps an English question to (`nlFilterMapper`),
@@ -115,6 +122,16 @@ export interface LabelVocab {
   featureIds: ReadonlySet<string>;
   /** Catalog flow entry ids (`flow-<slug>`); may be EMPTY today. */
   flowIds: ReadonlySet<string>;
+  /**
+   * OPTIONAL lean feature BUCKET ids (`feature-<slug>`, #1385) — the distinct
+   * family ids the full→lean map points to. When present, a feature-axis slug
+   * that misses the child set but hits a bucket id resolves to an
+   * `mb-bucket-feature-<slug>` family clause. ABSENT/empty → no buckets offered
+   * or accepted (behaviour identical to pre-#1385).
+   */
+  featureBucketIds?: ReadonlySet<string>;
+  /** OPTIONAL lean flow BUCKET ids (`flow-<slug>`, #1385). Same semantics. */
+  flowBucketIds?: ReadonlySet<string>;
 }
 
 /** The builder's deterministic output. */
@@ -127,13 +144,19 @@ export interface JqlBuildResult {
 const DEFAULT_STATUS = "statusCategory != Done";
 
 /**
- * Resolve a feature/flow axis against the catalog. Catalog-conditional:
- *   - EMPTY catalog set → every requested slug PASSES THROUGH as a label + one
- *     "not yet populated" warning (the clause is correct but inert until the
- *     deferred matcher runs).
- *   - NON-EMPTY catalog set → a slug whose `<idPrefix><slug>` id is not in the
- *     set is DROPPED + warned (kills hallucinations); known slugs become labels.
- * Labels emitted are `<labelPrefix><slug>` (e.g. `mb-feature-widget`).
+ * Resolve a feature/flow axis against the catalog (Rule B, #1385). Per slug,
+ * STRICT precedence — child → bucket → child-empty passthrough → drop:
+ *   1. `<idPrefix><slug>` ∈ CHILD set → child label `<labelPrefix><slug>`
+ *      (today's behaviour; precise area query).
+ *   2. else `<idPrefix><slug>` ∈ BUCKET set → family label
+ *      `<bucketLabelPrefix><slug>` (the broad family query #1385 accepts).
+ *   3. else CHILD set EMPTY → passthrough `<labelPrefix><slug>` + one "not yet
+ *      populated" warning (forward-compat — the gate keys off the CHILD set
+ *      ONLY, evaluated AFTER the bucket check, so a populated bucket set never
+ *      suppresses the warning).
+ *   4. else (child set non-empty, no match on either) → DROP + axis-named warn.
+ * Labels emitted are `<labelPrefix><slug>` (e.g. `mb-feature-widget`) or
+ * `<bucketLabelPrefix><slug>` (e.g. `mb-bucket-feature-platform`).
  */
 function resolveCatalogAxis(
   values: readonly string[],
@@ -142,24 +165,28 @@ function resolveCatalogAxis(
   labelPrefix: string,
   axisName: string,
   warnings: string[],
+  bucketIds: ReadonlySet<string> = new Set<string>(),
+  bucketLabelPrefix = "",
 ): string[] {
   const labels: string[] = [];
   let dropped = 0;
+  let passthrough = 0;
   const catalogEmpty = catalogIds.size === 0;
   for (const raw of values) {
     const s = slug(raw ?? "");
     if (s.length === 0) continue;
-    if (catalogEmpty) {
-      labels.push(`${labelPrefix}${s}`);
-      continue;
-    }
     if (catalogIds.has(`${idPrefix}${s}`)) {
-      labels.push(`${labelPrefix}${s}`);
+      labels.push(`${labelPrefix}${s}`); // 1. child (most precise)
+    } else if (bucketIds.has(`${idPrefix}${s}`)) {
+      labels.push(`${bucketLabelPrefix}${s}`); // 2. lean family bucket
+    } else if (catalogEmpty) {
+      labels.push(`${labelPrefix}${s}`); // 3. forward-compat passthrough (child set empty)
+      passthrough++;
     } else {
-      dropped++;
+      dropped++; // 4. unknown on a populated child set → drop
     }
   }
-  if (catalogEmpty && labels.length > 0) {
+  if (passthrough > 0) {
     warnings.push(
       `${axisName} labels not yet populated — this clause matches nothing until the deferred matcher runs.`,
     );
@@ -176,10 +203,25 @@ function resolveCatalogAxis(
  * Composition: `project in (...)` (when projects present) AND each non-empty
  * label axis (feature, then flow, then symptom — within-axis OR via
  * `labels in (...)`, across-axis AND) AND the status clause (last). Pure +
- * referentially transparent: same `(filter, vocab)` → identical `{jql, warnings}`.
+ * referentially transparent: same `(filter, vocab, opts)` → identical
+ * `{jql, warnings}`.
+ *
+ * Rule A — same-concept cross-axis union (#1392, gated by `opts.crossAxisUnion`,
+ * default ON): when ONE named area is double-mapped as a feature CHILD AND a flow
+ * CHILD sharing a byte-identical namespace-stripped stem, the two child labels
+ * merge into ONE `labels in ("mb-feature-<stem>","mb-flow-<stem>")` OR-clause
+ * (recall) instead of being ANDed (silent intersection). Union candidacy is
+ * pinned to the two CHILD namespaces (`mb-feature-`/`mb-flow-`) — bucket/family
+ * labels (`mb-bucket-*`) are NEVER union candidates and ride inside their per-axis
+ * clause. Distinct stems still AND; the symptom axis is never merged.
  */
-export function buildJqlFromFilter(filter: StructuredFilter, vocab: LabelVocab): JqlBuildResult {
+export function buildJqlFromFilter(
+  filter: StructuredFilter,
+  vocab: LabelVocab,
+  opts?: { crossAxisUnion?: boolean },
+): JqlBuildResult {
   const warnings: string[] = [];
+  const crossAxisUnion = opts?.crossAxisUnion ?? true;
 
   // --- Symptom axis: HARD validation against the live taxonomy ---
   const symptomLabels: string[] = [];
@@ -197,7 +239,8 @@ export function buildJqlFromFilter(filter: StructuredFilter, vocab: LabelVocab):
     warnings.push(`dropped ${droppedSymptoms} unknown symptom value(s) (not in taxonomy).`);
   }
 
-  // --- Feature / flow axes: catalog-conditional (forward-compatible) ---
+  // --- Feature / flow axes: catalog-conditional (forward-compatible) + lean
+  // bucket resolution (Rule B, #1385) ---
   const featureLabels = resolveCatalogAxis(
     filter.features ?? [],
     vocab.featureIds,
@@ -205,6 +248,8 @@ export function buildJqlFromFilter(filter: StructuredFilter, vocab: LabelVocab):
     NS_FEATURE,
     "feature",
     warnings,
+    vocab.featureBucketIds ?? new Set<string>(),
+    NS_BUCKET_FEATURE,
   );
   const flowLabels = resolveCatalogAxis(
     filter.flows ?? [],
@@ -213,7 +258,44 @@ export function buildJqlFromFilter(filter: StructuredFilter, vocab: LabelVocab):
     NS_FLOW,
     "flow",
     warnings,
+    vocab.flowBucketIds ?? new Set<string>(),
+    NS_BUCKET_FLOW,
   );
+
+  // --- Rule A — same-stem CHILD cross-axis union (#1392) ---
+  // Candidate iff the label begins with a CHILD namespace (`mb-feature-`/
+  // `mb-flow-`); this structurally EXCLUDES `mb-bucket-*` (which begins with
+  // `mb-bucket-`). The stem strips ONLY the matched child prefix. A stem that
+  // appears as a child candidate on BOTH axes merges into one OR-clause.
+  let featureClauseLabels = featureLabels;
+  let flowClauseLabels = flowLabels;
+  const unionClauses: string[] = [];
+  if (crossAxisUnion) {
+    const featureStems = new Map<string, string>(); // stem → child label
+    for (const l of featureLabels) {
+      if (l.startsWith(NS_FEATURE)) featureStems.set(l.slice(NS_FEATURE.length), l);
+    }
+    const flowStems = new Map<string, string>();
+    for (const l of flowLabels) {
+      if (l.startsWith(NS_FLOW)) flowStems.set(l.slice(NS_FLOW.length), l);
+    }
+    const collidingStems = [...featureStems.keys()].filter((s) => flowStems.has(s)).sort();
+    if (collidingStems.length > 0) {
+      const colliding = new Set(collidingStems);
+      // Pull the colliding CHILD labels out of their per-axis clauses; buckets +
+      // non-colliding children stay put.
+      featureClauseLabels = featureLabels.filter(
+        (l) => !(l.startsWith(NS_FEATURE) && colliding.has(l.slice(NS_FEATURE.length))),
+      );
+      flowClauseLabels = flowLabels.filter(
+        (l) => !(l.startsWith(NS_FLOW) && colliding.has(l.slice(NS_FLOW.length))),
+      );
+      // One merged OR-clause per colliding stem, emitted sorted-by-stem.
+      for (const stem of collidingStems) {
+        unionClauses.push(labelsInClause([featureStems.get(stem)!, flowStems.get(stem)!]));
+      }
+    }
+  }
 
   // --- Project clause (prepended) — keys sanitised for injection-safety ---
   const projectKeys = [
@@ -228,13 +310,17 @@ export function buildJqlFromFilter(filter: StructuredFilter, vocab: LabelVocab):
   const priorityFragment = resolveSingleAxis(filter.priority, PRIORITY_FRAGMENTS, "priority", warnings);
   const recencyFragment = resolveSingleAxis(filter.recency, RECENCY_FRAGMENTS, "recency", warnings);
 
-  // --- Assemble: project AND feature AND flow AND symptom AND priority AND recency AND status ---
+  // --- Assemble (deterministic order): project → feature clause (non-colliding
+  // children + all feature buckets) → flow clause (non-colliding children + all
+  // flow buckets) → per-stem child-union clauses (sorted by stem) → symptom →
+  // priority → recency → status ---
   const clauses: string[] = [];
   if (projectKeys.length > 0) {
     clauses.push(`project in (${projectKeys.join(",")})`);
   }
-  if (featureLabels.length > 0) clauses.push(labelsInClause(featureLabels));
-  if (flowLabels.length > 0) clauses.push(labelsInClause(flowLabels));
+  if (featureClauseLabels.length > 0) clauses.push(labelsInClause(featureClauseLabels));
+  if (flowClauseLabels.length > 0) clauses.push(labelsInClause(flowClauseLabels));
+  for (const c of unionClauses) clauses.push(c);
   if (symptomLabels.length > 0) clauses.push(labelsInClause(symptomLabels));
   if (priorityFragment !== null) clauses.push(priorityFragment);
   if (recencyFragment !== null) clauses.push(recencyFragment);

--- a/src/jira/labelVocab.ts
+++ b/src/jira/labelVocab.ts
@@ -12,15 +12,32 @@ import { LabelVocab } from "./jqlFromFilter";
  * Build the `LabelVocab` from a catalog + (optionally overridden) symptom set.
  * Reuses `membershipFromCatalog` so the feature/flow id sets are derived exactly
  * as the label writer derives them — one source of truth, no drift.
+ *
+ * The optional `parentOf` map (#1385, full child id → lean BUCKET id) is threaded
+ * through, and the DISTINCT lean bucket ids it points to are split by axis prefix
+ * (`feature-`/`flow-`) into `featureBucketIds`/`flowBucketIds` so the builder can
+ * accept a family/bucket name as input. Absent map → empty bucket sets (behaviour
+ * identical to pre-#1385).
  */
 export function buildVocab(
   catalog: CatalogIdSource,
   symptoms: readonly string[] = DEFECT_CATEGORIES,
+  parentOf?: ReadonlyMap<string, string>,
 ): LabelVocab {
-  const membership = membershipFromCatalog(catalog);
+  const membership = membershipFromCatalog(catalog, parentOf);
+  const featureBucketIds = new Set<string>();
+  const flowBucketIds = new Set<string>();
+  if (parentOf) {
+    for (const leanId of parentOf.values()) {
+      if (leanId.startsWith("feature-")) featureBucketIds.add(leanId);
+      else if (leanId.startsWith("flow-")) flowBucketIds.add(leanId);
+    }
+  }
   return {
     symptoms: new Set(symptoms),
     featureIds: membership.featureIds,
     flowIds: membership.flowIds,
+    featureBucketIds,
+    flowBucketIds,
   };
 }

--- a/src/jira/nlFilterMapper.ts
+++ b/src/jira/nlFilterMapper.ts
@@ -209,6 +209,13 @@ function buildSystemPrompt(vocab: LabelVocab): string {
   const symptoms = [...vocab.symptoms].sort();
   const features = [...vocab.featureIds].map((id) => id.replace(/^feature-/, "")).sort();
   const flows = [...vocab.flowIds].map((id) => id.replace(/^flow-/, "")).sort();
+  // #1385 — lean family/bucket slugs the LLM may ALSO echo (a family name returns
+  // the WHOLE family). Names come from the injected vocab at runtime (PUBLIC repo:
+  // no real bucket names are hardcoded here). Empty/absent → "(none)", a no-op.
+  const featureFamilies = [...(vocab.featureBucketIds ?? [])]
+    .map((id) => id.replace(/^feature-/, ""))
+    .sort();
+  const flowFamilies = [...(vocab.flowBucketIds ?? [])].map((id) => id.replace(/^flow-/, "")).sort();
   return [
     "You translate an English question about software defects into a JSON filter.",
     "Answer with a SINGLE JSON object and NOTHING else (no prose, no code fences).",
@@ -217,7 +224,10 @@ function buildSystemPrompt(vocab: LabelVocab): string {
     `Allowed symptoms: ${symptoms.length > 0 ? symptoms.join(", ") : "(none)"}`,
     "Map generic symptom words to the closest allowed symptom slug — e.g. crash/freeze/hang/error/bug/exception → crash-error; cannot/can't/unable/fails/blocked → cannot-complete; wrong/incorrect/mismatch/duplicate → data-incorrect; missing/blank/empty/not shown → missing-element; layout/button/font/colour/UI → display-ui; navigate/redirect/back button → navigation-flow; slow/lag/delay/timeout → performance.",
     `Allowed features: ${features.length > 0 ? features.join(", ") : "(none)"}`,
+    `Allowed feature families: ${featureFamilies.length > 0 ? featureFamilies.join(", ") : "(none)"}`,
     `Allowed flows: ${flows.length > 0 ? flows.join(", ") : "(none)"}`,
+    `Allowed flow families: ${flowFamilies.length > 0 ? flowFamilies.join(", ") : "(none)"}`,
+    "A family/bucket name on the feature or flow axis returns the WHOLE family — use a family name only when the question names a broad area rather than one specific feature/flow; otherwise prefer the specific name. Do NOT name the SAME concept on both the feature and flow axes — pick the one axis that fits.",
     "projects is a list of UPPERCASE Jira project keys mentioned in the question (e.g. DEMO); empty if none.",
     `priority is exactly ONE token from [${PRIORITY_TOKENS.join(", ")}] when the question implies priority (high priority/critical/urgent); empty string otherwise.`,
     `recency is exactly ONE token from [${RECENCY_TOKENS.join(", ")}] when the question implies a time window (this week/last release/latest); empty string otherwise.`,

--- a/src/jira/nlToJql.ts
+++ b/src/jira/nlToJql.ts
@@ -30,6 +30,11 @@ export interface AnswerNlQueryDeps {
    * / empty → behaviour unchanged.
    */
   defaultProjects?: string[];
+  /**
+   * #1392 cross-axis-union knob, forwarded to the pure builder. Default `true`
+   * (the recall-restoring union). `false` → legacy pure-AND across axes.
+   */
+  crossAxisUnion?: boolean;
 }
 
 export interface NlQueryResult {
@@ -58,7 +63,9 @@ export async function answerNlQuery(
   const scopedFilter = needsDefault
     ? { ...filter, projects: deps.defaultProjects! }
     : filter;
-  const { jql, warnings } = buildJqlFromFilter(scopedFilter, deps.vocab);
+  const { jql, warnings } = buildJqlFromFilter(scopedFilter, deps.vocab, {
+    crossAxisUnion: deps.crossAxisUnion ?? true,
+  });
   const result: NlQueryResult = { jql, warnings, filter: scopedFilter };
   if (deps.run && deps.search) {
     result.issues = await deps.search.search(jql);

--- a/tests/answerJql.test.ts
+++ b/tests/answerJql.test.ts
@@ -10,7 +10,11 @@
  * privacy gate. Do NOT "fix" this back to the Atlassian-host form. See the plan's
  * privacy gate + plan-review MUST-fix #2.
  */
-import { buildAnswerJql } from "../src/jira/answerJql";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+import { buildAnswerJql, loadFullToLeanMap } from "../src/jira/answerJql";
 import { JiraIssue, JqlSearchFetcher } from "../src/jira/sync";
 
 const SYNTHETIC_CREDS = {
@@ -84,5 +88,90 @@ describe("buildAnswerJql (#1346 wiring)", () => {
       issues: [],
       warnings: ["Jira credentials are not configured."],
     });
+  });
+
+  it("#1392 — JQL_CROSS_AXIS_UNION=0 still runs with no throw (legacy path wired)", async () => {
+    const fakeSearch = { search: jest.fn(async () => []) };
+    const env = { ...SYNTHETIC_CREDS, JQL_CROSS_AXIS_UNION: "0" } as NodeJS.ProcessEnv;
+    const answer = buildAnswerJql({ env, search: fakeSearch });
+    const reply = await answer("show me crashes");
+    expect(typeof reply.jql).toBe("string");
+    expect(reply.jql.length).toBeGreaterThan(0);
+    expect(fakeSearch.search).toHaveBeenCalledTimes(1);
+  });
+
+  it("#1385 AC6 — an ABSENT map file leaves output identical to pre-change (forward-compat, no throw)", async () => {
+    const fakeSearch = { search: jest.fn(async () => []) };
+    const missingMap = path.join(os.tmpdir(), "does-not-exist-full-to-lean.json");
+    const withMissing = buildAnswerJql({
+      env: SYNTHETIC_CREDS,
+      search: fakeSearch,
+      mapPath: missingMap,
+    });
+    const baseline = buildAnswerJql({ env: SYNTHETIC_CREDS, search: fakeSearch });
+    const a = await withMissing("show me crashes");
+    const b = await baseline("show me crashes");
+    expect(a.jql).toBe(b.jql);
+  });
+
+  it("#1385 — a synthetic map at mapPath loads without throw and still answers", async () => {
+    const fakeSearch = { search: jest.fn(async () => []) };
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "jql-map-"));
+    const mapPath = path.join(dir, "full-to-lean-map.json");
+    fs.writeFileSync(
+      mapPath,
+      JSON.stringify({
+        features: { "feature-widget": "feature-platform" },
+        flows: { "flow-onboarding": "flow-platform" },
+      }),
+    );
+    try {
+      const answer = buildAnswerJql({ env: SYNTHETIC_CREDS, search: fakeSearch, mapPath });
+      const reply = await answer("show me crashes");
+      expect(typeof reply.jql).toBe("string");
+      expect(reply.jql.length).toBeGreaterThan(0);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("loadFullToLeanMap (#1385 parse seam)", () => {
+  it("merges the features + flows sections into ONE flat parentOf map", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "jql-map-parse-"));
+    const mapPath = path.join(dir, "full-to-lean-map.json");
+    fs.writeFileSync(
+      mapPath,
+      JSON.stringify({
+        features: { "feature-widget": "feature-platform", "feature-onboarding": "feature-platform" },
+        flows: { "flow-checkout": "flow-core" },
+        unmapped: ["feature-orphan"],
+      }),
+    );
+    try {
+      const m = loadFullToLeanMap(mapPath);
+      expect(m.get("feature-widget")).toBe("feature-platform");
+      expect(m.get("feature-onboarding")).toBe("feature-platform");
+      expect(m.get("flow-checkout")).toBe("flow-core");
+      expect(m.size).toBe(3); // `unmapped` section is ignored.
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("an ABSENT file ⇒ an EMPTY map, never throws", () => {
+    const missing = path.join(os.tmpdir(), "absolutely-missing-map.json");
+    expect(loadFullToLeanMap(missing).size).toBe(0);
+  });
+
+  it("a MALFORMED file ⇒ an EMPTY map, never throws", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "jql-map-bad-"));
+    const mapPath = path.join(dir, "full-to-lean-map.json");
+    fs.writeFileSync(mapPath, "{ this is not json");
+    try {
+      expect(loadFullToLeanMap(mapPath).size).toBe(0);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
   });
 });

--- a/tests/jqlFromFilter.test.ts
+++ b/tests/jqlFromFilter.test.ts
@@ -216,3 +216,192 @@ describe("#1364 — priority / recency closed-enum axes", () => {
     expect(warnings.join(" ")).toMatch(/unknown recency/i);
   });
 });
+
+/**
+ * #1392 (Rule A) cross-axis same-stem union + #1385 (Rule B) full↔lean vocab.
+ *
+ * SYNTHETIC vocab ONLY. `VOCAB_UNION` holds feature/flow CHILDREN that can collide
+ * by stem (`onboarding`, `checkout`) plus a flow CHILD `flow-platform` and a
+ * feature BUCKET `feature-platform` so the bucket-vs-same-slug-child composition
+ * (AC4b) is exercised. `VOCAB_FAMILIES` carries platform on BOTH bucket axes only.
+ */
+const VOCAB_UNION: LabelVocab = {
+  symptoms: new Set(DEFECT_CATEGORIES),
+  featureIds: new Set(["feature-widget", "feature-onboarding", "feature-checkout"]),
+  flowIds: new Set(["flow-onboarding", "flow-checkout", "flow-platform"]),
+  featureBucketIds: new Set(["feature-platform"]),
+  flowBucketIds: new Set<string>(),
+};
+
+const VOCAB_FAMILIES: LabelVocab = {
+  symptoms: new Set(DEFECT_CATEGORIES),
+  featureIds: new Set(["feature-widget"]),
+  flowIds: new Set(["flow-onboarding"]),
+  featureBucketIds: new Set(["feature-platform"]),
+  flowBucketIds: new Set(["flow-platform"]),
+};
+
+describe("#1392 Rule A — same-stem CHILD cross-axis union", () => {
+  it("AC2 — feature+flow children sharing a stem merge into ONE OR-clause, not two AND clauses", () => {
+    const { jql } = buildJqlFromFilter(
+      filter({ features: ["onboarding"], flows: ["onboarding"] }),
+      VOCAB_UNION,
+    );
+    // ONE merged union clause (recall), sorted feature-before-flow.
+    expect(jql).toContain('labels in ("mb-feature-onboarding","mb-flow-onboarding")');
+    // NOT the legacy two-AND intersection form.
+    expect(jql).not.toContain(
+      'labels in ("mb-feature-onboarding") AND labels in ("mb-flow-onboarding")',
+    );
+    expect(jql).toContain("statusCategory != Done");
+  });
+
+  it("AC5 — crossAxisUnion:false reverts to the legacy two-AND intersection (kill-switch)", () => {
+    const { jql } = buildJqlFromFilter(
+      filter({ features: ["onboarding"], flows: ["onboarding"] }),
+      VOCAB_UNION,
+      { crossAxisUnion: false },
+    );
+    expect(jql).toContain(
+      'labels in ("mb-feature-onboarding") AND labels in ("mb-flow-onboarding")',
+    );
+    expect(jql).not.toContain('labels in ("mb-feature-onboarding","mb-flow-onboarding")');
+  });
+
+  it("symptom is NEVER merged — feature child + symptom stays a feature clause AND a symptom clause", () => {
+    const { jql } = buildJqlFromFilter(
+      filter({ features: ["widget"], symptoms: ["crash-error"] }),
+      VOCAB_UNION,
+    );
+    expect(jql).toBe(
+      'labels in ("mb-feature-widget") AND labels in ("mb-symptom-crash-error") AND statusCategory != Done',
+    );
+  });
+
+  it("AC3 — TWO DISTINCT areas (different stems) STILL AND (genuine intersection preserved)", () => {
+    const { jql } = buildJqlFromFilter(
+      filter({ features: ["onboarding"], flows: ["checkout"] }),
+      VOCAB_UNION,
+    );
+    expect(jql).toBe(
+      'labels in ("mb-feature-onboarding") AND labels in ("mb-flow-checkout") AND statusCategory != Done',
+    );
+  });
+
+  it("union + symptom together — area recall (one union clause) AND symptom precision", () => {
+    const { jql } = buildJqlFromFilter(
+      filter({ features: ["onboarding"], flows: ["onboarding"], symptoms: ["crash-error"] }),
+      VOCAB_UNION,
+    );
+    expect(jql).toBe(
+      'labels in ("mb-feature-onboarding","mb-flow-onboarding") AND labels in ("mb-symptom-crash-error") AND statusCategory != Done',
+    );
+  });
+
+  it("two distinct collisions ⇒ TWO union clauses ANDed, sorted by stem (checkout before onboarding)", () => {
+    const { jql } = buildJqlFromFilter(
+      filter({ features: ["onboarding", "checkout"], flows: ["onboarding", "checkout"] }),
+      VOCAB_UNION,
+    );
+    expect(jql).toBe(
+      'labels in ("mb-feature-checkout","mb-flow-checkout") AND labels in ("mb-feature-onboarding","mb-flow-onboarding") AND statusCategory != Done',
+    );
+  });
+});
+
+describe("#1385 Rule B — full child OR lean bucket vocabulary", () => {
+  it("AC4 — a feature-axis lean-bucket slug resolves to a mb-bucket-feature-* family clause", () => {
+    const { jql } = buildJqlFromFilter(filter({ features: ["platform"] }), VOCAB_FAMILIES);
+    expect(jql).toBe(
+      'labels in ("mb-bucket-feature-platform") AND statusCategory != Done',
+    );
+  });
+
+  it("AC4 — a flow-axis lean-bucket slug resolves to a mb-bucket-flow-* family clause", () => {
+    const { jql } = buildJqlFromFilter(filter({ flows: ["platform"] }), VOCAB_FAMILIES);
+    expect(jql).toBe('labels in ("mb-bucket-flow-platform") AND statusCategory != Done');
+  });
+
+  it("precedence — a full CHILD slug still resolves to mb-feature-* even when also a bucket id", () => {
+    const vocab: LabelVocab = {
+      symptoms: new Set(DEFECT_CATEGORIES),
+      featureIds: new Set(["feature-platform"]),
+      flowIds: new Set<string>(),
+      featureBucketIds: new Set(["feature-platform"]),
+      flowBucketIds: new Set<string>(),
+    };
+    const { jql } = buildJqlFromFilter(filter({ features: ["platform"] }), vocab);
+    expect(jql).toContain('labels in ("mb-feature-platform")');
+    expect(jql).not.toContain("mb-bucket-feature-platform");
+  });
+
+  it("NEG — a slug in NEITHER child nor bucket set (catalog populated) is dropped + axis-named warned, never echoed", () => {
+    const { jql, warnings } = buildJqlFromFilter(
+      filter({ features: ["ghostarea"] }),
+      VOCAB_FAMILIES,
+    );
+    expect(jql).toBe("statusCategory != Done");
+    expect(jql).not.toContain("ghostarea");
+    expect(warnings.join(" ")).toMatch(/unknown feature/i);
+    expect(warnings.join(" ")).not.toContain("ghostarea");
+  });
+
+  it("populated bucket set does NOT suppress the child-empty passthrough warning (gate keys off CHILD set)", () => {
+    const vocab: LabelVocab = {
+      symptoms: new Set(DEFECT_CATEGORIES),
+      featureIds: new Set<string>(), // CHILD set empty → forward-compat passthrough
+      flowIds: new Set<string>(),
+      featureBucketIds: new Set(["feature-platform"]),
+      flowBucketIds: new Set<string>(),
+    };
+    const { jql, warnings } = buildJqlFromFilter(filter({ features: ["widget"] }), vocab);
+    expect(jql).toContain('labels in ("mb-feature-widget")');
+    expect(warnings.join(" ")).toMatch(/feature labels not yet populated/i);
+  });
+});
+
+describe("#1392/#1385 composition — buckets NEVER enter a union (AC4b, the resolved gap)", () => {
+  it("AC4b — feature BUCKET + flow CHILD with the same residual slug do NOT merge (exact two-AND form)", () => {
+    // featureBucketIds has feature-platform; flowIds (CHILD) has flow-platform.
+    const first = buildJqlFromFilter(
+      filter({ features: ["platform"], flows: ["platform"] }),
+      VOCAB_UNION,
+    );
+    expect(first.jql).toBe(
+      'labels in ("mb-bucket-feature-platform") AND labels in ("mb-flow-platform") AND statusCategory != Done',
+    );
+    // The merge substring MUST be ABSENT — a four-namespace stripper would emit it.
+    expect(first.jql).not.toContain('mb-bucket-feature-platform","mb-flow-platform');
+    // Determinism — a second call is byte-identical.
+    const second = buildJqlFromFilter(
+      filter({ features: ["platform"], flows: ["platform"] }),
+      VOCAB_UNION,
+    );
+    expect(second.jql).toBe(first.jql);
+    expect(second.warnings).toEqual(first.warnings);
+  });
+
+  it("a bucket on one axis + a DIFFERENT-stem child union on the other still compose (bucket never absorbed)", () => {
+    // feature platform → bucket; feature/flow checkout → child union; buckets stay put.
+    const { jql } = buildJqlFromFilter(
+      filter({ features: ["platform", "checkout"], flows: ["checkout"] }),
+      VOCAB_UNION,
+    );
+    expect(jql).toBe(
+      'labels in ("mb-bucket-feature-platform") AND labels in ("mb-feature-checkout","mb-flow-checkout") AND statusCategory != Done',
+    );
+  });
+
+  it("determinism — a union build is byte-identical across repeated calls", () => {
+    const f = filter({
+      features: ["onboarding", "checkout"],
+      flows: ["onboarding", "checkout"],
+      symptoms: ["crash-error"],
+      projects: ["DEMO"],
+    });
+    const a = buildJqlFromFilter(f, VOCAB_UNION);
+    const b = buildJqlFromFilter(f, VOCAB_UNION);
+    expect(a.jql).toBe(b.jql);
+    expect(a.warnings).toEqual(b.warnings);
+  });
+});

--- a/tests/labelVocab.test.ts
+++ b/tests/labelVocab.test.ts
@@ -1,0 +1,39 @@
+import { buildVocab } from "../src/jira/labelVocab";
+import { CatalogIdSource } from "../src/jira/namespacedLabels";
+import { DEFECT_CATEGORIES } from "../src/triage/categorizeDefect";
+
+/**
+ * #1385 — `buildVocab` derives the lean BUCKET id sets from the optional
+ * full→lean `parentOf` map. SYNTHETIC ids only.
+ */
+
+const CATALOG: CatalogIdSource = {
+  features: [{ id: "feature-widget" }, { id: "feature-onboarding" }],
+  flows: [{ id: "flow-onboarding" }, { id: "flow-checkout" }],
+};
+
+describe("buildVocab (#1385 lean-bucket derivation)", () => {
+  it("splits the DISTINCT lean bucket ids by axis prefix into feature/flow bucket sets", () => {
+    const parentOf = new Map<string, string>([
+      ["feature-widget", "feature-platform"],
+      ["feature-onboarding", "feature-platform"], // duplicate lean id → deduped
+      ["flow-onboarding", "flow-platform"],
+      ["flow-checkout", "flow-core"],
+    ]);
+    const vocab = buildVocab(CATALOG, undefined, parentOf);
+
+    expect([...(vocab.featureBucketIds ?? [])].sort()).toEqual(["feature-platform"]);
+    expect([...(vocab.flowBucketIds ?? [])].sort()).toEqual(["flow-core", "flow-platform"]);
+    // Child id sets are unchanged.
+    expect(vocab.featureIds.has("feature-widget")).toBe(true);
+    expect(vocab.flowIds.has("flow-checkout")).toBe(true);
+    // Symptom default still applied.
+    expect([...vocab.symptoms].sort()).toEqual([...DEFECT_CATEGORIES].sort());
+  });
+
+  it("absent parentOf ⇒ EMPTY bucket sets (behaviour identical to pre-#1385)", () => {
+    const vocab = buildVocab(CATALOG);
+    expect([...(vocab.featureBucketIds ?? [])]).toEqual([]);
+    expect([...(vocab.flowBucketIds ?? [])]).toEqual([]);
+  });
+});

--- a/tests/nlToJql.test.ts
+++ b/tests/nlToJql.test.ts
@@ -128,3 +128,39 @@ describe("answerNlQuery — default-project scoping (#1363)", () => {
     expect(original.projects).toEqual([]);
   });
 });
+
+describe("answerNlQuery — crossAxisUnion forwarded to the builder (#1392)", () => {
+  const UNION_VOCAB: LabelVocab = {
+    symptoms: new Set(DEFECT_CATEGORIES),
+    featureIds: new Set(["feature-onboarding"]),
+    flowIds: new Set(["flow-onboarding"]),
+  };
+  const SAME_STEM_FILTER: StructuredFilter = {
+    symptoms: [],
+    features: ["onboarding"],
+    flows: ["onboarding"],
+    projects: [],
+  };
+
+  it("default (crossAxisUnion absent) ⇒ ONE merged union clause in the result JQL", async () => {
+    const result = await answerNlQuery("onboarding issues", {
+      mapper: stubMapper(SAME_STEM_FILTER),
+      vocab: UNION_VOCAB,
+    });
+    expect(result.jql).toContain('labels in ("mb-feature-onboarding","mb-flow-onboarding")');
+    expect(result.jql).not.toContain(
+      'labels in ("mb-feature-onboarding") AND labels in ("mb-flow-onboarding")',
+    );
+  });
+
+  it("crossAxisUnion:false ⇒ the legacy two-AND clauses in the result JQL", async () => {
+    const result = await answerNlQuery("onboarding issues", {
+      mapper: stubMapper(SAME_STEM_FILTER),
+      vocab: UNION_VOCAB,
+      crossAxisUnion: false,
+    });
+    expect(result.jql).toContain(
+      'labels in ("mb-feature-onboarding") AND labels in ("mb-flow-onboarding")',
+    );
+  });
+});


### PR DESCRIPTION
## Summary
Two `/jql` composition fixes, one branch.

**#1392 — over-constrain (AND→OR):** when one named area resolves to multiple label axes (a feature CHILD and a flow CHILD sharing a stem), the query ANDed them → silent recall loss. Adds a CHILD-only same-stem union: feature+flow child labels with an identical namespace-stripped stem merge into one `labels in (a,b)` OR-clause; distinct stems still AND; symptom labels never merged; bucket labels (`mb-bucket-*`) are structurally excluded from the union (candidacy pinned to `mb-feature-`/`mb-flow-`). Rule B strict precedence: child → bucket → child-empty passthrough → drop, with the empty-catalog forward-compat warning keyed on the child set only.

**#1385 — full/lean vocab:** wires the previously-unused full↔lean map so `/jql` accepts both vocabularies.

Knobs (default ON): `JQL_CROSS_AXIS_UNION`, `JQL_ACCEPT_LEAN_VOCAB` (lean is data-gated — a no-op when the map is absent/empty, never throws).

## Test plan
- New/extended suites: jqlFromFilter (AC4b exact two-AND-clause form + absence of the merge substring for the bucket-vs-same-slug-child case + determinism), labelVocab, nlToJql (knob forwarding), answerJql (knob=0 no-throw, absent-map forward-compat, map parse seam).
- Full jest: 568/568 (58 suites); build + `tsc --noEmit` clean; privacy grep over the 9-file delta: 0.

https://claude.ai/code/session_01R5rpgymipJKn4AhCTmsYpD