### PR TITLE
chore: release 0.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [0.16.0](https://github.com/ziyilam3999/monday-bot/compare/v0.15.0...v0.16.0) (2026-07-02)
+
+### Features
+
+- feat: label-aware /ask — a question naming a known feature/flow area also surfaces that area's tagged Jira defects, appended after the cited doc answer; citation numbering, abstain logic, and no-area behavior unchanged; new knobs ASK_LABEL_AWARE (default on, data-gated) + ASK_DEFECTS_MAX (default 5) (#1386) (#262)
+
 ## [0.15.0](https://github.com/ziyilam3999/monday-bot/compare/v0.14.0...v0.15.0) (2026-06-30)
 
 ### Bug Fixes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "monday-bot",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "monday-bot",
-      "version": "0.15.0",
+      "version": "0.16.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.90.0",
         "@slack/bolt": "^4.7.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "monday-bot",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "Team Slack knowledge assistant — answers from internal documents with cited, fact-based summaries.",
   "private": true,
   "type": "commonjs",


### PR DESCRIPTION
## Summary
Release v0.16.0 — bundles the #1386 label-aware /ask feature (PR #262, merged as da1be33).

release-pr: true

https://claude.ai/code/session_019PJ7hN28SQYvVjTwNZDVVB