### PR TITLE
feat: label-aware /ask surfaces tagged Jira defects for named feature/flow areas (#1386)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ import { JiraFetcher } from "./jira/sync";
 import { SlackAdapter, AppFactory } from "./slack/adapter";
 import { AdminService } from "./slack/commands";
 import { buildAnswerJql } from "./jira/answerJql";
+import { buildAskJiraAugment } from "./jira/askAreaAugment";
 
 export interface RunMondayOptions {
   /** Override Bolt App factory (jest tests + AC-06 shell-spawn path). */
@@ -263,6 +264,11 @@ export async function runMonday(opts: RunMondayOptions = {}): Promise<RunMondayH
       knowledgeService: knowledge,
       adminService,
       appFactory,
+      // #1386 — label-aware /ask. Built once at startup like buildAnswerJql, but
+      // caches NOTHING data-gated: the returned closure re-reads the catalog +
+      // rebuilds the vocab on EVERY /ask, so label-awareness activates with no
+      // restart the moment the catalog lands (in lockstep with /jql).
+      askAugment: buildAskJiraAugment({ env: process.env }),
     });
   } catch (err) {
     return handleStartupError(err);

--- a/src/jira/answerJql.ts
+++ b/src/jira/answerJql.ts
@@ -115,8 +115,12 @@ export function loadFullToLeanMap(mapPath?: string): Map<string, string> {
  * Read an env flag that defaults ON (#1385/#1392 knobs). Any value except `"0"`
  * / `"false"` (case-insensitive, trimmed) keeps the feature ON; an UNSET flag is
  * ON. `=0`/`=false` is the explicit kill-switch.
+ *
+ * EXPORTED (#1386) — the single source of truth for the ON-by-default flag
+ * semantics shared by the `JQL_*` knobs and the new `ASK_LABEL_AWARE` kill-switch
+ * (`src/jira/askAreaAugment.ts`). One definition avoids a forked truth-table.
  */
-function envFlagOn(raw: string | undefined): boolean {
+export function envFlagOn(raw: string | undefined): boolean {
   if (raw === undefined) return true;
   const v = raw.trim().toLowerCase();
   return v !== "0" && v !== "false";

--- a/src/jira/askAreaAugment.ts
+++ b/src/jira/askAreaAugment.ts
@@ -1,0 +1,234 @@
+/**
+ * Label-aware `/ask` augment (#1386) — bridges the doc Q&A path to the SAME
+ * tagged-Jira-defect resolver the `/jql` command uses, WITHOUT perturbing the
+ * cited doc answer.
+ *
+ * When an `/ask` question genuinely names a known feature/flow area (validated as
+ * an ACTUAL catalog member — child or lean bucket), this surfaces that area's
+ * tagged defects as an APPENDED block after the doc answer. When no known area is
+ * named, or the kill-switch is off, or the catalog/creds have not landed, the
+ * augment resolves to `null` and `/ask` is byte-identical to today.
+ *
+ * Design (mirrors `buildAnswerJql` — `src/jira/answerJql.ts`):
+ *   - The factory does the BARE MINIMUM at build time: read the static kill-switch
+ *     and close over `deps`. ALL catalog/vocab/mapper/search/Jira I/O lives inside
+ *     the per-call closure, so `/ask` re-reads the catalog on EVERY call and flips
+ *     to active the instant the data-gated catalog lands — in lockstep with `/jql`,
+ *     no restart needed (B1).
+ *   - The whole closure body is wrapped in one try/catch and NEVER throws (returns
+ *     `null` on any error — creds, catalog read, vocab build, mapper LLM, Jira GET).
+ *
+ * PUBLIC repo: creds flow via env ONLY and are never logged/echoed/committed. No
+ * value-bearing logs (preserves the axis-only warning discipline).
+ */
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+import { parseDefaultProjects } from "../config/env";
+import { slug } from "../catalog/slug";
+import { JqlReplyIssue } from "../slack/commands";
+import { buildVocab } from "./labelVocab";
+import { buildLlmFilterMapper, NlFilterMapper } from "./nlFilterMapper";
+import { CatalogIdSource } from "./namespacedLabels";
+import { buildJqlSearchFetcher, JqlSearchFetcher } from "./sync";
+import { answerNlQuery } from "./nlToJql";
+import { LabelVocab, StructuredFilter } from "./jqlFromFilter";
+import { BuildAnswerJqlDeps, envFlagOn, loadFullToLeanMap } from "./answerJql";
+
+/** The full default cap on surfaced defect bullets (`ASK_DEFECTS_MAX`). */
+const DEFAULT_ASK_DEFECTS_MAX = 5;
+
+/**
+ * The result the augment resolves to when an area IS named, validated, and has
+ * tracked defects. `issues` is the FULL matched set — the visible cap (and the
+ * `…and N more` overflow affordance) is applied downstream in the formatter.
+ */
+export interface AskAugmentResult {
+  jql: string;
+  issues: JqlReplyIssue[];
+}
+
+/**
+ * Injectable seams for `buildAskJiraAugment`. Mirrors `BuildAnswerJqlDeps` plus an
+ * optional `mapper` override so the per-call closure can be unit-tested with ZERO
+ * network (a fake mapper + injected `search`).
+ */
+export type BuildAskAugmentDeps = BuildAnswerJqlDeps & { mapper?: NlFilterMapper };
+
+/**
+ * Strip a trailing `/wiki` (and trailing slash) so the site root feeds Jira REST.
+ *
+ * INLINE-MIRROR of the module-private `toSiteRoot` in `src/jira/answerJql.ts:56`
+ * (itself a deliberate inline-mirror of `src/knowledge/startup.ts:83`). Re-inlining
+ * keeps the `jira/` module self-contained and the strip one-liner identical, and
+ * adds no new export edge.
+ */
+function toSiteRoot(url: string): string {
+  return url.replace(/\/wiki\/?$/, "").replace(/\/$/, "");
+}
+
+/**
+ * Read the gitignored catalog (or an empty catalog if absent / unreadable).
+ *
+ * INLINE-MIRROR of the module-private `loadCatalog` in `src/jira/answerJql.ts:71`.
+ * Tiny never-throws JSON read anchored at `process.cwd()` (the repo root for the
+ * production launch `node dist/index.js`). Any other cwd / a missing catalog safely
+ * degrades to the empty-catalog fallback. NEVER throws.
+ */
+function loadCatalog(catalogPath?: string): CatalogIdSource {
+  const resolved =
+    catalogPath ??
+    path.resolve(process.cwd(), ".ai-workspace", "catalog", "feature-catalog.json");
+  try {
+    const raw = JSON.parse(fs.readFileSync(resolved, "utf8"));
+    return {
+      features: Array.isArray(raw.features) ? raw.features : [],
+      flows: Array.isArray(raw.flows) ? raw.flows : [],
+    };
+  } catch {
+    return { features: [], flows: [] };
+  }
+}
+
+/**
+ * Parse the `ASK_DEFECTS_MAX` integer knob (caps the visible defect bullets).
+ *
+ * INTEGER parse (NOT `envFlagOn` — this is a count, not a boolean): `parseInt`
+ * base-10, with a `NaN` / `< 1` fall back to the default `5`, and a `Math.floor`
+ * + clamp to a sane ceiling. Mirrors the `parseDefaultProjects` standalone-helper
+ * style so the parse seam is unit-testable in isolation.
+ */
+export function parseAskDefectsMax(raw: string | undefined): number {
+  const CEILING = 50;
+  const n = parseInt((raw ?? "").trim(), 10);
+  if (Number.isNaN(n) || n < 1) return DEFAULT_ASK_DEFECTS_MAX;
+  return Math.min(Math.floor(n), CEILING);
+}
+
+/**
+ * PURE, zero-I/O precision bar: which named areas in `filter` are ACTUAL catalog
+ * members (child OR lean bucket). Mirrors `resolveCatalogAxis`'s child/bucket
+ * membership test (`jqlFromFilter.ts`) but MEMBERSHIP-ONLY — there is NO
+ * forward-compat passthrough, so a value on an EMPTY catalog never counts, and a
+ * symptom-only / empty filter returns `[]`. Returns the matched slugs.
+ */
+export function resolveCatalogMatches(filter: StructuredFilter, vocab: LabelVocab): string[] {
+  const matched: string[] = [];
+  const check = (
+    values: readonly string[] | undefined,
+    childIds: ReadonlySet<string>,
+    bucketIds: ReadonlySet<string> | undefined,
+    idPrefix: string,
+  ): void => {
+    for (const raw of values ?? []) {
+      const s = slug(raw ?? "");
+      if (s.length === 0) continue;
+      const id = `${idPrefix}${s}`;
+      if (childIds.has(id) || (bucketIds?.has(id) ?? false)) matched.push(s);
+    }
+  };
+  check(filter.features, vocab.featureIds, vocab.featureBucketIds, "feature-");
+  check(filter.flows, vocab.flowIds, vocab.flowBucketIds, "flow-");
+  return matched;
+}
+
+/**
+ * Build the per-`/ask` Jira augment. The factory reads ONLY the static kill-switch
+ * (`ASK_LABEL_AWARE`, default ON) at build time; everything data-gated lives in the
+ * returned per-call closure (B1), so label-awareness activates the instant the
+ * catalog + creds land — no restart.
+ *
+ * Returns `async (question) => AskAugmentResult | null`. Resolves to `null` (and
+ * makes ZERO extra Jira/LLM calls) whenever: the switch is off, creds are missing,
+ * the catalog is empty, the lexical pre-gate misses, no named area is a catalog
+ * member, the Jira search errors, or the search returns no issues. NEVER throws.
+ */
+export function buildAskJiraAugment(
+  deps: BuildAskAugmentDeps,
+): (question: string) => Promise<AskAugmentResult | null> {
+  // Build-time: the ONLY static read. Kill-switch off → a no-op closure that
+  // makes zero downstream calls.
+  if (!envFlagOn(deps.env.ASK_LABEL_AWARE)) {
+    return async () => null;
+  }
+
+  return async function askAugment(question: string): Promise<AskAugmentResult | null> {
+    try {
+      // Creds — short-circuit BEFORE building any fetcher (mirror answerJql).
+      const url = deps.env.CONFLUENCE_URL ?? deps.env.CONFLUENCE_BASE_URL;
+      const email = deps.env.CONFLUENCE_EMAIL;
+      const apiToken = deps.env.CONFLUENCE_API_TOKEN;
+      if (!url || !email || !apiToken) return null;
+
+      // Per-call catalog + vocab (re-read EVERY call → /jql lockstep, no restart).
+      const catalog = loadCatalog(deps.catalogPath);
+      const parentOf = envFlagOn(deps.env.JQL_ACCEPT_LEAN_VOCAB)
+        ? loadFullToLeanMap(deps.mapPath)
+        : undefined;
+      const vocab = buildVocab(catalog, undefined, parentOf);
+
+      // Empty-catalog short-circuit: no area can ever validate → don't call the
+      // mapper or Jira (keeps /ask byte-identical in today's empty-catalog state,
+      // now re-checked per call so it flips active the moment the catalog lands).
+      const featureBuckets = vocab.featureBucketIds ?? new Set<string>();
+      const flowBuckets = vocab.flowBucketIds ?? new Set<string>();
+      if (
+        vocab.featureIds.size === 0 &&
+        vocab.flowIds.size === 0 &&
+        featureBuckets.size === 0 &&
+        flowBuckets.size === 0
+      ) {
+        return null;
+      }
+
+      // Lexical pre-gate (COST short-circuit only — NOT the precision bar). The
+      // Haiku mapper stays behind it so English synonym → catalog label recall is
+      // preserved. Build the stem token set (strip the axis prefixes off child +
+      // bucket ids, then split hyphenated slugs into word tokens).
+      const stemTokens = new Set<string>();
+      const addStem = (id: string, prefix: string): void => {
+        const stem = id.startsWith(prefix) ? id.slice(prefix.length) : id;
+        for (const tok of stem.split("-")) if (tok.length > 0) stemTokens.add(tok);
+      };
+      for (const id of vocab.featureIds) addStem(id, "feature-");
+      for (const id of vocab.flowIds) addStem(id, "flow-");
+      for (const id of featureBuckets) addStem(id, "feature-");
+      for (const id of flowBuckets) addStem(id, "flow-");
+      // Guard: empty stem set → skip the pre-gate (belt-and-suspenders; the
+      // empty-catalog short-circuit already returned null above).
+      if (stemTokens.size > 0) {
+        const questionTokens = (question.toLowerCase().match(/[a-z0-9]+/g) ?? []);
+        const shares = questionTokens.some((t) => stemTokens.has(t));
+        if (!shares) return null;
+      }
+
+      // Compose the seams (engine unchanged; mapper injectable for tests).
+      const mapper = deps.mapper ?? buildLlmFilterMapper();
+      const search =
+        deps.search ??
+        buildJqlSearchFetcher(
+          { baseUrl: toSiteRoot(url), email, apiToken },
+          deps.fetchImpl ?? globalThis.fetch,
+        );
+
+      // Map English → StructuredFilter with run:false (map + build, NO search).
+      const res = await answerNlQuery(question, {
+        mapper,
+        vocab,
+        run: false,
+        defaultProjects: parseDefaultProjects(deps.env.JIRA_DEFAULT_PROJECTS),
+        crossAxisUnion: envFlagOn(deps.env.JQL_CROSS_AXIS_UNION),
+      });
+
+      // Precision bar: a named area must be an ACTUAL catalog member.
+      if (resolveCatalogMatches(res.filter, vocab).length === 0) return null;
+
+      // ONE read-only GET. Return the FULL matched set (the formatter caps).
+      const issues = await search.search(res.jql);
+      return issues.length > 0 ? { jql: res.jql, issues } : null;
+    } catch {
+      // Any I/O path degrades to null — /ask still answers from the doc payload.
+      return null;
+    }
+  };
+}

--- a/src/slack/adapter.ts
+++ b/src/slack/adapter.ts
@@ -1,5 +1,7 @@
 import { App, LogLevel } from "@slack/bolt";
 import { handleQuery } from "./queryHandler";
+import { formatAskDefectsBlocks } from "./formatter";
+import { AskAugmentResult, parseAskDefectsMax } from "../jira/askAreaAugment";
 import {
   AdminService,
   statusCommand,
@@ -43,6 +45,15 @@ export interface SlackAdapterOptions {
   appFactory?: AppFactory;
   /** Optional log level. Defaults to LogLevel.INFO. */
   logLevel?: LogLevel;
+  /**
+   * Optional label-aware `/ask` augment (#1386). When present, an `/ask` (or
+   * app_mention DOC-branch) question that names a known feature/flow area ALSO
+   * surfaces that area's tagged Jira defects, appended AFTER the cited doc answer.
+   * ABSENCE = today's behaviour (no defects block ever). NEVER perturbs the doc
+   * answer's citations or abstain logic — the augment only appends blocks, and a
+   * thrown/`null` augment leaves the reply unchanged.
+   */
+  askAugment?: (question: string) => Promise<AskAugmentResult | null>;
 }
 
 export type AppFactory = (opts: ConstructorParameters<typeof App>[0]) => App;
@@ -68,6 +79,7 @@ export class SlackAdapter {
   private readonly appToken: string;
   private readonly knowledgeService: AnswerProvider;
   private readonly adminService: AdminService;
+  private readonly askAugment?: (question: string) => Promise<AskAugmentResult | null>;
   private readonly app: App;
 
   constructor(opts: SlackAdapterOptions) {
@@ -97,6 +109,9 @@ export class SlackAdapter {
     // KnowledgeService's getStatus()), use it for /status-monday. Otherwise the admin
     // surface is empty and individual handlers degrade to "not configured".
     this.adminService = opts.adminService ?? (opts.knowledgeService as unknown as AdminService);
+    // #1386 — optional label-aware augment. Absent ⇒ today's behaviour (the
+    // augment is never invoked, no defects block ever appended).
+    this.askAugment = opts.askAugment;
 
     const factory: AppFactory = opts.appFactory ?? ((appOpts) => new App(appOpts));
     this.app = factory({
@@ -153,12 +168,23 @@ export class SlackAdapter {
           });
         } else {
           // handleQuery centralises the success/error split — never throws.
-          const payload = await handleQuery(question, this.knowledgeService);
+          // #1386 — run the label-aware augment CONCURRENTLY (no added latency);
+          // a thrown/null augment degrades to today's doc-only reply.
+          const [payload, augment] = await Promise.all([
+            handleQuery(question, this.knowledgeService),
+            this.askAugment ? this.askAugment(question).catch(() => null) : Promise.resolve(null),
+          ]);
+          const blocks = augment
+            ? [
+                ...(payload.blocks ?? []),
+                ...formatAskDefectsBlocks(augment, parseAskDefectsMax(process.env.ASK_DEFECTS_MAX)),
+              ]
+            : payload.blocks;
           await client?.chat?.postMessage?.({
             channel,
             thread_ts: threadTs,
             text: payload.text,
-            blocks: payload.blocks,
+            blocks,
           });
         }
       } catch (err) {
@@ -197,11 +223,22 @@ export class SlackAdapter {
       }
       try {
         // handleQuery centralises the success/error split — never throws.
-        const payload = await handleQuery(question, this.knowledgeService);
+        // #1386 — run the label-aware augment CONCURRENTLY (no added latency);
+        // a thrown/null augment degrades to today's doc-only reply.
+        const [payload, augment] = await Promise.all([
+          handleQuery(question, this.knowledgeService),
+          this.askAugment ? this.askAugment(question).catch(() => null) : Promise.resolve(null),
+        ]);
+        const blocks = augment
+          ? [
+              ...(payload.blocks ?? []),
+              ...formatAskDefectsBlocks(augment, parseAskDefectsMax(process.env.ASK_DEFECTS_MAX)),
+            ]
+          : payload.blocks;
         await respond?.({
           response_type: "ephemeral",
           text: payload.text,
-          blocks: payload.blocks,
+          blocks,
         });
       } catch (err) {
         // Should only fire if the Slack respond() call itself fails.

--- a/src/slack/formatter.ts
+++ b/src/slack/formatter.ts
@@ -211,3 +211,55 @@ export function formatAnswer(input: FormatAnswerInput): SlackMessagePayload {
     text: truncate(answer.length > 0 ? answer : "(no answer)", 1000),
   };
 }
+
+/** A single tracked defect surfaced under a label-aware `/ask` answer (#1386). */
+export interface AskDefectIssue {
+  key: string;
+  summary?: string;
+}
+
+/**
+ * PURE formatter for the label-aware `/ask` defects block (#1386). Renders the
+ * tagged-Jira defects an `/ask` question's named area resolved to, as blocks
+ * APPENDED after the cited doc answer — so it NEVER perturbs the citation
+ * numbering (`[1]…[N]`) or the abstain/refusal logic upstream.
+ *
+ * Layout (only when there are issues):
+ *   1. Divider (separates the defects from the doc answer + citation list).
+ *   2. Section block — `*Related tracked defects:*` followed by up to `max`
+ *      `• KEY — summary` bullet lines, plus a trailing `…and N more` line when the
+ *      matched issue count exceeds `max`.
+ *
+ * Emits NO `[N]` citation markers anywhere. Returns `[]` for empty/missing issues
+ * (so no empty "Related defects" block is ever appended).
+ */
+export function formatAskDefectsBlocks(
+  reply: { issues?: AskDefectIssue[] } | null | undefined,
+  max: number = 5,
+): SlackBlock[] {
+  const issues = reply && Array.isArray(reply.issues) ? reply.issues : [];
+  if (issues.length === 0) return [];
+
+  const cap = Number.isFinite(max) && max >= 1 ? Math.floor(max) : issues.length;
+  const shown = issues.slice(0, cap);
+  const lines = shown.map((it) => {
+    const key = sanitizeTitle(it.key ?? "");
+    const summary =
+      typeof it.summary === "string" && it.summary.length > 0
+        ? ` — ${sanitizeTitle(it.summary)}`
+        : "";
+    return `• ${key}${summary}`;
+  });
+
+  const overflow = issues.length - shown.length;
+  const bodyLines = ["*Related tracked defects:*", ...lines];
+  if (overflow > 0) bodyLines.push(`…and ${overflow} more`);
+
+  return [
+    { type: "divider" },
+    {
+      type: "section",
+      text: { type: "mrkdwn", text: truncate(bodyLines.join("\n"), MAX_SECTION_TEXT) },
+    },
+  ];
+}

--- a/tests/askAreaAugment.test.ts
+++ b/tests/askAreaAugment.test.ts
@@ -1,0 +1,337 @@
+/**
+ * Unit tests for the label-aware `/ask` augment (#1386) — bridges the doc Q&A
+ * path to the SAME tagged-Jira-defect resolver `/jql` uses, additively.
+ *
+ * ZERO network: the `mapper` + `search` seams are injected and `MONDAY_TEST_MODE=1`
+ * is set so even the fallback mapper is deterministic. SYNTHETIC fixtures only.
+ *
+ * NOTE ON SYNTHETIC HOSTS: these tests use `https://demo.example.com` (NOT the
+ * Atlassian-branded sandbox host) to avoid the AC9 privacy grep — same convention
+ * as `answerJql.test.ts`. Do NOT "fix" this back to the Atlassian-host form.
+ */
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+import {
+  buildAskJiraAugment,
+  parseAskDefectsMax,
+  resolveCatalogMatches,
+} from "../src/jira/askAreaAugment";
+import { NlFilterMapper } from "../src/jira/nlFilterMapper";
+import { LabelVocab, StructuredFilter } from "../src/jira/jqlFromFilter";
+import { buildVocab } from "../src/jira/labelVocab";
+import { JiraIssue, JqlSearchFetcher } from "../src/jira/sync";
+
+const SYNTHETIC_CREDS = {
+  CONFLUENCE_URL: "https://demo.example.com",
+  CONFLUENCE_EMAIL: "qa@example.com",
+  CONFLUENCE_API_TOKEN: "synthetic-token",
+} as unknown as NodeJS.ProcessEnv;
+
+/** A synthetic single-feature catalog (`feature-widget`). */
+const WIDGET_CATALOG = { features: [{ id: "feature-widget" }], flows: [] };
+
+/** Write a synthetic catalog JSON to a fresh temp path and return it. */
+function writeCatalog(obj: unknown): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "ask-augment-"));
+  const p = path.join(dir, "feature-catalog.json");
+  fs.writeFileSync(p, JSON.stringify(obj), "utf8");
+  return p;
+}
+
+/** A fake mapper returning a fixed StructuredFilter for ANY question. */
+function fakeMapper(filter: Partial<StructuredFilter>): NlFilterMapper {
+  return {
+    map: jest.fn(
+      async (): Promise<StructuredFilter> => ({
+        symptoms: [],
+        features: [],
+        flows: [],
+        projects: [],
+        ...filter,
+      }),
+    ),
+  };
+}
+
+function fakeSearch(issues: JiraIssue[]): JqlSearchFetcher & { search: jest.Mock } {
+  return { search: jest.fn(async (_jql: string) => issues) };
+}
+
+const DEMO_ISSUE: JiraIssue = {
+  key: "DEMO-1",
+  summary: "synthetic crash",
+  descriptionText: "",
+  commentTexts: [],
+};
+
+describe("askAreaAugment (#1386) — buildAskJiraAugment", () => {
+  let savedTestMode: string | undefined;
+
+  beforeEach(() => {
+    savedTestMode = process.env.MONDAY_TEST_MODE;
+    process.env.MONDAY_TEST_MODE = "1";
+  });
+
+  afterEach(() => {
+    if (savedTestMode === undefined) delete process.env.MONDAY_TEST_MODE;
+    else process.env.MONDAY_TEST_MODE = savedTestMode;
+    jest.restoreAllMocks();
+  });
+
+  it("detection true-positive: named known area + tagged defects ⇒ {jql, issues}, search once, no network", async () => {
+    const mapper = fakeMapper({ features: ["widget"] });
+    const search = fakeSearch([DEMO_ISSUE]);
+    const fetchSpy = jest.spyOn(globalThis, "fetch");
+
+    const augment = buildAskJiraAugment({
+      env: SYNTHETIC_CREDS,
+      mapper,
+      search,
+      catalogPath: writeCatalog(WIDGET_CATALOG),
+    });
+    const result = await augment("how do I use the widget area?");
+
+    expect(result).not.toBeNull();
+    expect(typeof result!.jql).toBe("string");
+    expect(result!.jql.length).toBeGreaterThan(0);
+    expect(result!.issues).toEqual([DEMO_ISSUE]);
+    expect(search.search).toHaveBeenCalledTimes(1);
+    expect(search.search).toHaveBeenCalledWith(result!.jql);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("true-negative (symptom-only): no area named ⇒ null, search NOT called", async () => {
+    const mapper = fakeMapper({ symptoms: ["crash-error"] });
+    const search = fakeSearch([DEMO_ISSUE]);
+
+    const augment = buildAskJiraAugment({
+      env: SYNTHETIC_CREDS,
+      mapper,
+      search,
+      catalogPath: writeCatalog(WIDGET_CATALOG),
+    });
+    // Question passes the lexical pre-gate (contains "widget") so the mapper IS
+    // consulted; the precision bar then drops the symptom-only filter.
+    const result = await augment("the widget keeps crashing");
+
+    expect(result).toBeNull();
+    expect(search.search).not.toHaveBeenCalled();
+  });
+
+  it("unknown-area drop (populated catalog): mapped area not a catalog member ⇒ null, search NOT called", async () => {
+    const mapper = fakeMapper({ features: ["not-in-catalog"] });
+    const search = fakeSearch([DEMO_ISSUE]);
+
+    const augment = buildAskJiraAugment({
+      env: SYNTHETIC_CREDS,
+      mapper,
+      search,
+      catalogPath: writeCatalog(WIDGET_CATALOG),
+    });
+    const result = await augment("question about the widget");
+
+    expect(result).toBeNull();
+    expect(search.search).not.toHaveBeenCalled();
+  });
+
+  it("empty-catalog short-circuit: empty catalog ⇒ null, mapper NOT called, search NOT called", async () => {
+    const mapper = fakeMapper({ features: ["widget"] });
+    const search = fakeSearch([DEMO_ISSUE]);
+
+    const augment = buildAskJiraAugment({
+      env: SYNTHETIC_CREDS,
+      mapper,
+      search,
+      catalogPath: writeCatalog({ features: [], flows: [] }),
+    });
+    const result = await augment("how do I use the widget area?");
+
+    expect(result).toBeNull();
+    expect((mapper.map as jest.Mock)).not.toHaveBeenCalled();
+    expect(search.search).not.toHaveBeenCalled();
+  });
+
+  it("per-call activation (B1): empty catalog first ⇒ null; same closure resolves once the catalog lands (no rebuild)", async () => {
+    const mapper = fakeMapper({ features: ["widget"] });
+    const search = fakeSearch([DEMO_ISSUE]);
+    const catalogPath = writeCatalog({ features: [], flows: [] });
+
+    const augment = buildAskJiraAugment({
+      env: SYNTHETIC_CREDS,
+      mapper,
+      search,
+      catalogPath,
+    });
+
+    // First call: empty catalog → null, mapper NOT called.
+    expect(await augment("how do I use the widget area?")).toBeNull();
+    expect((mapper.map as jest.Mock)).not.toHaveBeenCalled();
+
+    // Catalog lands (same path) — NO factory rebuild.
+    fs.writeFileSync(catalogPath, JSON.stringify(WIDGET_CATALOG), "utf8");
+
+    const result = await augment("how do I use the widget area?");
+    expect(result).not.toBeNull();
+    expect(result!.issues).toEqual([DEMO_ISSUE]);
+    expect((mapper.map as jest.Mock)).toHaveBeenCalledTimes(1);
+    expect(search.search).toHaveBeenCalledTimes(1);
+  });
+
+  it("kill-switch off (ASK_LABEL_AWARE=0): ⇒ null, mapper + search NOT called", async () => {
+    const mapper = fakeMapper({ features: ["widget"] });
+    const search = fakeSearch([DEMO_ISSUE]);
+
+    const augment = buildAskJiraAugment({
+      env: { ...SYNTHETIC_CREDS, ASK_LABEL_AWARE: "0" } as unknown as NodeJS.ProcessEnv,
+      mapper,
+      search,
+      catalogPath: writeCatalog(WIDGET_CATALOG),
+    });
+    const result = await augment("how do I use the widget area?");
+
+    expect(result).toBeNull();
+    expect((mapper.map as jest.Mock)).not.toHaveBeenCalled();
+    expect(search.search).not.toHaveBeenCalled();
+  });
+
+  it("Jira-error degrades gracefully: search.search throws ⇒ resolves null, NEVER throws", async () => {
+    const mapper = fakeMapper({ features: ["widget"] });
+    const search: JqlSearchFetcher = {
+      search: jest.fn(async () => {
+        throw new Error("jira boom");
+      }),
+    };
+
+    const augment = buildAskJiraAugment({
+      env: SYNTHETIC_CREDS,
+      mapper,
+      search,
+      catalogPath: writeCatalog(WIDGET_CATALOG),
+    });
+
+    await expect(augment("how do I use the widget area?")).resolves.toBeNull();
+  });
+
+  it("no-defects ⇒ no section: area matches but search returns [] ⇒ null", async () => {
+    const mapper = fakeMapper({ features: ["widget"] });
+    const search = fakeSearch([]);
+
+    const augment = buildAskJiraAugment({
+      env: SYNTHETIC_CREDS,
+      mapper,
+      search,
+      catalogPath: writeCatalog(WIDGET_CATALOG),
+    });
+    const result = await augment("how do I use the widget area?");
+
+    expect(result).toBeNull();
+    expect(search.search).toHaveBeenCalledTimes(1);
+  });
+
+  it("no creds (missing CONFLUENCE_API_TOKEN): ⇒ null, mapper + search NOT called", async () => {
+    const mapper = fakeMapper({ features: ["widget"] });
+    const search = fakeSearch([DEMO_ISSUE]);
+    const env = {
+      CONFLUENCE_URL: "https://demo.example.com",
+      CONFLUENCE_EMAIL: "qa@example.com",
+    } as unknown as NodeJS.ProcessEnv;
+
+    const augment = buildAskJiraAugment({
+      env,
+      mapper,
+      search,
+      catalogPath: writeCatalog(WIDGET_CATALOG),
+    });
+    const result = await augment("how do I use the widget area?");
+
+    expect(result).toBeNull();
+    expect((mapper.map as jest.Mock)).not.toHaveBeenCalled();
+    expect(search.search).not.toHaveBeenCalled();
+  });
+
+  it("bucket match (#1385 family): mapped family name resolves via featureBucketIds", async () => {
+    const mapper = fakeMapper({ features: ["platform"] });
+    const search = fakeSearch([DEMO_ISSUE]);
+    const catalogPath = writeCatalog(WIDGET_CATALOG);
+    const mapDir = fs.mkdtempSync(path.join(os.tmpdir(), "ask-augment-map-"));
+    const mapPath = path.join(mapDir, "full-to-lean-map.json");
+    fs.writeFileSync(
+      mapPath,
+      JSON.stringify({ features: { "feature-widget": "feature-platform" } }),
+      "utf8",
+    );
+
+    const augment = buildAskJiraAugment({
+      env: SYNTHETIC_CREDS,
+      mapper,
+      search,
+      catalogPath,
+      mapPath,
+    });
+    // Question shares the bucket stem "platform" so the lexical pre-gate passes.
+    const result = await augment("how does the platform area behave?");
+
+    expect(result).not.toBeNull();
+    expect(result!.issues).toEqual([DEMO_ISSUE]);
+    expect(search.search).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("askAreaAugment (#1386) — parseAskDefectsMax", () => {
+  it("unset ⇒ default 5", () => {
+    expect(parseAskDefectsMax(undefined)).toBe(5);
+  });
+  it('"3" ⇒ 3', () => {
+    expect(parseAskDefectsMax("3")).toBe(3);
+  });
+  it('non-numeric / "0" / "-2" ⇒ default 5', () => {
+    expect(parseAskDefectsMax("abc")).toBe(5);
+    expect(parseAskDefectsMax("0")).toBe(5);
+    expect(parseAskDefectsMax("-2")).toBe(5);
+  });
+  it("clamps to the ceiling", () => {
+    expect(parseAskDefectsMax("9999")).toBe(50);
+  });
+});
+
+describe("askAreaAugment (#1386) — resolveCatalogMatches (pure)", () => {
+  const vocab: LabelVocab = buildVocab(WIDGET_CATALOG);
+
+  const filter = (f: Partial<StructuredFilter>): StructuredFilter => ({
+    symptoms: [],
+    features: [],
+    flows: [],
+    projects: [],
+    ...f,
+  });
+
+  it("child hit returns the matched slug", () => {
+    expect(resolveCatalogMatches(filter({ features: ["widget"] }), vocab)).toEqual(["widget"]);
+  });
+
+  it("bucket hit matches via featureBucketIds", () => {
+    const leanVocab = buildVocab(
+      WIDGET_CATALOG,
+      undefined,
+      new Map([["feature-widget", "feature-platform"]]),
+    );
+    expect(resolveCatalogMatches(filter({ features: ["platform"] }), leanVocab)).toEqual([
+      "platform",
+    ]);
+  });
+
+  it("miss on a populated catalog returns []", () => {
+    expect(resolveCatalogMatches(filter({ features: ["nope"] }), vocab)).toEqual([]);
+  });
+
+  it("empty filter returns []", () => {
+    expect(resolveCatalogMatches(filter({}), vocab)).toEqual([]);
+  });
+
+  it("empty vocab (no passthrough) returns []", () => {
+    const emptyVocab = buildVocab({ features: [], flows: [] });
+    expect(resolveCatalogMatches(filter({ features: ["widget"] }), emptyVocab)).toEqual([]);
+  });
+});

--- a/tests/formatter.askDefects.test.ts
+++ b/tests/formatter.askDefects.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Unit tests for `formatAskDefectsBlocks` (#1386) — the PURE formatter that
+ * renders a label-aware `/ask` answer's tagged defects as APPENDED blocks. It must
+ * NEVER emit a `[N]` citation marker (citation-safety) and must honour the
+ * `ASK_DEFECTS_MAX` cap with a `…and N more` overflow affordance.
+ */
+import { formatAskDefectsBlocks, SlackSectionBlock } from "../src/slack/formatter";
+
+const CITATION_MARKER = /\[\d+\]/;
+
+function sectionText(blocks: ReturnType<typeof formatAskDefectsBlocks>): string {
+  const section = blocks.find((b) => b.type === "section") as SlackSectionBlock | undefined;
+  return section?.text.text ?? "";
+}
+
+describe("formatAskDefectsBlocks (#1386)", () => {
+  it("empty issues ⇒ []", () => {
+    expect(formatAskDefectsBlocks({ issues: [] })).toEqual([]);
+  });
+
+  it("missing issues / null reply ⇒ []", () => {
+    expect(formatAskDefectsBlocks({})).toEqual([]);
+    expect(formatAskDefectsBlocks(null)).toEqual([]);
+    expect(formatAskDefectsBlocks(undefined)).toEqual([]);
+  });
+
+  it("one+ issues ⇒ [divider, section] with a defects header + bullet, no [N] marker", () => {
+    const blocks = formatAskDefectsBlocks({
+      issues: [{ key: "DEMO-1", summary: "synthetic crash" }],
+    });
+    expect(blocks).toHaveLength(2);
+    expect(blocks[0]).toEqual({ type: "divider" });
+    const text = sectionText(blocks);
+    expect(text).toContain("Related tracked defects");
+    expect(text).toContain("• DEMO-1 — synthetic crash");
+    expect(text).not.toMatch(CITATION_MARKER);
+  });
+
+  it("omits the ' — summary' when a summary is absent", () => {
+    const text = sectionText(formatAskDefectsBlocks({ issues: [{ key: "DEMO-2" }] }));
+    expect(text).toContain("• DEMO-2");
+    expect(text).not.toContain("— ");
+  });
+
+  it("sanitizeTitle strips stray *, ~ and backtick from key + summary", () => {
+    const text = sectionText(
+      formatAskDefectsBlocks({ issues: [{ key: "DE*MO-3", summary: "a ~bad~ `title`" }] }),
+    );
+    expect(text).toContain("• DEMO-3 — a bad title");
+    // The bullet line itself carries no stray emphasis chars (the `*Related…*`
+    // header legitimately uses `*` for bold, so scope the check to the bullet).
+    const bullet = text.split("\n").find((l) => l.startsWith("• "))!;
+    expect(bullet).not.toMatch(/[*~`]/);
+  });
+
+  it("cap + overflow affordance: 8 issues, max=3 ⇒ 3 bullets + '…and 5 more'", () => {
+    const issues = Array.from({ length: 8 }, (_v, i) => ({
+      key: `DEMO-${i + 1}`,
+      summary: `issue ${i + 1}`,
+    }));
+    const text = sectionText(formatAskDefectsBlocks({ issues }, 3));
+    const bullets = text.split("\n").filter((l) => l.startsWith("• "));
+    expect(bullets).toHaveLength(3);
+    expect(text).toContain("…and 5 more");
+  });
+
+  it("no overflow line when max >= count", () => {
+    const issues = [
+      { key: "DEMO-1", summary: "a" },
+      { key: "DEMO-2", summary: "b" },
+    ];
+    const text = sectionText(formatAskDefectsBlocks({ issues }, 5));
+    const bullets = text.split("\n").filter((l) => l.startsWith("• "));
+    expect(bullets).toHaveLength(2);
+    expect(text).not.toContain("more");
+  });
+});

--- a/tests/slack-adapter.test.ts
+++ b/tests/slack-adapter.test.ts
@@ -455,3 +455,177 @@ describe("slack/adapter — start/stop", () => {
     expect(fakeApp._stopped).toBe(true);
   });
 });
+
+describe("slack/adapter — label-aware /ask augment (#1386)", () => {
+  type Block = { type: string; text?: { text: string } };
+
+  /** Abstain knowledge service: citation-free NO_CONTEXT-style answer. */
+  function abstainKnowledge(): AnswerProvider & { calls: string[] } {
+    const calls: string[] = [];
+    return {
+      calls,
+      async query(question: string) {
+        calls.push(question);
+        return {
+          answer: "I could not find anything about that in the indexed docs.",
+          citations: [],
+        };
+      },
+    };
+  }
+
+  const DEFECTS = [
+    { key: "DEMO-1", summary: "synthetic crash" },
+    { key: "DEMO-2", summary: "another synthetic issue" },
+  ];
+  const augmentReturning = (issues = DEFECTS) => async () => ({ jql: "JQL-X", issues });
+
+  /** Capture the blocks an /ask reply produced for a given adapter + question. */
+  async function askBlocks(adapter: SlackAdapter, text: string): Promise<Block[]> {
+    const fakeApp = adapter._getApp() as unknown as {
+      _triggerCommand(name: string, cmd: unknown): Promise<void>;
+      _respondMessages: Array<{ blocks?: Block[]; text: string }>;
+    };
+    await fakeApp._triggerCommand("/ask", { text });
+    return fakeApp._respondMessages[fakeApp._respondMessages.length - 1].blocks ?? [];
+  }
+
+  it("citation-numbering-unperturbed: doc blocks are a byte-identical PREFIX, defects appended at END", async () => {
+    const question = "tell me about the widget";
+    // Reference: same adapter WITHOUT askAugment.
+    const refBlocks = await askBlocks(
+      new SlackAdapter({
+        botToken: "xoxb-test",
+        appToken: "xapp-test",
+        knowledgeService: fakeKnowledge(),
+      }),
+      question,
+    );
+
+    const withAug = await askBlocks(
+      new SlackAdapter({
+        botToken: "xoxb-test",
+        appToken: "xapp-test",
+        knowledgeService: fakeKnowledge(),
+        askAugment: augmentReturning(),
+      }),
+      question,
+    );
+
+    // The doc answer + citation list are an UNCHANGED prefix.
+    expect(withAug.slice(0, refBlocks.length)).toEqual(refBlocks);
+    // The defects ride at the END: divider + section.
+    const appended = withAug.slice(refBlocks.length);
+    expect(appended[0]).toEqual({ type: "divider" });
+    expect(appended[1].type).toBe("section");
+    expect(appended[1].text!.text).toContain("Related tracked defects");
+    expect(appended[1].text!.text).toContain("• DEMO-1 — synthetic crash");
+    // The citation marker [1] survives untouched in the prefix.
+    const joined = refBlocks.map((b) => b.text?.text ?? "").join("\n");
+    expect(joined).toMatch(/\[1\]/);
+  });
+
+  it("no askAugment ⇒ identical-to-today reply blocks", async () => {
+    const question = "tell me about the widget";
+    const a = await askBlocks(
+      new SlackAdapter({
+        botToken: "xoxb-test",
+        appToken: "xapp-test",
+        knowledgeService: fakeKnowledge(),
+      }),
+      question,
+    );
+    // No divider/section beyond the doc answer + citation context.
+    expect(a.filter((b) => b.text?.text?.includes("Related tracked defects"))).toHaveLength(0);
+  });
+
+  it("augment throws/returns null ⇒ reply unchanged (no crash, no extra blocks)", async () => {
+    const question = "tell me about the widget";
+    const refBlocks = await askBlocks(
+      new SlackAdapter({
+        botToken: "xoxb-test",
+        appToken: "xapp-test",
+        knowledgeService: fakeKnowledge(),
+      }),
+      question,
+    );
+    const thrown = await askBlocks(
+      new SlackAdapter({
+        botToken: "xoxb-test",
+        appToken: "xapp-test",
+        knowledgeService: fakeKnowledge(),
+        askAugment: async () => {
+          throw new Error("augment boom");
+        },
+      }),
+      question,
+    );
+    expect(thrown).toEqual(refBlocks);
+  });
+
+  it("abstain-still-clean (no area): abstain payload unchanged, no defects section", async () => {
+    const blocks = await askBlocks(
+      new SlackAdapter({
+        botToken: "xoxb-test",
+        appToken: "xapp-test",
+        knowledgeService: abstainKnowledge(),
+        askAugment: async () => null,
+      }),
+      "something totally unknown",
+    );
+    // Citation-free abstain: a single section, no divider, no defects.
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0].type).toBe("section");
+    expect(blocks[0].text!.text).not.toContain("Related tracked defects");
+    expect(blocks.map((b) => b.text?.text ?? "").join("\n")).not.toMatch(/\[\d+\]/);
+  });
+
+  it("R3 — abstain-but-area-matched surfaces defects (abstain text UNCHANGED, marker-free)", async () => {
+    const ks = abstainKnowledge();
+    const refBlocks = await askBlocks(
+      new SlackAdapter({
+        botToken: "xoxb-test",
+        appToken: "xapp-test",
+        knowledgeService: abstainKnowledge(),
+      }),
+      "tell me about the widget",
+    );
+    const blocks = await askBlocks(
+      new SlackAdapter({
+        botToken: "xoxb-test",
+        appToken: "xapp-test",
+        knowledgeService: ks,
+        askAugment: augmentReturning(),
+      }),
+      "tell me about the widget",
+    );
+    // The abstain blocks are an UNCHANGED prefix (still citation-free).
+    expect(blocks.slice(0, refBlocks.length)).toEqual(refBlocks);
+    expect(refBlocks.map((b) => b.text?.text ?? "").join("\n")).not.toMatch(/\[\d+\]/);
+    // Defects ARE appended on the doc-abstain.
+    const appended = blocks.slice(refBlocks.length);
+    expect(appended[0]).toEqual({ type: "divider" });
+    expect(appended[1].text!.text).toContain("Related tracked defects");
+  });
+
+  it("app_mention DOC branch also appends the defects section", async () => {
+    const adapter = new SlackAdapter({
+      botToken: "xoxb-test",
+      appToken: "xapp-test",
+      knowledgeService: fakeKnowledge(),
+      askAugment: augmentReturning(),
+    });
+    const fakeApp = adapter._getApp() as unknown as {
+      _triggerEvent(name: string, ev: unknown): Promise<void>;
+      _postMessages: Array<{ blocks?: Block[] }>;
+    };
+    await fakeApp._triggerEvent("app_mention", {
+      text: "<@U12345> tell me about the widget",
+      channel: "C123",
+      ts: "1700000000.000900",
+    });
+    const blocks = fakeApp._postMessages[0].blocks ?? [];
+    const hasDefects = blocks.some((b) => b.text?.text?.includes("Related tracked defects"));
+    expect(hasDefects).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
Makes `/ask` (and the app_mention doc branch) label-aware: when a question names a known feature/flow area, the reply ALSO surfaces that area's tagged Jira defects, appended AFTER the cited doc answer. Bridges the doc-retrieval path and the Jira path that `/jql` already uses.

- New `src/jira/askAreaAugment.ts`: `buildAskJiraAugment` factory. All catalog/vocab/mapper/Jira-search I/O runs per-call inside one try/catch (never throws → null), mirroring `buildAnswerJql` — so it activates in lockstep with `/jql` when the catalog lands, no restart. Membership-only precision bar (`resolveCatalogMatches`) excludes symptom-only/passthrough/empty-catalog. Lexical pre-gate short-circuits before the mapper LLM call.
- New `formatAskDefectsBlocks` in the Slack formatter: appends defects as separate blocks with NO `[N]` citation markers, capped at `ASK_DEFECTS_MAX` with a "…and N more" overflow line.
- Adapter wires `askAugment` to run concurrently with `handleQuery`; absent/kill-switch-off = byte-identical legacy behavior.

## Behavior guarantees
- Doc citation numbering ([1],[2]…) and the abstain/refusal logic (#1374/#1380/#1393 paths) are untouched — the augment is purely additive at the adapter layer.
- No area named, or kill-switch off → byte-identical to today.
- Jira error/timeout → augment returns null, `/ask` still answers.
- R3: on doc-abstain WITH an area match + defects, defect blocks still surface; abstain text unchanged.

## New env
- `ASK_LABEL_AWARE` (default ON, data-gated by the empty-catalog short-circuit).
- `ASK_DEFECTS_MAX` (integer, default 5, NaN/<1 → 5, ceiling 50).

## Test plan
600/600 tests pass (568 baseline + 32 new): detection true-positive / true-negative / unknown-area-drop, empty-catalog short-circuit (mapper not called), per-call activation, kill-switch-off identity, Jira-error→null, citation-prefix-identity, abstain-still-clean, R3 abstain+area-match surfaces defects, app_mention doc branch, ASK_DEFECTS_MAX parse + formatter truncation. Build (tsc) clean, `tsc --noEmit` clean, privacy denylist clean (synthetic fixtures only).

4-role chain: planner → plan-review (round-2 PASS) → executor → execution-review (PASS, gates independently re-run).

https://claude.ai/code/session_01R5rpgymipJKn4AhCTmsYpD