### PR TITLE
chore: release 0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [0.15.0](https://github.com/ziyilam3999/monday-bot/compare/v0.14.0...v0.15.0) (2026-06-30)
+
+### Bug Fixes
+
+- fix: /jql cross-axis child-stem union + full/lean vocab — same-named area across feature+flow axes now ORs instead of over-constraining; accepts both full and lean vocabulary (#1392, #1385) (#260)
+- fix: /ask how-to intent classifier tolerates hyphen/glued spelling — "how-to"/"howto" now answer like "how to" (#1393) (#259)
+
 ## [0.14.0](https://github.com/ziyilam3999/monday-bot/compare/v0.13.0...v0.14.0) (2026-06-30)
 
 ### Features

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "monday-bot",
-  "version": "0.13.0",
+  "version": "0.15.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "monday-bot",
-      "version": "0.13.0",
+      "version": "0.15.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.90.0",
         "@slack/bolt": "^4.7.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "monday-bot",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "Team Slack knowledge assistant — answers from internal documents with cited, fact-based summaries.",
   "private": true,
   "type": "commonjs",


### PR DESCRIPTION
## Summary
Single release bundling the three UAT follow-up fixes shipped after v0.14.0:

- **#1393** (PR #259) — `/ask` how-to intent classifier tolerates hyphen/glued spelling.
- **#1392** (PR #260) — `/jql` cross-axis child-stem union (AND→OR for one named area resolving to multiple label axes).
- **#1385** (PR #260) — `/jql` accepts both full and lean vocabulary.

Version bump 0.14.0 → 0.15.0, CHANGELOG prepended.

release-pr: true

https://claude.ai/code/session_01R5rpgymipJKn4AhCTmsYpD